### PR TITLE
feat: add bootnodes cli param

### DIFF
--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -7,6 +7,7 @@ use std::{
 use clap::{Parser, Subcommand};
 use ream_network_spec::{cli::network_parser, networks::NetworkSpec};
 use ream_node::version::FULL_VERSION;
+use ream_p2p::bootnodes::Bootnodes;
 
 const DEFAULT_DISABLE_DISCOVERY: bool = false;
 const DEFAULT_DISCOVERY_PORT: u16 = 8000;
@@ -70,6 +71,13 @@ pub struct NodeConfig {
         help = "Use new data directory, located in OS temporary directory. If used together with --data-dir, new directory will be created there instead."
     )]
     pub ephemeral: bool,
+
+    #[arg(
+        default_value = "default",
+        long = "bootnodes",
+        help = "One or more comma-delimited base64-encoded ENR's of peers to initially connect to. Use 'default' to use the default bootnodes for the network. Use 'none' to disable bootnodes."
+    )]
+    pub bootnodes: Bootnodes,
 }
 
 #[cfg(test)]

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use ream::cli::{Cli, Commands};
 use ream_discv5::config::NetworkConfig;
 use ream_executor::ReamExecutor;
-use ream_p2p::{bootnodes::Bootnodes, network::Network};
+use ream_p2p::network::Network;
 use ream_rpc::{config::ServerConfig, start_server};
 use ream_storage::db::ReamDB;
 use tracing::{error, info};
@@ -43,10 +43,10 @@ async fn main() {
             ))
             .build();
 
-            let bootnodes = Bootnodes::new(config.network.network);
+            let bootnodes = config.bootnodes.to_enrs(config.network.network);
             let binding = NetworkConfig {
                 discv5_config,
-                bootnodes: bootnodes.bootnodes,
+                bootnodes,
                 disable_discovery: config.disable_discovery,
                 total_peers: 0,
             };


### PR DESCRIPTION
@Vid201 ping for review

@Vid201 wanted a way for the user to specify which bootnodes to connect to through the CLI. Initially he tried in this PR https://github.com/ReamLabs/ream/pull/253 to  extend the pre-existing list, but I would prefer fleshed out approach if we are going to add a bootnodes cli. I message him and he said it is fine if I make a PR for this