### PR TITLE
test: add operation tests for `process_voluntary_exit` & `process_bls_to_execution_change`

### DIFF
--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -66,8 +66,20 @@ test_consensus_type!(Withdrawal);
 // Testing operations for block processing
 test_operation!(deposit, Deposit, "deposit", process_deposit);
 test_operation!(
+    voluntary_exit,
+    SignedVoluntaryExit,
+    "voluntary_exit",
+    process_voluntary_exit
+);
+test_operation!(
     withdrawals,
     ExecutionPayload,
     "execution_payload",
     process_withdrawals
+);
+test_operation!(
+    bls_to_execution_change,
+    SignedBLSToExecutionChange,
+    "address_change",
+    process_bls_to_execution_change
 );


### PR DESCRIPTION
This PR adds some operation tests that are currently passing the cases.
- `process_voluntary_exit`
- `process_bls_to_execution_change`