### PR TITLE
feat: add proposer_boost_root table to the database

### DIFF
--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -9,7 +9,7 @@ use crate::{
     tables::{
         beacon_block::BeaconBlockTable, beacon_state::BeaconStateTable,
         block_timeliness::BlockTimelinessTable, checkpoint_states::CheckpointStatesTable,
-        latest_messages::LatestMessagesTable,
+        latest_messages::LatestMessagesTable, proposer_boost_root::ProposerBoostRootField,
         unrealized_justifications::UnrealizedJustificationsTable,
     },
 };
@@ -76,6 +76,12 @@ impl ReamDB {
 
     pub fn unrealized_justifications_provider(&self) -> UnrealizedJustificationsTable {
         UnrealizedJustificationsTable {
+            db: self.db.clone(),
+        }
+    }
+
+    pub fn proposer_boost_root_provider(&self) -> ProposerBoostRootField {
+        ProposerBoostRootField {
             db: self.db.clone(),
         }
     }

--- a/crates/storage/src/tables/mod.rs
+++ b/crates/storage/src/tables/mod.rs
@@ -3,6 +3,7 @@ pub mod beacon_state;
 pub mod block_timeliness;
 pub mod checkpoint_states;
 pub mod latest_messages;
+pub mod proposer_boost_root;
 pub mod unrealized_justifications;
 
 use std::{any::type_name, fmt::Debug};
@@ -21,6 +22,15 @@ pub trait Table {
     fn get(&self, key: Self::Key) -> Result<Option<Self::Value>, StoreError>;
 
     fn insert(&self, key: Self::Key, value: Self::Value) -> Result<(), StoreError>;
+}
+
+#[allow(clippy::result_large_err)]
+pub trait Field {
+    type Value;
+
+    fn get(&self) -> Result<Option<Self::Value>, StoreError>;
+
+    fn insert(&self, value: Self::Value) -> Result<(), StoreError>;
 }
 
 /// Wrapper type to handle keys and values using SSZ encoding

--- a/crates/storage/src/tables/proposer_boost_root.rs
+++ b/crates/storage/src/tables/proposer_boost_root.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use redb::{Database, Durability, TableDefinition};
+
+use super::{Field, SSZEncoding};
+use crate::errors::StoreError;
+
+/// Table definition for the Proposer_Boost_Root table
+///
+/// Value: Root
+pub const PROPOSER_BOOST_ROOT_FIELD: TableDefinition<&str, SSZEncoding<B256>> =
+    TableDefinition::new("proposer_boost_root");
+
+pub const PROPOSER_BOOST_ROOT_KEY: &str = "proposer_boost_root_key";
+
+pub struct ProposerBoostRootField {
+    pub db: Arc<Database>,
+}
+
+impl Field for ProposerBoostRootField {
+    type Value = B256;
+
+    fn get(&self) -> Result<Option<Self::Value>, StoreError> {
+        let read_txn = self.db.begin_read()?;
+
+        let table = read_txn.open_table(PROPOSER_BOOST_ROOT_FIELD)?;
+        let result = table.get(PROPOSER_BOOST_ROOT_KEY)?;
+        Ok(result.map(|res| res.value()))
+    }
+
+    fn insert(&self, value: Self::Value) -> Result<(), StoreError> {
+        let mut write_txn = self.db.begin_write()?;
+        write_txn.set_durability(Durability::Immediate);
+        let mut table = write_txn.open_table(PROPOSER_BOOST_ROOT_FIELD)?;
+        table.insert(PROPOSER_BOOST_ROOT_KEY, value)?;
+        drop(table);
+        write_txn.commit()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
fixes https://github.com/ReamLabs/ream/issues/277

added the proposer_boost_root table to the database
https://ethereum.github.io/consensus-specs/specs/phase0/fork-choice/#store