### PR TITLE
ci: run rust tests in release mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Test
-      run: cargo test --workspace -- --nocapture
+      run: cargo test --release --workspace -- --nocapture
 
     - name: Test consensus spec tests
       run: cd testing/ef-tests && make test

--- a/testing/ef-tests/Makefile
+++ b/testing/ef-tests/Makefile
@@ -32,7 +32,7 @@ $(TARGET):
 
 test: $(EXTRACT_DIR)
 	@echo "Running tests..."
-	@cargo test --features ef-tests
+	@cargo test --release --features ef-tests
 	@echo "Tests complete."
 
 clean:


### PR DESCRIPTION
As we add more tests running them in debug mode takes a lot of time, I was running https://github.com/ReamLabs/ream/pull/108 in debug mode and it took quite a bit to finish, running the tests in release mode helped a lot