### PR TITLE
chore: set CI's which must pass to be merged

### DIFF
--- a/.github/workflows/core-rust.yml
+++ b/.github/workflows/core-rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
@@ -47,18 +48,6 @@ jobs:
 
     - name: Run cargo sort
       run: cargo sort --grouped --check
-
-  cargo-udeps:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install cargo udeps
-      run: cargo install cargo-udeps
-
-    - name: Run cargo udeps
-      run: cargo +nightly udeps --workspace --tests --all-targets --release --exclude ef-tests
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/optional-rust.yml
+++ b/.github/workflows/optional-rust.yml
@@ -1,0 +1,23 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-udeps:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install cargo udeps
+      run: cargo install cargo-udeps
+
+    - name: Run cargo udeps
+      run: cargo +nightly udeps --workspace --tests --all-targets --release --exclude ef-tests

--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
If these CI's fail we want the `merge-queue` to stop a PR from being merged. This can be helpful if we are merging multiple PR's in the same queue and an interaction between the different PR's cause's a critical CI to fail.

Documentation on `merge_group` can be found here https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

This PR doesn't require `cargo-udeps` to pass I view it as not as critical as the other CI's