### PR TITLE
fix(ci): risc0 changed how toolchain is installed

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -36,7 +36,6 @@ jobs:
       run: |
         curl -L https://risczero.com/install | bash
         /home/runner/.risc0/bin/rzup install
-        cargo risczero install
         rustup default risc0
         
     - name: Build Risc0


### PR DESCRIPTION
CI was failing on my db PR #249 due to Risc0 changing how they install the default toolchain here is a link to the failing CI https://github.com/ReamLabs/ream/actions/runs/14076476787/job/39420262633?pr=249 which throws an error giving instructions on what we should do instead now.

In short `rzup install` now also does what `cargo risczero install` used to do, which install the latest toolchain