### PR TITLE
feat: implement slot and state root index tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4150,6 +4150,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
+ "tree_hash",
 ]
 
 [[package]]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -18,6 +18,7 @@ redb.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tree_hash.workspace = true
 
 # Ream dependencies
 ream-consensus.workspace = true

--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -12,7 +12,8 @@ use crate::{
         equivocating_indices::EquivocatingIndicesField,
         finalized_checkpoint::FinalizedCheckpointField, genesis_time::GenesisTimeField,
         justified_checkpoint::JustifiedCheckpointField, latest_messages::LatestMessagesTable,
-        proposer_boost_root::ProposerBoostRootField, time::TimeField,
+        proposer_boost_root::ProposerBoostRootField, slot_index::SlotIndexTable,
+        state_root_index::StateRootIndexTable, time::TimeField,
         unrealized_finalized_checkpoint::UnrealizedFinalizedCheckpointField,
         unrealized_justifications::UnrealizedJustificationsTable,
         unrealized_justified_checkpoint::UnrealizedJustifiedCheckpointField,
@@ -129,6 +130,18 @@ impl ReamDB {
 
     pub fn equivocating_indices_provider(&self) -> EquivocatingIndicesField {
         EquivocatingIndicesField {
+            db: self.db.clone(),
+        }
+    }
+
+    pub fn slot_index_provider(&self) -> SlotIndexTable {
+        SlotIndexTable {
+            db: self.db.clone(),
+        }
+    }
+
+    pub fn state_root_index_provider(&self) -> StateRootIndexTable {
+        StateRootIndexTable {
             db: self.db.clone(),
         }
     }

--- a/crates/storage/src/tables/beacon_block.rs
+++ b/crates/storage/src/tables/beacon_block.rs
@@ -3,8 +3,11 @@ use std::sync::Arc;
 use alloy_primitives::B256;
 use ream_consensus::deneb::beacon_block::BeaconBlock;
 use redb::{Database, Durability, TableDefinition};
+use tree_hash::TreeHash;
 
-use super::{SSZEncoding, Table};
+use super::{
+    SSZEncoding, Table, slot_index::SlotIndexTable, state_root_index::StateRootIndexTable,
+};
 use crate::errors::StoreError;
 
 /// Table definition for the Beacon Block table
@@ -35,9 +38,23 @@ impl Table for BeaconBlockTable {
         let mut write_txn = self.db.begin_write()?;
         write_txn.set_durability(Durability::Immediate);
         let mut table = write_txn.open_table(BEACON_BLOCK_TABLE)?;
-        table.insert(key, value)?;
+        table.insert(key, value.clone())?;
         drop(table);
         write_txn.commit()?;
+
+        // insert entry to slot_index table
+        let block_root = value.tree_hash_root();
+        let slot_index_table = SlotIndexTable {
+            db: self.db.clone(),
+        };
+        slot_index_table.insert(value.slot, block_root)?;
+
+        // insert entry to state root index table
+        let state_root_index_table = StateRootIndexTable {
+            db: self.db.clone(),
+        };
+        state_root_index_table.insert(value.state_root, block_root)?;
+
         Ok(())
     }
 }

--- a/crates/storage/src/tables/mod.rs
+++ b/crates/storage/src/tables/mod.rs
@@ -8,6 +8,8 @@ pub mod genesis_time;
 pub mod justified_checkpoint;
 pub mod latest_messages;
 pub mod proposer_boost_root;
+pub mod slot_index;
+pub mod state_root_index;
 pub mod time;
 pub mod unrealized_finalized_checkpoint;
 pub mod unrealized_justifications;

--- a/crates/storage/src/tables/slot_index.rs
+++ b/crates/storage/src/tables/slot_index.rs
@@ -10,7 +10,7 @@ use crate::errors::StoreError;
 ///
 /// Key: slot number
 /// Value: block_root
-pub const SLOT_INDEX_TABLE: TableDefinition<SSZEncoding<u64>, SSZEncoding<B256>> =
+pub const SLOT_INDEX_TABLE: TableDefinition<u64, SSZEncoding<B256>> =
     TableDefinition::new("slot_index");
 
 pub struct SlotIndexTable {

--- a/crates/storage/src/tables/slot_index.rs
+++ b/crates/storage/src/tables/slot_index.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use redb::{Database, Durability, TableDefinition};
+
+use super::{SSZEncoding, Table};
+use crate::errors::StoreError;
+
+/// Table definition for the Slot Index table
+///
+/// Key: slot number
+/// Value: block_root
+pub const SLOT_INDEX_TABLE: TableDefinition<SSZEncoding<u64>, SSZEncoding<B256>> =
+    TableDefinition::new("slot_index");
+
+pub struct SlotIndexTable {
+    pub db: Arc<Database>,
+}
+
+impl Table for SlotIndexTable {
+    type Key = u64;
+
+    type Value = B256;
+
+    fn get(&self, key: Self::Key) -> Result<Option<Self::Value>, StoreError> {
+        let read_txn = self.db.begin_read()?;
+
+        let table = read_txn.open_table(SLOT_INDEX_TABLE)?;
+        let result = table.get(key)?;
+        Ok(result.map(|res| res.value()))
+    }
+
+    fn insert(&self, key: Self::Key, value: Self::Value) -> Result<(), StoreError> {
+        let mut write_txn = self.db.begin_write()?;
+        write_txn.set_durability(Durability::Immediate);
+        let mut table = write_txn.open_table(SLOT_INDEX_TABLE)?;
+        table.insert(key, value)?;
+        drop(table);
+        write_txn.commit()?;
+        Ok(())
+    }
+}

--- a/crates/storage/src/tables/state_root_index.rs
+++ b/crates/storage/src/tables/state_root_index.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use redb::{Database, Durability, TableDefinition};
+
+use super::{SSZEncoding, Table};
+use crate::errors::StoreError;
+
+/// Table definition for the State Root Index table
+///
+/// Key: state_root
+/// Value: block_root
+pub const STATE_ROOT_INDEX_TABLE: TableDefinition<SSZEncoding<B256>, SSZEncoding<B256>> =
+    TableDefinition::new("state_root_index");
+
+pub struct StateRootIndexTable {
+    pub db: Arc<Database>,
+}
+
+impl Table for StateRootIndexTable {
+    type Key = B256;
+
+    type Value = B256;
+
+    fn get(&self, key: Self::Key) -> Result<Option<Self::Value>, StoreError> {
+        let read_txn = self.db.begin_read()?;
+
+        let table = read_txn.open_table(STATE_ROOT_INDEX_TABLE)?;
+        let result = table.get(key)?;
+        Ok(result.map(|res| res.value()))
+    }
+
+    fn insert(&self, key: Self::Key, value: Self::Value) -> Result<(), StoreError> {
+        let mut write_txn = self.db.begin_write()?;
+        write_txn.set_durability(Durability::Immediate);
+        let mut table = write_txn.open_table(STATE_ROOT_INDEX_TABLE)?;
+        table.insert(key, value)?;
+        drop(table);
+        write_txn.commit()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Implements the following tables: 
- Slot -> Block root (u64->B256)
- State Root -> Block Root (B256 -> B256)


Both required for Beacon APIs
