### PR TITLE
fix: check overflow at `process_voluntary_exit`

### DIFF
--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -945,8 +945,12 @@ impl BeaconState {
         );
 
         // Verify the validator has been active long enough
+        let earlist_exit_epoch = validator
+            .activation_epoch
+            .checked_add(SHARD_COMMITTEE_PERIOD)
+            .ok_or(anyhow!("Failed to calculate earlist exit epoch"))?;
         ensure!(
-            self.get_current_epoch() >= validator.activation_epoch + SHARD_COMMITTEE_PERIOD,
+            self.get_current_epoch() >= earlist_exit_epoch,
             "Validator has not been active long enough"
         );
 


### PR DESCRIPTION
I found this issue while integrating with EF tests. `validator.activation_epoch` can be the max of `u64`. 