### PR TITLE
feat: updated beacon state table to use block_root instead of slot number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4141,6 +4141,7 @@ version = "0.1.0"
 name = "ream-storage"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "directories",
  "ethereum_ssz",

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+alloy-primitives.workspace = true
 anyhow.workspace = true
 directories.workspace = true
 ethereum_ssz.workspace = true

--- a/crates/storage/src/tables/beacon_state.rs
+++ b/crates/storage/src/tables/beacon_state.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use alloy_primitives::B256;
 use ream_consensus::deneb::beacon_state::BeaconState;
 use redb::{Database, Durability, TableDefinition};
 
@@ -8,9 +9,9 @@ use crate::errors::StoreError;
 
 /// Table definition for the Beacon State table
 ///
-/// Key: Slot number
+/// Key: block_root
 /// Value: BeaconState
-pub const BEACON_STATE_TABLE: TableDefinition<u64, SSZEncoding<BeaconState>> =
+pub const BEACON_STATE_TABLE: TableDefinition<SSZEncoding<B256>, SSZEncoding<BeaconState>> =
     TableDefinition::new("beacon_state");
 
 pub struct BeaconStateTable {
@@ -18,7 +19,7 @@ pub struct BeaconStateTable {
 }
 
 impl Table for BeaconStateTable {
-    type Key = u64;
+    type Key = B256;
 
     type Value = BeaconState;
 

--- a/crates/storage/src/tables/mod.rs
+++ b/crates/storage/src/tables/mod.rs
@@ -2,14 +2,14 @@ pub mod beacon_state;
 
 use std::{any::type_name, fmt::Debug};
 
-use redb::{TypeName, Value};
+use redb::{Key, TypeName, Value};
 use ssz::{Decode, Encode};
 
 use crate::errors::StoreError;
 
 #[allow(clippy::result_large_err)]
 pub trait Table {
-    type Key: Value;
+    type Key;
 
     type Value;
 
@@ -21,6 +21,15 @@ pub trait Table {
 /// Wrapper type to handle keys and values using SSZ encoding
 #[derive(Debug)]
 pub struct SSZEncoding<T>(pub T);
+
+impl<T> Key for SSZEncoding<T>
+where
+    T: Debug + Encode + Decode + Ord,
+{
+    fn compare(data1: &[u8], data2: &[u8]) -> std::cmp::Ordering {
+        Self::from_bytes(data1).cmp(&Self::from_bytes(data2))
+    }
+}
 
 impl<T> Value for SSZEncoding<T>
 where


### PR DESCRIPTION
updated beacon state table to use block_root instead of slot number