### PR TITLE
feat: implement `/node/identity` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,9 +4089,7 @@ name = "ream-network-spec"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "discv5",
  "enr",
- "libp2p-identity",
  "ream-consensus",
  "serde",
 ]
@@ -4127,11 +4125,9 @@ dependencies = [
 name = "ream-rpc"
 version = "0.1.0"
 dependencies = [
- "libp2p-identity",
  "ream-consensus",
  "ream-network-spec",
  "ream-node",
- "ream-p2p",
  "serde",
  "serde_json",
  "thiserror 2.0.12",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,7 +4089,11 @@ name = "ream-network-spec"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "discv5",
+ "enr",
+ "libp2p-identity",
  "ream-consensus",
+ "serde",
 ]
 
 [[package]]
@@ -4123,9 +4127,11 @@ dependencies = [
 name = "ream-rpc"
 version = "0.1.0"
 dependencies = [
+ "libp2p-identity",
  "ream-consensus",
  "ream-network-spec",
  "ream-node",
+ "ream-p2p",
  "serde",
  "serde_json",
  "thiserror 2.0.12",

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
                 match Network::init(async_executor, &binding).await {
                     Ok(mut network) => {
                         let _ = tx.send(Identity::new(
-                            network.get_config(),
+                            network.get_peer_id(),
                             network.get_local_enr(),
                             config.discovery_port,
                             config.socket_address.to_string(),

--- a/crates/common/network_spec/Cargo.toml
+++ b/crates/common/network_spec/Cargo.toml
@@ -11,6 +11,10 @@ version.workspace = true
 
 [dependencies]
 alloy-primitives.workspace = true
+enr.workspace = true
+discv5.workspace = true
+libp2p-identity.workspace = true
+serde.workspace = true
 
 # ream-dependencies
 ream-consensus.workspace = true

--- a/crates/common/network_spec/Cargo.toml
+++ b/crates/common/network_spec/Cargo.toml
@@ -12,8 +12,6 @@ version.workspace = true
 [dependencies]
 alloy-primitives.workspace = true
 enr.workspace = true
-discv5.workspace = true
-libp2p-identity.workspace = true
 serde.workspace = true
 
 # ream-dependencies

--- a/crates/common/network_spec/src/identity.rs
+++ b/crates/common/network_spec/src/identity.rs
@@ -1,0 +1,49 @@
+use enr::{CombinedKey, Enr};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Identity {
+    pub peer_id: String,
+    pub enr: String,
+    pub p2p_address: String,
+    pub discovery_address: String,
+    pub metadata: MetaData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MetaData {
+    pub seq_number: String,
+    pub attnets: String,
+    pub syncnets: String,
+}
+
+impl Identity {
+    pub fn new(
+        peer_id: String,
+        enr: Enr<CombinedKey>,
+        discovery_port: u16,
+        socket_addr: String,
+        socket_port: u16,
+    ) -> Self {
+        Self {
+            peer_id: peer_id.clone(),
+            enr: format!("{}{}", "enr:-", enr.to_base64()),
+            p2p_address: format!(
+                "{}{}{}{}/{}",
+                "/ip4/", socket_addr, "/tcp/", socket_port, peer_id
+            ),
+            discovery_address: format!("{}{}/p2p/{}", "/ip4/7.7.7.7/udp/", discovery_port, peer_id),
+            metadata: MetaData::mock(),
+        }
+    }
+}
+
+impl MetaData {
+    pub fn mock() -> Self {
+        Self {
+            seq_number: String::from("1"),
+            attnets: String::from("0x000000"),
+            syncnets: String::from("0x0f"),
+        }
+    }
+}

--- a/crates/common/network_spec/src/lib.rs
+++ b/crates/common/network_spec/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod cli;
+pub mod identity;
 pub mod networks;

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -153,6 +153,11 @@ impl Discovery {
 
         self.discovery_queries.push(Box::pin(query_future));
     }
+
+    /// fetch the local ENR of running node.
+    pub fn local_enr(&self) -> Enr {
+        self.discv5.local_enr()
+    }
 }
 
 impl NetworkBehaviour for Discovery {

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -53,6 +53,14 @@ pub struct Network {
     peer_id: PeerId,
     swarm: Swarm<ReamBehaviour>,
 }
+impl Network {
+    pub fn get_config(&self) -> String {
+        self.peer_id.to_base58()
+    }
+    pub fn get_local_enr(&self) -> Enr {
+        self.swarm.behaviour().discovery.local_enr()
+    }
+}
 
 struct Executor(ReamExecutor);
 

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -54,7 +54,7 @@ pub struct Network {
     swarm: Swarm<ReamBehaviour>,
 }
 impl Network {
-    pub fn get_config(&self) -> String {
+    pub fn get_peer_id(&self) -> String {
         self.peer_id.to_base58()
     }
     pub fn get_local_enr(&self) -> Enr {

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -14,8 +14,10 @@ version.workspace = true
 ream-consensus.workspace = true
 ream-network-spec.workspace = true
 ream-node.workspace = true
+ream-p2p.workspace = true
 
 #misc
+libp2p-identity.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -14,10 +14,8 @@ version.workspace = true
 ream-consensus.workspace = true
 ream-network-spec.workspace = true
 ream-node.workspace = true
-ream-p2p.workspace = true
 
 #misc
-libp2p-identity.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/rpc/src/handlers/identity.rs
+++ b/crates/rpc/src/handlers/identity.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use ream_network_spec::identity::Identity;
+use warp::{
+    http::status::StatusCode,
+    reject::Rejection,
+    reply::{Reply, with_status},
+};
+
+use super::Data;
+
+/// Called by `/identity` to get the Identity of the current running Node.
+pub async fn get_node_identity(p2p_config: Arc<Identity>) -> Result<impl Reply, Rejection> {
+    Ok(with_status(Data::json(p2p_config), StatusCode::OK))
+}

--- a/crates/rpc/src/handlers/mod.rs
+++ b/crates/rpc/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod genesis;
+pub mod identity;
 pub mod version;
 
 use serde::Serialize;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use config::ServerConfig;
-use ream_network_spec::networks::NetworkSpec;
+use ream_network_spec::{identity::Identity, networks::NetworkSpec};
 use routes::get_routes;
 use tracing::info;
 use utils::error::handle_rejection;
@@ -14,8 +14,12 @@ pub mod types;
 pub mod utils;
 
 /// Start the Beacon API server.
-pub async fn start_server(network_spec: Arc<NetworkSpec>, server_config: ServerConfig) {
-    let routes = get_routes(network_spec).recover(handle_rejection);
+pub async fn start_server(
+    network_spec: Arc<NetworkSpec>,
+    server_config: Arc<ServerConfig>,
+    p2p_config: Identity,
+) {
+    let routes = get_routes(network_spec, p2p_config).recover(handle_rejection);
 
     info!("Starting server on {:?}", server_config.http_socket_address);
     serve(routes).run(server_config.http_socket_address).await;

--- a/crates/rpc/src/routes/mod.rs
+++ b/crates/rpc/src/routes/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use beacon::get_beacon_routes;
 use node::get_node_routes;
-use ream_network_spec::networks::NetworkSpec;
+use ream_network_spec::{identity::Identity, networks::NetworkSpec};
 use warp::{Filter, Rejection, path, reply::Reply};
 
 pub mod beacon;
@@ -11,12 +11,13 @@ pub mod node;
 /// Creates and returns all possible routes.
 pub fn get_routes(
     network_spec: Arc<NetworkSpec>,
+    p2p_config: Identity,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let eth_base = path("eth").and(path("v1"));
 
     let beacon_routes = get_beacon_routes(network_spec);
 
-    let node_routes = get_node_routes();
+    let node_routes = get_node_routes(p2p_config.into());
 
     eth_base.and(beacon_routes.or(node_routes))
 }

--- a/crates/rpc/src/routes/node.rs
+++ b/crates/rpc/src/routes/node.rs
@@ -1,13 +1,29 @@
+use std::sync::Arc;
+
+use ream_network_spec::identity::Identity;
 use warp::{Filter, Rejection, filters::path::end, get, log, path, reply::Reply};
 
-use crate::handlers::version::get_version;
+use crate::handlers::{identity::get_node_identity, version::get_version};
 
 /// Creates and returns all `/node` routes.
-pub fn get_node_routes() -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    path("node")
+pub fn get_node_routes(
+    p2p_config: Arc<Identity>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    let base_path = path("node");
+
+    let version_endpoint = base_path
         .and(path("version"))
         .and(end())
         .and(get())
         .and_then(get_version)
-        .with(log("version"))
+        .with(log("version"));
+
+    let identity_endpoint = base_path
+        .and(path("identity"))
+        .and(end())
+        .and(get())
+        .and_then(move || get_node_identity(p2p_config.clone()))
+        .with(log("identity"));
+
+    version_endpoint.or(identity_endpoint)
 }


### PR DESCRIPTION
Closes #177 

To run, start a node:

```
cargo run node
```


Make `GET` request to:
```
/node/identity
```


Note: The `metadata` field gives dummy values now, this will be updated once we add `attnets` and other related networking fields