### PR TITLE
feat: implement engine_forkchoiceUpdatedV3 api rpc call

### DIFF
--- a/crates/common/consensus/src/execution_engine/mod.rs
+++ b/crates/common/consensus/src/execution_engine/mod.rs
@@ -10,7 +10,10 @@ use jsonwebtoken::{encode, get_current_timestamp, EncodingKey, Header};
 use new_payload_request::NewPayloadRequest;
 use reqwest::{Client, Request};
 use rpc_types::{
-    eth_syncing::EthSyncing, execution_payload::ExecutionPayloadV3, get_payload::PayloadV3,
+    eth_syncing::EthSyncing,
+    execution_payload::ExecutionPayloadV3,
+    forkchoice_update::{ForkchoiceStateV1, ForkchoiceUpdateResult, PayloadAttributesV3},
+    get_payload::PayloadV3,
     payload_status::PayloadStatusV1,
 };
 use serde_json::json;
@@ -163,6 +166,28 @@ impl ExecutionEngine {
             .execute(http_post_request)
             .await?
             .json::<JsonRpcResponse<PayloadStatusV1>>()
+            .await?
+            .to_result()
+    }
+
+    pub async fn engine_forkchoice_updatedv3(
+        &self,
+        forkchoice_state: ForkchoiceStateV1,
+        payload_attributes: PayloadAttributesV3,
+    ) -> anyhow::Result<ForkchoiceUpdateResult> {
+        let request_body = JsonRpcRequest {
+            id: 1,
+            jsonrpc: "2.0".to_string(),
+            method: "engine_forkchoiceUpdatedV3".to_string(),
+            params: vec![json!(forkchoice_state), json!(payload_attributes)],
+        };
+
+        let http_post_request = self.build_request(request_body)?;
+
+        self.http_client
+            .execute(http_post_request)
+            .await?
+            .json::<JsonRpcResponse<ForkchoiceUpdateResult>>()
             .await?
             .to_result()
     }

--- a/crates/common/consensus/src/execution_engine/mod.rs
+++ b/crates/common/consensus/src/execution_engine/mod.rs
@@ -107,7 +107,11 @@ impl ExecutionEngine {
     }
 
     pub async fn engine_exchange_capabilities(&self) -> anyhow::Result<Vec<String>> {
-        let capabilities: Vec<String> = vec![];
+        let capabilities: Vec<String> = vec![
+            "engine_getPayloadV3".to_string(),
+            "engine_newPayloadV3".to_string(),
+            "engine_forkchoiceUpdatedV3".to_string(),
+        ];
         let request_body = JsonRpcRequest {
             id: 1,
             jsonrpc: "2.0".to_string(),
@@ -125,7 +129,7 @@ impl ExecutionEngine {
             .to_result()
     }
 
-    pub async fn engine_get_payloadv3(&self, payload_id: B64) -> anyhow::Result<PayloadV3> {
+    pub async fn engine_get_payload_v3(&self, payload_id: B64) -> anyhow::Result<PayloadV3> {
         let request_body = JsonRpcRequest {
             id: 1,
             jsonrpc: "2.0".to_string(),
@@ -143,7 +147,7 @@ impl ExecutionEngine {
             .to_result()
     }
 
-    pub async fn engine_new_payloadv3(
+    pub async fn engine_new_payload_v3(
         &self,
         execution_payload: ExecutionPayloadV3,
         expected_blob_versioned_hashes: Vec<B256>,
@@ -170,10 +174,10 @@ impl ExecutionEngine {
             .to_result()
     }
 
-    pub async fn engine_forkchoice_updatedv3(
+    pub async fn engine_forkchoice_updated_v3(
         &self,
         forkchoice_state: ForkchoiceStateV1,
-        payload_attributes: PayloadAttributesV3,
+        payload_attributes: Option<PayloadAttributesV3>,
     ) -> anyhow::Result<ForkchoiceUpdateResult> {
         let request_body = JsonRpcRequest {
             id: 1,

--- a/crates/common/consensus/src/execution_engine/rpc_types/forkchoice_update.rs
+++ b/crates/common/consensus/src/execution_engine/rpc_types/forkchoice_update.rs
@@ -1,0 +1,32 @@
+use alloy_primitives::{Address, B256, B64};
+use serde::{Deserialize, Serialize};
+use ssz_types::{typenum, VariableList};
+
+use super::payload_status::PayloadStatusV1;
+use crate::withdrawal::Withdrawal;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkchoiceStateV1 {
+    pub head_block_hash: B256,
+    pub safe_block_hash: B256,
+    pub finalized_block_hash: B256,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PayloadAttributesV3 {
+    #[serde(with = "serde_utils::u64_hex_be")]
+    pub timestamp: u64,
+    pub prev_randao: B256,
+    pub suggested_fee_recipient: Address,
+    pub withdrawals: VariableList<Withdrawal, typenum::U16>,
+    pub parent_beacon_block_root: B256,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkchoiceUpdateResult {
+    pub payload_status: PayloadStatusV1,
+    pub payload_id: Option<B64>,
+}

--- a/crates/common/consensus/src/execution_engine/rpc_types/mod.rs
+++ b/crates/common/consensus/src/execution_engine/rpc_types/mod.rs
@@ -1,4 +1,5 @@
 pub mod eth_syncing;
 pub mod execution_payload;
+pub mod forkchoice_update;
 pub mod get_payload;
 pub mod payload_status;


### PR DESCRIPTION
This PR must be merged after https://github.com/ReamLabs/ream/pull/123

Implemented this issue in this PR https://github.com/ReamLabs/ream/issues/120

This is required to implement process_execution_payload() https://github.com/ReamLabs/ream/issues/51

implementing json engine api rpc calls