### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 crates/common/consensus/        @KolbyML @Kayden-ML @varun-doshi
 crates/common/execution_engine/ @KolbyML @Kayden-ML
 crates/crypto/                  @KolbyML @syjn99
-crates/rpc/                     @KolbyML @varun-doshi @varun-doshi
+crates/rpc/                     @KolbyML @varun-doshi
 crates/testing/                 @KolbyML @Kayden-ML @syjn99

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Context on this file: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# The basic jist is that this file is used to automatically request reviews from the people listed in the file when a PR is opened.
+*                               @KolbyML
+crates/common/consensus/        @KolbyML @Kayden-ML @varun-doshi
+crates/common/execution_engine/ @KolbyML @Kayden-ML
+crates/crypto/                  @KolbyML @syjn99
+crates/rpc/                     @KolbyML @varun-doshi @varun-doshi
+crates/testing/                 @KolbyML @Kayden-ML @syjn99

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Context on this file: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # The basic jist is that this file is used to automatically request reviews from the people listed in the file when a PR is opened.
-*                               @KolbyML
-crates/common/consensus/        @KolbyML @Kayden-ML @varun-doshi
-crates/common/execution_engine/ @KolbyML @Kayden-ML
+*                               @KolbyML @syjn99
+crates/common/consensus/        @KolbyML @Kayden-ML @syjn99 @varun-doshi
+crates/common/execution_engine/ @KolbyML @Kayden-ML @syjn99
 crates/crypto/                  @KolbyML @syjn99
 crates/rpc/                     @KolbyML @varun-doshi
 crates/testing/                 @KolbyML @Kayden-ML @syjn99


### PR DESCRIPTION
Adds a `CODEOWNERS` file that (at a minimum) automatically assigns reviewers to PRs based on the files changed.

I mostly assigned people to folders based what they worked on. CODEOWNERS will be helpful for 3rd party contributors as they can't assign reviewers themselves. This will be modified overtime as the project progresses

More about the CODEOWNERS file [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)