### PR TITLE
chore: bump edition to 2024 and version to 1.85

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         curl -L https://risczero.com/install | bash
         /home/runner/.risc0/bin/rzup install
+        /home/runner/.risc0/bin/rzup install rust 1.85.0
         rustup default risc0
         
     - name: Build Risc0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ resolver = "2"
 
 [workspace.package]
 authors = ["https://github.com/ReamLabs/ream/graphs/contributors"]
-edition = "2021"
+edition = "2024"
 keywords = ["ethereum", "beam-chain", "blockchain", "consensus", "protocol", "ream"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ReamLabs/ream"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2024"]
-
 [workspace]
 members = [
     "bin/ream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [workspace]
 members = [
     "bin/ream",

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::{env, net::Ipv4Addr};
 
 use clap::Parser;
 use ream::cli::{Cli, Commands};
@@ -12,13 +12,13 @@ use tracing_subscriber::EnvFilter;
 #[tokio::main]
 async fn main() {
     // Set the default log level to `info` if not set
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
-    }
+    let rust_log = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default();
+    let env_filter = match rust_log.is_empty() {
+        true => EnvFilter::builder().parse_lossy("info"),
+        false => EnvFilter::builder().parse_lossy(rust_log),
+    };
 
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
 
     let cli = Cli::parse();
 

--- a/crates/common/consensus/src/attestation.rs
+++ b/crates/common/consensus/src/attestation.rs
@@ -1,7 +1,7 @@
 use ream_bls::BLSSignature;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum, BitList};
+use ssz_types::{BitList, typenum};
 use tree_hash_derive::TreeHash;
 
 use crate::attestation_data::AttestationData;

--- a/crates/common/consensus/src/deneb/beacon_block_body.rs
+++ b/crates/common/consensus/src/deneb/beacon_block_body.rs
@@ -3,8 +3,8 @@ use ream_bls::BLSSignature;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
-    typenum::{U128, U16, U2, U4096},
     VariableList,
+    typenum::{U2, U16, U128, U4096},
 };
 use tree_hash_derive::TreeHash;
 

--- a/crates/common/consensus/src/deneb/beacon_state.rs
+++ b/crates/common/consensus/src/deneb/beacon_state.rs
@@ -5,19 +5,19 @@ use std::{
     sync::Arc,
 };
 
-use alloy_primitives::{aliases::B32, Address, B256};
+use alloy_primitives::{Address, B256, aliases::B32};
 use anyhow::{anyhow, bail, ensure};
 use ethereum_hashing::{hash, hash_fixed};
 use itertools::Itertools;
 use ream_bls::{
-    traits::{Aggregatable, Verifiable},
     AggregatePubKey, BLSSignature, PubKey,
+    traits::{Aggregatable, Verifiable},
 };
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
-    typenum::{U1099511627776, U16777216, U2048, U4, U65536, U8192},
     BitVector, FixedVector, VariableList,
+    typenum::{U4, U2048, U8192, U65536, U16777216, U1099511627776},
 };
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;

--- a/crates/common/consensus/src/deneb/execution_payload.rs
+++ b/crates/common/consensus/src/deneb/execution_payload.rs
@@ -1,11 +1,12 @@
 use alloy_consensus::proofs::{ordered_trie_root, ordered_trie_root_with_encoder};
-use alloy_primitives::{b256, bytes, keccak256, Address, Bytes, B256, B64, U256};
+use alloy_primitives::{Address, B64, B256, Bytes, U256, b256, bytes, keccak256};
 use alloy_rlp::Encodable;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
+    FixedVector, VariableList,
     serde_utils::{hex_fixed_vec, hex_var_list, list_of_hex_var_list},
-    typenum, FixedVector, VariableList,
+    typenum,
 };
 use tree_hash_derive::TreeHash;
 

--- a/crates/common/consensus/src/deneb/execution_payload_header.rs
+++ b/crates/common/consensus/src/deneb/execution_payload_header.rs
@@ -2,8 +2,9 @@ use alloy_primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
+    FixedVector, VariableList,
     serde_utils::{hex_fixed_vec, hex_var_list},
