### PR TITLE
feat: implemented epoch processing test for process_rewards_and_penalties()

### DIFF
--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -118,6 +118,7 @@ test_epoch_processing!(
     process_participation_flag_updates
 );
 test_epoch_processing!(randao_mixes_reset, process_randao_mixes_reset);
+test_epoch_processing!(rewards_and_penalties, process_rewards_and_penalties);
 test_epoch_processing!(slashings, process_slashings);
 test_epoch_processing!(slashings_reset, process_slashings_reset);
 


### PR DESCRIPTION
It seemed that the get_inactivity_penalty_deltas() function was implemented in a later spec then what was implemented 

Issue: https://github.com/ReamLabs/ream/issues/161