### PR TITLE
fix: update `process_attestation` for deneb

### DIFF
--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -512,12 +512,12 @@ impl BeaconState {
     }
 
     pub fn add_flag(flags: u8, flag_index: u8) -> u8 {
-        let flag = 2 << flag_index;
+        let flag = 1 << flag_index;
         flags | flag
     }
 
     pub fn has_flag(flags: u8, flag_index: u8) -> bool {
-        let flag = 2 << flag_index;
+        let flag = 1 << flag_index;
         flags & flag == flag
     }
 
@@ -645,7 +645,7 @@ impl BeaconState {
         if is_matching_source && inclusion_delay <= (SLOTS_PER_EPOCH as f64).sqrt() as u64 {
             participation_flag_indices.push(TIMELY_SOURCE_FLAG_INDEX);
         }
-        if is_matching_target && inclusion_delay <= SLOTS_PER_EPOCH {
+        if is_matching_target {
             participation_flag_indices.push(TIMELY_TARGET_FLAG_INDEX);
         }
         if is_matching_head && inclusion_delay == MIN_ATTESTATION_INCLUSION_DELAY {

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -65,6 +65,7 @@ test_consensus_type!(VoluntaryExit);
 test_consensus_type!(Withdrawal);
 
 // Testing operations for block processing
+test_operation!(attestation, Attestation, "attestation", process_attestation);
 test_operation!(deposit, Deposit, "deposit", process_deposit);
 test_operation!(
     voluntary_exit,

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -66,6 +66,12 @@ test_consensus_type!(Withdrawal);
 
 // Testing operations for block processing
 test_operation!(attestation, Attestation, "attestation", process_attestation);
+test_operation!(
+    bls_to_execution_change,
+    SignedBLSToExecutionChange,
+    "address_change",
+    process_bls_to_execution_change
+);
 test_operation!(deposit, Deposit, "deposit", process_deposit);
 test_operation!(
     voluntary_exit,
@@ -78,12 +84,6 @@ test_operation!(
     ExecutionPayload,
     "execution_payload",
     process_withdrawals
-);
-test_operation!(
-    bls_to_execution_change,
-    SignedBLSToExecutionChange,
-    "address_change",
-    process_bls_to_execution_change
 );
 
 // Testing shuffling


### PR DESCRIPTION
- Fixed participation flags shifting issue.
- Applied [EIP-7045](https://eips.ethereum.org/EIPS/eip-7045), which removes the inclusion delay consideration from Deneb.
- Added EF test for `process_attestation`