### PR TITLE
fix: `is_valid_indexed_attestation` and enable bls tests for operation tests

### DIFF
--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -339,8 +339,13 @@ impl BeaconState {
             .fast_aggregate_verify(
                 indices
                     .iter()
-                    .filter_map(|&i| self.validators.get(i).map(|v| &v.pubkey))
-                    .collect::<Vec<_>>(),
+                    .map(|&index| {
+                        self.validators
+                            .get(index)
+                            .map(|validator| &validator.pubkey)
+                            .ok_or(anyhow!("Invalid index"))
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?,
                 signing_root.as_ref(),
             )
             .map_err(|e| anyhow!("Invalid indexed attestation: {:?}", e))

--- a/testing/ef-tests/src/macros/operations.rs
+++ b/testing/ef-tests/src/macros/operations.rs
@@ -14,19 +14,6 @@ macro_rules! test_operation_impl {
             let case_name = case_dir.file_name().unwrap().to_str().unwrap();
             println!("Testing case: {}", case_name);
 
-            let metadata_path = case_dir.join("meta.yaml");
-            if metadata_path.exists() {
-                let meta_content =
-                    std::fs::read_to_string(&metadata_path).expect("Failed to read meta.yaml");
-                let meta: serde_yaml::Value =
-                    serde_yaml::from_str(&meta_content).expect("Failed to parse meta.yaml");
-                if let Some(bls_setting) = meta.get("bls_setting") {
-                    if bls_setting.as_i64() == Some(1) {
-                        continue;
-                    }
-                }
-            }
-
             let pre_state: Arc<Mutex<BeaconState>> = Arc::new(Mutex::new(
                 utils::read_ssz_snappy(&case_dir.join("pre.ssz_snappy"))
                     .expect("cannot find test asset(pre.ssz_snappy)"),


### PR DESCRIPTION
The todo was removed in the last PR, but basically we weren't running operation tests which used bls, I fixed the bug so now the test suite works with BLS tests enabled