### PR TITLE
fix: no discovered peers in discv5

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use ream::cli::{Cli, Commands};
 use ream_discv5::config::NetworkConfig;
 use ream_executor::ReamExecutor;
-use ream_p2p::network::Network;
+use ream_p2p::{bootnodes::Bootnodes, network::Network};
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
@@ -25,6 +25,8 @@ async fn main() {
 
     let main_executor = ReamExecutor::new().unwrap();
 
+    let bootnodes = Bootnodes::new();
+
     let discv5_config = discv5::ConfigBuilder::new(discv5::ListenConfig::from_ip(
         Ipv4Addr::UNSPECIFIED.into(),
         8080,
@@ -32,7 +34,7 @@ async fn main() {
     .build();
     let binding = NetworkConfig {
         discv5_config,
-        boot_nodes_enr: vec![],
+        boot_nodes_enr: bootnodes.bootnodes,
         disable_discovery: false,
         total_peers: 0,
     };

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
     .build();
     let binding = NetworkConfig {
         discv5_config,
-        boot_nodes_enr: bootnodes.bootnodes,
+        bootnodes: bootnodes.bootnodes,
         disable_discovery: false,
         total_peers: 0,
     };

--- a/crates/networking/discv5/src/config.rs
+++ b/crates/networking/discv5/src/config.rs
@@ -3,7 +3,7 @@ use discv5::Enr;
 pub struct NetworkConfig {
     pub discv5_config: discv5::Config,
 
-    pub boot_nodes_enr: Vec<Enr>,
+    pub bootnodes: Vec<Enr>,
 
     pub disable_discovery: bool,
 

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -66,16 +66,16 @@ impl Discovery {
         let mut discv5 = Discv5::new(enr, enr_local, config.discv5_config.clone())
             .map_err(|err| anyhow!("Failed to create discv5: {err:?}"))?;
 
-        // adding bootnode to DHT
-        for bootnode_enr in config.boot_nodes_enr.clone() {
-            if bootnode_enr.node_id() == node_local_id {
-                // Skip adding ourselves to the routing table if we are a bootnode
+        // adding bootnodes to discv5
+        for enr in config.bootnodes.clone() {
+            // Skip adding ourselves to the routing table if we are a bootnode
+            if enr.node_id() == node_local_id {
                 continue;
             }
 
-            let _ = discv5.add_enr(bootnode_enr).map_err(|err| {
-                error!("Failed to add bootnode to DHT {err:?}");
-            });
+            if let Err(err) = discv5.add_enr(enr) {
+                error!("Failed to add bootnode to Discv5 {err:?}");
+            };
         }
 
         // init ports

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -152,12 +152,10 @@ impl Network {
         }
 
         for bootnode in config.boot_nodes_enr.clone() {
-            if let Some(ipv4) = bootnode.ip4() {
+            if let (Some(ipv4), Some(tcp_port)) = (bootnode.ip4(), bootnode.tcp4()) {
                 let mut multi_addr = Multiaddr::empty();
-                if let Some(tcp_port) = bootnode.tcp4() {
-                    multi_addr.push(ipv4.into());
-                    multi_addr.push(Protocol::Tcp(tcp_port));
-                }
+                multi_addr.push(ipv4.into());
+                multi_addr.push(Protocol::Tcp(tcp_port));
                 self.swarm.dial(multi_addr).unwrap();
             }
         }

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -151,7 +151,7 @@ impl Network {
             }
         }
 
-        for bootnode in config.boot_nodes_enr.clone() {
+        for bootnode in &config.bootnodes {
             if let (Some(ipv4), Some(tcp_port)) = (bootnode.ip4(), bootnode.tcp4()) {
                 let mut multi_addr = Multiaddr::empty();
                 multi_addr.push(ipv4.into());

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -27,8 +27,6 @@ use ream_discv5::{
 use ream_executor::ReamExecutor;
 use tracing::{error, info, warn};
 
-use crate::bootnodes::Bootnodes;
-
 #[derive(NetworkBehaviour)]
 pub(crate) struct ReamBehaviour {
     pub identify: identify::Behaviour,
@@ -135,7 +133,7 @@ impl Network {
         Ok(network)
     }
 
-    async fn start_network_worker(&mut self, _config: &NetworkConfig) -> anyhow::Result<()> {
+    async fn start_network_worker(&mut self, config: &NetworkConfig) -> anyhow::Result<()> {
         info!("Libp2p starting .... ");
 
         let mut multi_addr: Multiaddr = Ipv4Addr::UNSPECIFIED.into();
@@ -153,9 +151,7 @@ impl Network {
             }
         }
 
-        let bootnodes = Bootnodes::new();
-
-        for bootnode in bootnodes.bootnodes {
+        for bootnode in config.boot_nodes_enr.clone() {
             if let Some(ipv4) = bootnode.ip4() {
                 let mut multi_addr = Multiaddr::empty();
                 if let Some(tcp_port) = bootnode.tcp4() {


### PR DESCRIPTION
Discv5 doesn't find any peers in the current setting. This PR adds bootnodes to the discv5 service and now 16 peers are found.