### PR TITLE
feat: add network cli for specifying network specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,6 +3792,7 @@ dependencies = [
  "discv5",
  "ream-discv5",
  "ream-executor",
+ "ream-network-spec",
  "ream-p2p",
  "tokio",
  "tracing",
@@ -3865,6 +3866,10 @@ dependencies = [
  "futures",
  "tokio",
 ]
+
+[[package]]
+name = "ream-network-spec"
+version = "0.1.0"
 
 [[package]]
 name = "ream-p2p"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 members = [
     "bin/ream",
     "crates/common/consensus",
-    "crates/common/executor",
+    "crates/common/executor", 
+    "crates/common/network_spec",
     "crates/crypto/bls",
     "crates/networking/discv5",
     "crates/networking/p2p",
@@ -64,6 +65,7 @@ tree_hash_derive = "0.9"
 ream-bls = { path = "crates/crypto/bls", features = ["zkcrypto"] } # Default feature is zkcrypto
 ream-discv5 = { path = "crates/networking/discv5"}
 ream-executor = { path = "crates/common/executor" }
+ream-network-spec = { path = "crates/common/network_spec" }
 ream-p2p = { path = "crates/networking/p2p" }
 
 [patch.crates-io]

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 # ream dependencies
 ream-discv5 = { workspace = true }
 ream-executor = { workspace = true }
+ream-network-spec = { workspace = true }
 ream-p2p = { workspace = true }
 
 

--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -1,4 +1,9 @@
+use std::sync::Arc;
+
 use clap::{Parser, Subcommand};
+use ream_network_spec::{cli::network_parser, networks::NetworkSpec};
+
+const DEFAULT_NETWORK: &str = "mainnet";
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -19,6 +24,14 @@ pub struct NodeCommand {
     /// Verbosity level
     #[arg(short, long, default_value_t = 3)]
     pub verbosity: u8,
+
+    #[arg(
+        long,
+        help = "Choose mainnet, holesky, or sepolia",
+        default_value = DEFAULT_NETWORK,
+        value_parser = network_parser
+    )]
+    pub network: Arc<NetworkSpec>,
 }
 
 #[cfg(test)]

--- a/crates/common/network_spec/Cargo.toml
+++ b/crates/common/network_spec/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ream-network-spec"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]

--- a/crates/common/network_spec/src/cli.rs
+++ b/crates/common/network_spec/src/cli.rs
@@ -1,0 +1,14 @@
+use std::sync::Arc;
+
+use crate::networks::{NetworkSpec, HOLESKY, MAINNET, SEPOLIA};
+
+pub fn network_parser(network_string: &str) -> Result<Arc<NetworkSpec>, String> {
+    match network_string {
+        "mainnet" => Ok(MAINNET.clone()),
+        "holesky" => Ok(HOLESKY.clone()),
+        "sepolia" => Ok(SEPOLIA.clone()),
+        _ => Err(format!(
+            "Not a valid network: {network_string}, try mainnet, holesky, or sepolia"
+        )),
+    }
+}

--- a/crates/common/network_spec/src/lib.rs
+++ b/crates/common/network_spec/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod cli;
+pub mod networks;

--- a/crates/common/network_spec/src/networks.rs
+++ b/crates/common/network_spec/src/networks.rs
@@ -1,0 +1,34 @@
+use std::sync::{Arc, LazyLock};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Network {
+    Mainnet,
+    Holesky,
+    Sepolia,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NetworkSpec {
+    network: Network,
+}
+
+pub static MAINNET: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
+    NetworkSpec {
+        network: Network::Mainnet,
+    }
+    .into()
+});
+
+pub static HOLESKY: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
+    NetworkSpec {
+        network: Network::Holesky,
+    }
+    .into()
+});
+
+pub static SEPOLIA: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
+    NetworkSpec {
+        network: Network::Sepolia,
+    }
+    .into()
+});


### PR DESCRIPTION
Just the basic for adding multi network support. We will specify hardfork timestamps and such in the NetworkSpec. Any network specific configurations will belong here. As we build our client out the idea will be to for example 

```
if network.is_electra_enabled(timestamp) {
    // do xyz
}

```

by adding this now hopefully this gives everybody an idea and as we build the puzzle pieces will fall into place around this