### PR TITLE
feat: add CI that ream-consensus and ream-bls compiles to risc0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  build-risc0:
+    runs-on: ubuntu-latest
+    needs: [cargo-fmt, cargo-clippy]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install toolchain
+      run: |
+        curl -L https://risczero.com/install | bash
+        /home/runner/.risc0/bin/rzup install
+        cargo risczero install
+        rustup default risc0
+        
+    - name: Build Risc0
+      run: cargo build --target=riscv32im-risc0-zkvm-elf -p ream-consensus -p ream-bls
+ 
   cargo-fmt:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I added support for compiling to risc0

Issue: https://github.com/ReamLabs/ream/issues/147