### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,67 @@
+name: Bug Report
+description: Create a bug report
+labels: ["C-bug", "S-needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+
+        If you believe you have found a vulnerability, please provide details [here](mailto:security@reamlabs.com) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is.
+
+        If the bug is in a crate you are using (i.e. you are not running the standard `ream` binary) please mention that as well.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Please provide any steps you think might be relevant to reproduce the bug.
+      placeholder: |
+        Steps to reproduce:
+
+        1. Start '...'
+        2. Then '...'
+        3. Check '...'
+        4. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform(s)
+      description: What platform(s) did this occur on?
+      multiple: true
+      options:
+        - Linux (x86)
+        - Linux (ARM)
+        - Mac (Intel)
+        - Mac (Apple Silicon)
+        - Windows (x86)
+        - Windows (ARM)
+  - type: textarea
+    id: client-version
+    attributes:
+      label: What version/commit are you on?
+      description: This can be obtained with `ream --version`
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: If you've built Ream from source, provide the full command you used
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/ReamLabs/ream/blob/main/CONTRIBUTING.md#code-of-conduct)
+      options:
+        - label: I agree to follow the Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/ReamLabs/ream/discussions
+    about: Please ask and answer questions here to keep the issue tracker clean.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,19 @@
+name: Documentation
+description: Suggest a change to our documentation
+labels: ["C-docs", "S-needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If you are unsure if the docs are relevant or needed, please open up a discussion first.
+  - type: textarea
+    attributes:
+      label: Describe the change
+      description: |
+        Please describe the documentation you want to change or add, and if it is for end-users or contributors.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources)

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest a feature
+labels: ["C-enhancement", "S-needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that the feature has not already been requested in the issue tracker.
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: |
+        Please describe the feature and what it is aiming to solve, if relevant.
+
+        If the feature is for a crate, please include a proposed API surface.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Report a Vulnerability
+
+Contact [security@reamlabs.com](mailto:security@reamlabs.com).


### PR DESCRIPTION
The PR adds minimal issue templates that should faciliate contributions in a structured fashion.

New issues can be easily filtered by `S-needs-triage` for maintainers to triage them. (More on [triage](https://bevyengine.org/learn/contribute/reference/triage))

In order to complete this setup, we need to set up a discussions and make a security email account.

Note: the templates are heavily inspired by Ithaca's.