### PR TITLE
fix: nit block operations

### DIFF
--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -885,7 +885,7 @@ impl BeaconState {
             Some(self.genesis_validators_root),
         )?;
 
-        let signing_root = compute_signing_root(&address_change, domain);
+        let signing_root = compute_signing_root(address_change, domain);
         let sig = blst::min_pk::Signature::from_bytes(&signed_address_change.signature.signature)
             .map_err(|err| anyhow!("Failed to convert signiture type {err:?}"))?;
         let public_key = PublicKey::from_bytes(&address_change.from_bls_pubkey.inner)

--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -864,9 +864,9 @@ impl BeaconState {
 
     pub fn process_bls_to_execution_change(
         &mut self,
-        signed_address_change: SignedBLSToExecutionChange,
+        signed_address_change: &SignedBLSToExecutionChange,
     ) -> anyhow::Result<()> {
-        let address_change = signed_address_change.message;
+        let address_change = &signed_address_change.message;
 
         ensure!(address_change.validator_index < self.validators.len() as u64);
 
@@ -1525,7 +1525,7 @@ impl BeaconState {
             self.process_voluntary_exit(&voluntary_exit)?;
         }
         for bls_to_execution_change in body.bls_to_execution_changes {
-            self.process_bls_to_execution_change(bls_to_execution_change)?;
+            self.process_bls_to_execution_change(&bls_to_execution_change)?;
         }
 
         Ok(())

--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -841,7 +841,7 @@ impl BeaconState {
         Ok(())
     }
 
-    pub fn process_deposit(&mut self, deposit: Deposit) -> anyhow::Result<()> {
+    pub fn process_deposit(&mut self, deposit: &Deposit) -> anyhow::Result<()> {
         // Verify the Merkle branch
         ensure!(is_valid_merkle_branch(
             deposit.data.tree_hash_root(),
@@ -855,10 +855,10 @@ impl BeaconState {
         self.eth1_deposit_index += 1;
 
         self.apply_deposit(
-            deposit.data.pubkey,
+            deposit.data.pubkey.clone(),
             deposit.data.withdrawal_credentials,
             deposit.data.amount,
-            deposit.data.signature,
+            deposit.data.signature.clone(),
         )
     }
 
@@ -916,7 +916,7 @@ impl BeaconState {
 
     pub fn process_voluntary_exit(
         &mut self,
-        signed_voluntary_exit: SignedVoluntaryExit,
+        signed_voluntary_exit: &SignedVoluntaryExit,
     ) -> anyhow::Result<()> {
         let voluntary_exit = &signed_voluntary_exit.message;
         let validator_index = voluntary_exit.validator_index as usize;
@@ -1083,7 +1083,7 @@ impl BeaconState {
 
     pub fn process_attester_slashing(
         &mut self,
-        attester_slashing: AttesterSlashing,
+        attester_slashing: &AttesterSlashing,
     ) -> anyhow::Result<()> {
         let attestation_1 = &attester_slashing.attestation_1;
         let attestation_2 = &attester_slashing.attestation_2;
@@ -1509,23 +1509,23 @@ impl BeaconState {
                 )
         );
 
-        for operation in body.proposer_slashings {
-            self.process_proposer_slashing(&operation)?;
+        for proposer_slashing in body.proposer_slashings {
+            self.process_proposer_slashing(&proposer_slashing)?;
         }
-        for operation in body.attester_slashings {
-            self.process_attester_slashing(operation)?;
+        for attester_slashing in body.attester_slashings {
+            self.process_attester_slashing(&attester_slashing)?;
         }
-        for operation in body.attestations {
-            self.process_attestation(&operation)?;
+        for attestation in body.attestations {
+            self.process_attestation(&attestation)?;
         }
-        for operation in body.deposits {
-            self.process_deposit(operation)?;
+        for deposit in body.deposits {
+            self.process_deposit(&deposit)?;
         }
-        for operation in body.voluntary_exits {
-            self.process_voluntary_exit(operation)?;
+        for voluntary_exit in body.voluntary_exits {
+            self.process_voluntary_exit(&voluntary_exit)?;
         }
-        for operation in body.bls_to_execution_changes {
-            self.process_bls_to_execution_change(operation)?;
+        for bls_to_execution_change in body.bls_to_execution_changes {
+            self.process_bls_to_execution_change(bls_to_execution_change)?;
         }
 
         Ok(())

--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -1122,7 +1122,7 @@ impl BeaconState {
         Ok(())
     }
 
-    pub fn process_sync_aggregate(&mut self, sync_aggregate: SyncAggregate) -> anyhow::Result<()> {
+    pub fn process_sync_aggregate(&mut self, sync_aggregate: &SyncAggregate) -> anyhow::Result<()> {
         // Verify sync committee aggregate signature signing over the previous slot block root
         let committee_pubkeys = &self.current_sync_committee.pubkeys;
         let mut participant_pubkeys = vec![];


### PR DESCRIPTION
1. `operation_objects` is read-only, so those could be just a reference.
2. `process_operations` has some misleading variable name, so fixed those.