-    typenum, FixedVector, VariableList,
+    typenum,
 };
 use tree_hash_derive::TreeHash;
 

--- a/crates/common/consensus/src/deposit.rs
+++ b/crates/common/consensus/src/deposit.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::B256;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum::U33, FixedVector};
+use ssz_types::{FixedVector, typenum::U33};
 use tree_hash_derive::TreeHash;
 
 use crate::deposit_data::DepositData;

--- a/crates/common/consensus/src/fork_choice/store.rs
+++ b/crates/common/consensus/src/fork_choice/store.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{map::HashMap, B256};
+use alloy_primitives::{B256, map::HashMap};
 use serde::{Deserialize, Serialize};
 
 use super::{

--- a/crates/common/consensus/src/fork_data.rs
+++ b/crates/common/consensus/src/fork_data.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{aliases::B32, B256};
+use alloy_primitives::{B256, aliases::B32};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash::TreeHash;

--- a/crates/common/consensus/src/historical_batch.rs
+++ b/crates/common/consensus/src/historical_batch.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::B256;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum::U8192, FixedVector};
+use ssz_types::{FixedVector, typenum::U8192};
 use tree_hash_derive::TreeHash;
 
 // todo: add tests

--- a/crates/common/consensus/src/indexed_attestation.rs
+++ b/crates/common/consensus/src/indexed_attestation.rs
@@ -1,7 +1,7 @@
 use ream_bls::BLSSignature;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum, VariableList};
+use ssz_types::{VariableList, typenum};
 use tree_hash_derive::TreeHash;
 
 use crate::attestation_data::AttestationData;

--- a/crates/common/consensus/src/misc.rs
+++ b/crates/common/consensus/src/misc.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use alloy_primitives::{aliases::B32, B256};
+use alloy_primitives::{B256, aliases::B32};
 use anyhow::ensure;
 use ethereum_hashing::hash;
 use tree_hash::TreeHash;

--- a/crates/common/consensus/src/pending_attestation.rs
+++ b/crates/common/consensus/src/pending_attestation.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum, BitList};
+use ssz_types::{BitList, typenum};
 use tree_hash_derive::TreeHash;
 
 use crate::attestation_data::AttestationData;

--- a/crates/common/consensus/src/sync_aggregate.rs
+++ b/crates/common/consensus/src/sync_aggregate.rs
@@ -1,7 +1,7 @@
 use ream_bls::BLSSignature;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum, BitVector};
+use ssz_types::{BitVector, typenum};
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]

--- a/crates/common/consensus/src/sync_committee.rs
+++ b/crates/common/consensus/src/sync_committee.rs
@@ -1,7 +1,7 @@
 use ream_bls::PubKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum::U512, FixedVector};
+use ssz_types::{FixedVector, typenum::U512};
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]

--- a/crates/common/execution_engine/src/lib.rs
+++ b/crates/common/execution_engine/src/lib.rs
@@ -2,11 +2,11 @@ mod rpc_types;
 pub mod transaction;
 pub mod utils;
 
-use alloy_primitives::{hex, B256, B64};
+use alloy_primitives::{B64, B256, hex};
 use alloy_rlp::Decodable;
 use anyhow::anyhow;
 use async_trait::async_trait;
