### PR TITLE
feat: implement engine_getBlobV1 api rpc call

### DIFF
--- a/crates/common/consensus/src/execution_engine/mod.rs
+++ b/crates/common/consensus/src/execution_engine/mod.rs
@@ -13,6 +13,7 @@ use rpc_types::{
     eth_syncing::EthSyncing,
     execution_payload::ExecutionPayloadV3,
     forkchoice_update::{ForkchoiceStateV1, ForkchoiceUpdateResult, PayloadAttributesV3},
+    get_blobs::BlobsAndProofV1,
     get_payload::PayloadV3,
     payload_status::PayloadStatusV1,
 };
@@ -192,6 +193,27 @@ impl ExecutionEngine {
             .execute(http_post_request)
             .await?
             .json::<JsonRpcResponse<ForkchoiceUpdateResult>>()
+            .await?
+            .to_result()
+    }
+
+    pub async fn engine_get_blobs_v1(
+        &self,
+        blob_version_hashes: Vec<B256>,
+    ) -> anyhow::Result<Vec<Option<BlobsAndProofV1>>> {
+        let request_body = JsonRpcRequest {
+            id: 1,
+            jsonrpc: "2.0".to_string(),
+            method: "engine_getBlobsV1".to_string(),
+            params: vec![json!(blob_version_hashes)],
+        };
+
+        let http_post_request = self.build_request(request_body)?;
+
+        self.http_client
+            .execute(http_post_request)
+            .await?
+            .json::<JsonRpcResponse<Vec<Option<BlobsAndProofV1>>>>()
             .await?
             .to_result()
     }

--- a/crates/common/consensus/src/execution_engine/mod.rs
+++ b/crates/common/consensus/src/execution_engine/mod.rs
@@ -112,6 +112,7 @@ impl ExecutionEngine {
             "engine_getPayloadV3".to_string(),
             "engine_newPayloadV3".to_string(),
             "engine_forkchoiceUpdatedV3".to_string(),
+            "engine_getBlobsV1".to_string(),
         ];
         let request_body = JsonRpcRequest {
             id: 1,

--- a/crates/common/consensus/src/execution_engine/mod.rs
+++ b/crates/common/consensus/src/execution_engine/mod.rs
@@ -109,10 +109,10 @@ impl ExecutionEngine {
 
     pub async fn engine_exchange_capabilities(&self) -> anyhow::Result<Vec<String>> {
         let capabilities: Vec<String> = vec![
-            "engine_getPayloadV3".to_string(),
-            "engine_newPayloadV3".to_string(),
             "engine_forkchoiceUpdatedV3".to_string(),
             "engine_getBlobsV1".to_string(),
+            "engine_getPayloadV3".to_string(),
+            "engine_newPayloadV3".to_string(),
         ];
         let request_body = JsonRpcRequest {
             id: 1,

--- a/crates/common/consensus/src/execution_engine/rpc_types/get_blobs.rs
+++ b/crates/common/consensus/src/execution_engine/rpc_types/get_blobs.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+use ssz_types::{serde_utils::list_of_hex_var_list, typenum, VariableList};
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobsAndProofV1 {
+    #[serde(with = "list_of_hex_var_list")]
+    pub blob: VariableList<VariableList<u8, typenum::U1073741824>, typenum::U1048576>,
+    #[serde(with = "list_of_hex_var_list")]
+    pub proofs: VariableList<VariableList<u8, typenum::U96>, typenum::U1024>,
+}

--- a/crates/common/consensus/src/execution_engine/rpc_types/mod.rs
+++ b/crates/common/consensus/src/execution_engine/rpc_types/mod.rs
@@ -1,5 +1,6 @@
 pub mod eth_syncing;
 pub mod execution_payload;
 pub mod forkchoice_update;
+pub mod get_blobs;
 pub mod get_payload;
 pub mod payload_status;


### PR DESCRIPTION


This is required to implement process_execution_payload() https://github.com/ReamLabs/ream/issues/51

implementing json engine api rpc calls