### PR TITLE
fix: ci/(make lint) fmt requires nightly to function properly with rustfmt.toml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,21 +10,46 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  cargo-fmt:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Rust nightly
+      run: rustup install nightly
+
+    - name: Install rustfmt for nightly
+      run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+
     - name: Run rustfmt
-      run: cargo fmt -- --check
+      run: cargo +nightly fmt -- --check
+
+  cargo-clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
 
     - name: Run Clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [cargo-fmt, cargo-clippy]
+
+    steps:
+    - uses: actions/checkout@v4
 
     - name: Build
       run: cargo build --verbose
 
-    - name: Run tests
+  test:
+    runs-on: ubuntu-latest
+    needs: [cargo-fmt, cargo-clippy]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test
       run: cargo test --verbose

--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,5 @@ clean: # Run `cargo clean`.
 
 .PHONY: lint
 lint: # Run `clippy` and `rustfmt`.
-	cargo fmt --all
+	cargo +nightly fmt --all
 	cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
+use ream::cli::{Cli, Commands};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
-
-use ream::cli::{Cli, Commands};
 
 fn main() {
     // Set the default log level to `info` if not set


### PR DESCRIPTION
@varun-doshi

anyone can review this.

Anyways since our CI required the nightly flag to work with our `rustfmt.toml` options