-use jsonwebtoken::{encode, get_current_timestamp, EncodingKey, Header};
+use jsonwebtoken::{EncodingKey, Header, encode, get_current_timestamp};
 use ream_consensus::{
     deneb::execution_payload::ExecutionPayload,
     execution_engine::{engine_trait::ExecutionApi, new_payload_request::NewPayloadRequest},
@@ -23,7 +23,7 @@ use rpc_types::{
 use serde_json::json;
 use ssz_types::VariableList;
 use transaction::{BlobTransaction, TransactionType};
-use utils::{strip_prefix, Claims, JsonRpcRequest, JsonRpcResponse};
+use utils::{Claims, JsonRpcRequest, JsonRpcResponse, strip_prefix};
 
 pub struct ExecutionEngine {
     http_client: Client,

--- a/crates/common/execution_engine/src/rpc_types/execution_payload.rs
+++ b/crates/common/execution_engine/src/rpc_types/execution_payload.rs
@@ -3,8 +3,9 @@ use ream_consensus::{deneb::execution_payload::ExecutionPayload, withdrawal::Wit
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
+    FixedVector, VariableList,
     serde_utils::{hex_fixed_vec, hex_var_list, list_of_hex_var_list},
-    typenum, FixedVector, VariableList,
+    typenum,
 };
 use tree_hash_derive::TreeHash;
 

--- a/crates/common/execution_engine/src/rpc_types/forkchoice_update.rs
+++ b/crates/common/execution_engine/src/rpc_types/forkchoice_update.rs
@@ -1,7 +1,7 @@
-use alloy_primitives::{Address, B256, B64};
+use alloy_primitives::{Address, B64, B256};
 use ream_consensus::withdrawal::Withdrawal;
 use serde::{Deserialize, Serialize};
-use ssz_types::{typenum, VariableList};
+use ssz_types::{VariableList, typenum};
 
 use super::payload_status::PayloadStatusV1;
 

--- a/crates/common/execution_engine/src/rpc_types/get_blobs.rs
+++ b/crates/common/execution_engine/src/rpc_types/get_blobs.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use ssz_types::{serde_utils::list_of_hex_var_list, typenum, VariableList};
+use ssz_types::{VariableList, serde_utils::list_of_hex_var_list, typenum};
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/crates/common/execution_engine/src/rpc_types/get_payload.rs
+++ b/crates/common/execution_engine/src/rpc_types/get_payload.rs
@@ -2,7 +2,7 @@ use alloy_primitives::B256;
 use ream_consensus::kzg_commitment::KZGCommitment;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{serde_utils::list_of_hex_var_list, typenum, VariableList};
+use ssz_types::{VariableList, serde_utils::list_of_hex_var_list, typenum};
 use tree_hash_derive::TreeHash;
 
 use super::execution_payload::ExecutionPayloadV3;

--- a/crates/common/execution_engine/src/transaction.rs
+++ b/crates/common/execution_engine/src/transaction.rs
@@ -1,5 +1,5 @@
-use alloy_primitives::{Address, Bytes, B256, U256, U64};
-use alloy_rlp::{bytes, Buf, Decodable, Encodable, RlpDecodable, RlpEncodable, EMPTY_STRING_CODE};
+use alloy_primitives::{Address, B256, Bytes, U64, U256};
+use alloy_rlp::{Buf, Decodable, EMPTY_STRING_CODE, Encodable, RlpDecodable, RlpEncodable, bytes};
 use serde::Deserialize;
 
 #[derive(Default, Eq, Debug, Clone, PartialEq)]

--- a/crates/common/network_spec/src/cli.rs
+++ b/crates/common/network_spec/src/cli.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::networks::{NetworkSpec, DEV, HOLESKY, HOODI, MAINNET, SEPOLIA};
+use crate::networks::{DEV, HOLESKY, HOODI, MAINNET, NetworkSpec, SEPOLIA};
 
 pub fn network_parser(network_string: &str) -> Result<Arc<NetworkSpec>, String> {
     match network_string {

--- a/crates/crypto/bls/src/pubkey.rs
+++ b/crates/crypto/bls/src/pubkey.rs
@@ -2,7 +2,7 @@ use alloy_primitives::hex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum, FixedVector};
+use ssz_types::{FixedVector, typenum};
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Clone, Encode, Decode, TreeHash, Default)]

--- a/crates/crypto/bls/src/signature.rs
+++ b/crates/crypto/bls/src/signature.rs
@@ -2,7 +2,7 @@ use alloy_primitives::hex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
-use ssz_types::{typenum, FixedVector};
+use ssz_types::{FixedVector, typenum};
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Clone, Encode, Decode, TreeHash, Default)]

