### PR TITLE
test: add more opertation tests

### DIFF
--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -675,7 +675,7 @@ impl BeaconState {
         Ok((rewards, penalties))
     }
 
-    pub fn process_block_header(&mut self, block: BeaconBlock) -> anyhow::Result<()> {
+    pub fn process_block_header(&mut self, block: &BeaconBlock) -> anyhow::Result<()> {
         // Verify that the slots match
         ensure!(
             self.slot == block.slot,

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -67,12 +67,25 @@ test_consensus_type!(Withdrawal);
 // Testing operations for block processing
 test_operation!(attestation, Attestation, "attestation", process_attestation);
 test_operation!(
+    attester_slashing,
+    AttesterSlashing,
+    "attester_slashing",
+    process_attester_slashing
+);
+test_operation!(block_header, BeaconBlock, "block", process_block_header);
+test_operation!(
     bls_to_execution_change,
     SignedBLSToExecutionChange,
     "address_change",
     process_bls_to_execution_change
 );
 test_operation!(deposit, Deposit, "deposit", process_deposit);
+test_operation!(
+    proposer_slashing,
+    ProposerSlashing,
+    "proposer_slashing",
+    process_proposer_slashing
+);
 test_operation!(
     voluntary_exit,
     SignedVoluntaryExit,


### PR DESCRIPTION
We now need two operation tests:
- `process_sync_aggregate`
- `process_execution_payload`: Not implemented yet

It seems like `process_sync_aggregate` has some problem. I would open an issue for this.