### PR TITLE
ci: add CI which runs cargo sort --check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,18 @@ jobs:
         cargo clippy --all --all-targets --no-deps -- --deny warnings # clippy for ream, default features
         cargo clippy --package ream-bls --all-targets --features "supranational" --no-deps -- --deny warnings # clippy for ream-bls, supranational feature
 
+  cargo-sort:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install cargo sort
+      run: cargo install cargo-sort
+
+    - name: Run cargo sort
+      run: cargo sort --grouped --check
+
   build:
     runs-on: ubuntu-latest
     needs: [cargo-fmt, cargo-clippy]

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ lint: # Run `clippy` and `rustfmt`.
 	cargo clippy --package ream-bls --all-targets --features "supranational" --no-deps -- --deny warnings
 
 	# cargo sort
-	cargo sort -g
+	cargo sort --grouped
 
 .PHONY: test
 test: # Run all tests.


### PR DESCRIPTION
Adding a CI which makes sure our `Cargo.toml` files are sorted, we are using `cargo-sort` for this which was added to our makefile and Ream book recently. Since it is included in `make lint` we should have a ci for it