--- a/crates/crypto/bls/src/supranational/signature.rs
+++ b/crates/crypto/bls/src/supranational/signature.rs
@@ -1,4 +1,4 @@
-use blst::{min_pk::Signature as BlstSignature, BLST_ERROR};
+use blst::{BLST_ERROR, min_pk::Signature as BlstSignature};
 
 use crate::{
     constants::DST,

--- a/crates/crypto/bls/src/traits.rs
+++ b/crates/crypto/bls/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{errors::BLSError, AggregatePubKey, PubKey};
+use crate::{AggregatePubKey, PubKey, errors::BLSError};
 
 /// Trait for aggregating BLS public keys.
 ///

--- a/crates/crypto/bls/src/zkcrypto/aggregate_pubkey.rs
+++ b/crates/crypto/bls/src/zkcrypto/aggregate_pubkey.rs
@@ -1,9 +1,9 @@
 use bls12_381::{G1Affine, G1Projective};
 
 use crate::{
+    AggregatePubKey, PubKey,
     errors::BLSError,
     traits::{Aggregatable, ZkcryptoAggregatable},
-    AggregatePubKey, PubKey,
 };
 
 impl Aggregatable for AggregatePubKey {

--- a/crates/crypto/bls/src/zkcrypto/pubkey.rs
+++ b/crates/crypto/bls/src/zkcrypto/pubkey.rs
@@ -1,6 +1,6 @@
 use bls12_381::{G1Affine, G1Projective};
 
-use crate::{errors::BLSError, PubKey};
+use crate::{PubKey, errors::BLSError};
 
 impl From<G1Projective> for PubKey {
     fn from(value: G1Projective) -> Self {

--- a/crates/crypto/bls/src/zkcrypto/signature.rs
+++ b/crates/crypto/bls/src/zkcrypto/signature.rs
@@ -1,13 +1,14 @@
 use bls12_381::{
+    G1Affine, G2Affine, G2Projective,
     hash_to_curve::{ExpandMsgXmd, HashToCurve},
-    pairing, G1Affine, G2Affine, G2Projective,
+    pairing,
 };
 
 use crate::{
+    AggregatePubKey, BLSSignature, PubKey,
     constants::DST,
     errors::BLSError,
     traits::{Aggregatable, Verifiable, ZkcryptoVerifiable},
-    AggregatePubKey, BLSSignature, PubKey,
 };
 
 impl TryFrom<&BLSSignature> for G2Affine {

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -8,18 +8,18 @@ use std::{
 
 use anyhow::anyhow;
 use discv5::{
-    enr::{k256::ecdsa::SigningKey, CombinedKey, NodeId},
     Discv5, Enr,
+    enr::{CombinedKey, NodeId, k256::ecdsa::SigningKey},
 };
-use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryFutureExt};
+use futures::{FutureExt, StreamExt, TryFutureExt, stream::FuturesUnordered};
 use libp2p::{
-    core::{transport::PortUse, Endpoint},
+    Multiaddr, PeerId,
+    core::{Endpoint, transport::PortUse},
     identity::Keypair,
     swarm::{
-        dummy::ConnectionHandler, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour,
-        THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+        ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
+        THandlerOutEvent, ToSwarm, dummy::ConnectionHandler,
     },
-    Multiaddr, PeerId,
 };
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -10,16 +10,16 @@ use std::{
 use anyhow::anyhow;
 use discv5::Enr;
 use libp2p::{
-    connection_limits,
+    Multiaddr, PeerId, Swarm, SwarmBuilder, Transport, connection_limits,
     core::{muxing::StreamMuxerBox, transport::Boxed},
     futures::StreamExt,
     identify,
     multiaddr::Protocol,
     noise,
     swarm::{NetworkBehaviour, SwarmEvent},
-    yamux, Multiaddr, PeerId, Swarm, SwarmBuilder, Transport,
+    yamux,
 };
-use libp2p_identity::{secp256k1, Keypair, PublicKey};
+use libp2p_identity::{Keypair, PublicKey, secp256k1};
 use ream_discv5::{
     config::NetworkConfig,
     discovery::{DiscoveredPeers, Discovery},


### PR DESCRIPTION
Rust 2024 edition came out, and I am also bumping Ream's minimum Rust version to compile with to 1.85

If anybody is running older toolchains they can do

```
rustup update
rustup default 1.85
```