### PR TITLE
fix: process_withdrawals and add corresponding ef-tests

### DIFF
--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -724,7 +724,7 @@ impl BeaconState {
                 withdrawals.push(Withdrawal {
                     index: withdrawal_index,
                     validator_index,
-                    address: Address::from_slice(&validator.withdrawal_credentials[..12]),
+                    address: Address::from_slice(&validator.withdrawal_credentials[12..]),
                     amount: balance,
                 });
                 withdrawal_index += 1
@@ -732,7 +732,7 @@ impl BeaconState {
                 withdrawals.push(Withdrawal {
                     index: withdrawal_index,
                     validator_index,
-                    address: Address::from_slice(&validator.withdrawal_credentials[..12]),
+                    address: Address::from_slice(&validator.withdrawal_credentials[12..]),
                     amount: balance - MAX_EFFECTIVE_BALANCE,
                 });
                 withdrawal_index += 1
@@ -745,7 +745,7 @@ impl BeaconState {
         withdrawals
     }
 
-    pub fn process_withdrawals(&mut self, payload: ExecutionPayload) -> anyhow::Result<()> {
+    pub fn process_withdrawals(&mut self, payload: &ExecutionPayload) -> anyhow::Result<()> {
         let expected_withdrawals = self.get_expected_withdrawals();
         ensure!(
             payload.withdrawals.deref() == expected_withdrawals,
@@ -757,7 +757,7 @@ impl BeaconState {
         }
 
         // Update the next withdrawal index if this block contained withdrawals
-        if expected_withdrawals.is_empty() {
+        if !expected_withdrawals.is_empty() {
             let latest_withdrawal = &expected_withdrawals[expected_withdrawals.len() - 1];
             self.next_withdrawal_index = latest_withdrawal.index + 1
         }

--- a/testing/ef-tests/Makefile
+++ b/testing/ef-tests/Makefile
@@ -18,8 +18,8 @@ $(EXTRACT_DIR): $(TARGET)
 	fi
 
 $(TARGET):
-	@if [ -f $(TARGET) ]; then \
-		echo "$(TARGET) already downloaded. Skipping download."; \
+	@if [ -d $(EXTRACT_DIR) ]; then \
+		echo "$(EXTRACT_DIR) already downloaded. Skipping download."; \
 	else \
 		echo "Fetching the latest release URL for $(TARGET)..."; \
 		curl -s $(LATEST_RELEASE_URL) \

--- a/testing/ef-tests/src/macros/mod.rs
+++ b/testing/ef-tests/src/macros/mod.rs
@@ -1,0 +1,2 @@
+pub mod operations;
+pub mod ssz_static;

--- a/testing/ef-tests/src/macros/operations.rs
+++ b/testing/ef-tests/src/macros/operations.rs
@@ -1,63 +1,4 @@
 #[macro_export]
-macro_rules! test_consensus_type {
-    ($struct_name:ident) => {
-        paste::paste! {
-            #[cfg(test)]
-            #[allow(non_snake_case)]
-            mod [<tests_ $struct_name>] {
-                use super::*;
-                use rstest::rstest;
-                use serde_yaml::Value;
-                use snap::raw::Decoder;
-                use std::str::FromStr;
-                use tree_hash::TreeHash;
-                use ssz::Decode;
-                use ssz::Encode;
-
-                #[rstest]
-                #[case("case_0")]
-                #[case("case_1")]
-                #[case("case_2")]
-                #[case("case_3")]
-                #[case("case_4")]
-                fn test_type(#[case] case: &str) {
-                    let path = format!(
-                        "mainnet/tests/mainnet/deneb/ssz_static/{}/ssz_random/{case}/",
-                        stringify!($struct_name)
-                    );
-
-                    // Read and parse hash root
-                    let hash_root = {
-                        let hash_root_content = std::fs::read_to_string(format!("{path}roots.yaml"))
-                            .expect("cannot find test asset");
-                        let value: Value = serde_yaml::from_str(&hash_root_content).unwrap();
-                        alloy_primitives::B256::from_str(value.get("root").unwrap().as_str().unwrap())
-                            .unwrap()
-                    };
-
-                    // Deserialize the struct
-                    let content = {
-                        let value = std::fs::read_to_string(format!("{path}value.yaml"))
-                            .expect("cannot find test asset");
-                        serde_yaml::from_str::<$struct_name>(&value).unwrap()
-                    };
-
-                    // Read and decompress SSZ snappy file
-                    let ssz_snappy = std::fs::read(format!("{path}serialized.ssz_snappy")).expect("cannot find test asset");
-                    let mut decoder = Decoder::new();
-                    let ssz = decoder.decompress_vec(&ssz_snappy).unwrap();
-
-                    // Perform the assertions
-                    assert_eq!(ssz, content.as_ssz_bytes());
-                    assert_eq!(content, $struct_name::from_ssz_bytes(&ssz).unwrap());
-                    assert_eq!(hash_root, content.tree_hash_root());
-                }
-            }
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! test_operation {
     ($operation_name:ident, $operation_object:ty, $input_name:literal, $processing_fn:path) => {
         paste::paste! {
@@ -115,13 +56,13 @@ macro_rules! test_operation {
 
                         match (result, expected_post) {
                             (Ok(_), Some(expected)) => {
-                                assert_eq!(state, expected, "Post state mismatch in case {}", case_name);
+                                assert_eq!(state, expected, "Post state mismatch in case {case_name}");
                             }
                             (Ok(_), None) => {
-                                panic!("Test case {} should have failed but succeeded", case_name);
+                                panic!("Test case {case_name} should have failed but succeeded");
                             }
-                            (Err(_), Some(_)) => {
-                                panic!("Test case {} should have succeeded but failed", case_name);
+                            (Err(err), Some(_)) => {
+                                panic!("Test case {case_name} should have succeeded but failed, err={err:?}");
                             }
                             (Err(_), None) => {
                                 // Test should fail and there should be no post state

--- a/testing/ef-tests/src/macros/ssz_static.rs
+++ b/testing/ef-tests/src/macros/ssz_static.rs
@@ -1,0 +1,58 @@
+#[macro_export]
+macro_rules! test_consensus_type {
+    ($struct_name:ident) => {
+        paste::paste! {
+            #[cfg(test)]
+            #[allow(non_snake_case)]
+            mod [<tests_ $struct_name>] {
+                use super::*;
+                use rstest::rstest;
+                use serde_yaml::Value;
+                use snap::raw::Decoder;
+                use std::str::FromStr;
+                use tree_hash::TreeHash;
+                use ssz::Decode;
+                use ssz::Encode;
+
+                #[rstest]
+                #[case("case_0")]
+                #[case("case_1")]
+                #[case("case_2")]
+                #[case("case_3")]
+                #[case("case_4")]
+                fn test_type(#[case] case: &str) {
+                    let path = format!(
+                        "mainnet/tests/mainnet/deneb/ssz_static/{}/ssz_random/{case}/",
+                        stringify!($struct_name)
+                    );
+
+                    // Read and parse hash root
+                    let hash_root = {
+                        let hash_root_content = std::fs::read_to_string(format!("{path}roots.yaml"))
+                            .expect("cannot find test asset");
+                        let value: Value = serde_yaml::from_str(&hash_root_content).unwrap();
+                        alloy_primitives::B256::from_str(value.get("root").unwrap().as_str().unwrap())
+                            .unwrap()
+                    };
+
+                    // Deserialize the struct
+                    let content = {
+                        let value = std::fs::read_to_string(format!("{path}value.yaml"))
+                            .expect("cannot find test asset");
+                        serde_yaml::from_str::<$struct_name>(&value).unwrap()
+                    };
+
+                    // Read and decompress SSZ snappy file
+                    let ssz_snappy = std::fs::read(format!("{path}serialized.ssz_snappy")).expect("cannot find test asset");
+                    let mut decoder = Decoder::new();
+                    let ssz = decoder.decompress_vec(&ssz_snappy).unwrap();
+
+                    // Perform the assertions
+                    assert_eq!(ssz, content.as_ssz_bytes());
+                    assert_eq!(content, $struct_name::from_ssz_bytes(&ssz).unwrap());
+                    assert_eq!(hash_root, content.tree_hash_root());
+                }
+            }
+        }
+    };
+}

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -65,3 +65,9 @@ test_consensus_type!(Withdrawal);
 
 // Testing operations for block processing
 test_operation!(deposit, Deposit, "deposit", process_deposit);
+test_operation!(
+    withdrawals,
+    ExecutionPayload,
+    "execution_payload",
+    process_withdrawals
+);


### PR DESCRIPTION
We are trying to support all the `consensus-spec-tests`, I looked at the work @syjn99 was doing and wanted to instead target testcases which are more minimal and slowly work my way up to the more complex test cases, as then it should be smoother to progressively support more test cases.

I got the operation `Withdrawals` tests working.

I found 2 bugs
- We weren't decoding the addresses properly
- We were doing `if X == 0`, when the spec asked for `if X != 0`

After I fixed these 2 problems, the `process_withdrawal` tests started passing :rocket: 

Lets keep knocking these tests out :fire: 