### PR TITLE
feat: update `apply_deposit` and `add_validator_to_registry` to altair changes

### DIFF
--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -798,10 +798,10 @@ impl BeaconState {
             .push(amount)
             .map_err(|err| anyhow!("Couldn't push to balances {:?}", err))?;
         self.previous_epoch_participation
-            .push(0b00000000)
+            .push(0)
             .map_err(|err| anyhow!("Couldn't push to previous_epoch_participation {:?}", err))?;
         self.current_epoch_participation
-            .push(0b00000000)
+            .push(0)
             .map_err(|err| anyhow!("Couldn't push to current_epoch_participation {:?}", err))?;
         self.inactivity_scores
             .push(0)

--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -797,6 +797,15 @@ impl BeaconState {
         self.balances
             .push(amount)
             .map_err(|err| anyhow!("Couldn't push to balances {:?}", err))?;
+        self.previous_epoch_participation
+            .push(0b00000000)
+            .map_err(|err| anyhow!("Couldn't push to previous_epoch_participation {:?}", err))?;
+        self.current_epoch_participation
+            .push(0b00000000)
+            .map_err(|err| anyhow!("Couldn't push to current_epoch_participation {:?}", err))?;
+        self.inactivity_scores
+            .push(0)
+            .map_err(|err| anyhow!("Couldn't push to inactivity_scores {:?}", err))?;
         Ok(())
     }
 
@@ -823,8 +832,10 @@ impl BeaconState {
             let signing_root = compute_signing_root(deposit_message, domain);
             let sig = blst::min_pk::Signature::from_bytes(&signature.signature)
                 .map_err(|err| anyhow!("Failed to convert signiture type {err:?}"))?;
-            let public_key = PublicKey::from_bytes(&pubkey.inner)
-                .map_err(|err| anyhow!("Failed to convert pubkey type {err:?}"))?;
+            let public_key = match PublicKey::from_bytes(&pubkey.inner) {
+                Ok(pk) => pk,
+                Err(_) => return Ok(()) // Skip deposits with invalid public keys
+            };
             let verification_result =
                 sig.fast_aggregate_verify(true, signing_root.as_ref(), DST, &[&public_key]);
             if verification_result == blst::BLST_ERROR::BLST_SUCCESS {

--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -834,7 +834,7 @@ impl BeaconState {
                 .map_err(|err| anyhow!("Failed to convert signiture type {err:?}"))?;
             let public_key = match PublicKey::from_bytes(&pubkey.inner) {
                 Ok(pk) => pk,
-                Err(_) => return Ok(()) // Skip deposits with invalid public keys
+                Err(_) => return Ok(()), // Skip deposits with invalid public keys
             };
             let verification_result =
                 sig.fast_aggregate_verify(true, signing_root.as_ref(), DST, &[&public_key]);

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "ef-tests")]
 
 use ef_tests::test_consensus_type;
+use ef_tests::{test_operation, utils};
 use ream_consensus::{
     attestation::Attestation,
     attestation_data::AttestationData,
@@ -64,6 +65,4 @@ test_consensus_type!(VoluntaryExit);
 test_consensus_type!(Withdrawal);
 
 // Testing operations for block processing
-use ef_tests::{test_operation, utils};
-
 test_operation!(deposit, Deposit, "deposit", process_deposit);

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -64,3 +64,6 @@ test_consensus_type!(VoluntaryExit);
 test_consensus_type!(Withdrawal);
 
 // Testing operations for block processing
+use ef_tests::{test_operation, utils};
+
+test_operation!(deposit, Deposit, "deposit", process_deposit);

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "ef-tests")]
 
-use ef_tests::test_consensus_type;
-use ef_tests::{test_operation, utils};
+use ef_tests::{test_consensus_type, test_operation, utils};
 use ream_consensus::{
     attestation::Attestation,
     attestation_data::AttestationData,


### PR DESCRIPTION
1. `apply_deposit` should ignore the corresponding deposit when pubkey is in wrong format.
2. `add_validator_to_registry` should append new entry for the corresponding validator to `previous_epoch_participation`, `current_epoch_participation`, and `inactivity_scores`. This was added at Altair fork. ([Link](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#modified-add_validator_to_registry))

I added `test_operation!` for `process_deposit`, to check whether I correctly write the code.