### PR TITLE
feat: implement /eth/v2/debug/beacon/states/{state_id}

### DIFF
--- a/crates/rpc/src/handlers/state.rs
+++ b/crates/rpc/src/handlers/state.rs
@@ -1,7 +1,14 @@
 use ream_consensus::deneb::beacon_state::BeaconState;
 use ream_storage::{db::ReamDB, tables::Table};
+use warp::{
+    http::status::StatusCode, 
+    reject::Rejection, 
+    reply::{with_status, Reply}
+};
 
 use crate::types::{errors::ApiError, id::ID};
+
+use super::BeaconResponse;
 
 pub async fn get_state_from_id(state_id: ID, db: &ReamDB) -> Result<BeaconState, ApiError> {
     let block_root = match state_id {
@@ -19,4 +26,10 @@ pub async fn get_state_from_id(state_id: ID, db: &ReamDB) -> Result<BeaconState,
         .ok_or(ApiError::NotFound(format!(
             "Failed to find `beacon_state` from {block_root:?}"
         )))
+}
+
+pub async fn get_state(state_id: ID, db: ReamDB) -> Result<impl Reply, Rejection> {
+    let state = get_state_from_id(state_id, &db).await?;
+
+    Ok(with_status(BeaconResponse::json(state), StatusCode::OK))
 }

--- a/crates/rpc/src/handlers/state.rs
+++ b/crates/rpc/src/handlers/state.rs
@@ -1,35 +1,46 @@
-use alloy_primitives::FixedBytes;
 use ream_consensus::deneb::beacon_state::BeaconState;
-use ream_storage::{db::ReamDB, tables::{ Field, Table}};
+use ream_storage::{
+    db::ReamDB,
+    tables::{Field, Table},
+};
 use warp::{
-    http::status::StatusCode, 
-    reject::Rejection, 
-    reply::{with_status, Reply}
+    http::status::StatusCode,
+    reject::Rejection,
+    reply::{Reply, with_status},
 };
 
-use crate::types::{errors::ApiError, id::ID};
-
 use super::BeaconResponse;
+use crate::types::{errors::ApiError, id::ID};
 
 pub async fn get_state_from_id(state_id: ID, db: &ReamDB) -> Result<BeaconState, ApiError> {
     let block_root = match state_id {
-        ID::Named(ref name) => match name.as_str() {
-            "head" => {Ok(Some(FixedBytes::new([0; 32])))},
-            "justified" => {
-                let justified_checkpoint = db.justified_checkpoint_provider().get().map_err(|_| ApiError::InternalError)?
-                .ok_or_else(|| ApiError::NotFound(String::from("Justified checkpoint not found")))?;
-                
-                Ok(Some(justified_checkpoint.root))
-            },
-            "finalized" => {
-                let finalized_checkpoint = db.finalized_checkpoint_provider().get().map_err(|_| ApiError::InternalError)?
-                .ok_or_else(|| ApiError::NotFound(String::from("Finalized checkpoint not found")))?;
-                
-                Ok(Some(finalized_checkpoint.root))
-            },
-            "genesis" => db.slot_index_provider().get(0),
-            &_ => Ok(Some(FixedBytes::new([0; 32])))
-        },
+        ID::Finalized => {
+            let finalized_checkpoint = db
+                .finalized_checkpoint_provider()
+                .get()
+                .map_err(|_| ApiError::InternalError)?
+                .ok_or_else(|| {
+                    ApiError::NotFound(String::from("Finalized checkpoint not found"))
+                })?;
+
+            Ok(Some(finalized_checkpoint.root))
+        }
+        ID::Justified => {
+            let justified_checkpoint = db
+                .justified_checkpoint_provider()
+                .get()
+                .map_err(|_| ApiError::InternalError)?
+                .ok_or_else(|| {
+                    ApiError::NotFound(String::from("Justified checkpoint not found"))
+                })?;
+
+            Ok(Some(justified_checkpoint.root))
+        }
+        ID::Head | ID::Genesis => {
+            return Err(ApiError::NotFound(format!(
+                "This ID type is currently not supported: {state_id:?}"
+            )));
+        }
         ID::Slot(slot) => db.slot_index_provider().get(slot),
         ID::Root(root) => db.state_root_index_provider().get(root),
     }

--- a/crates/rpc/src/routes/beacon.rs
+++ b/crates/rpc/src/routes/beacon.rs
@@ -19,7 +19,7 @@ use crate::{
         randao::get_randao_mix, validator::get_validator_from_state,
     },
     types::{
-        id::{ValidatorID, ID},
+        id::{ID, ValidatorID},
         query::RandaoQuery,
     },
 };

--- a/crates/rpc/src/routes/beacon.rs
+++ b/crates/rpc/src/routes/beacon.rs
@@ -16,7 +16,7 @@ use super::with_db;
 use crate::{
     handlers::{
         checkpoint::get_finality_checkpoint, fork::get_fork, genesis::get_genesis,
-        randao::get_randao_mix, state::get_state, validator::get_validator_from_state,
+        randao::get_randao_mix, validator::get_validator_from_state,
     },
     types::{
         id::{ValidatorID, ID},

--- a/crates/rpc/src/routes/debug.rs
+++ b/crates/rpc/src/routes/debug.rs
@@ -1,0 +1,22 @@
+use ream_storage::db::ReamDB;
+use warp::{filters::path::{end, param}, get, log, path, reply::Reply, Filter, Rejection};
+
+use crate::{handlers::state::get_state, types::id::ID};
+use super::with_db;
+
+/// Creates and returns all `/debug` routes.
+pub fn get_debug_routes(
+    db: ReamDB,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    let db_filter = with_db(db);
+
+    path("debug")
+        .and(path("beacon"))
+        .and(path("states"))
+        .and(param::<ID>())
+        .and(end())
+        .and(get())
+        .and(db_filter.clone())
+        .and_then(move |state_id: ID, db: ReamDB| get_state(state_id, db))
+        .with(log("beacon_state"))
+}

--- a/crates/rpc/src/routes/debug.rs
+++ b/crates/rpc/src/routes/debug.rs
@@ -10,7 +10,7 @@ use super::with_db;
 use crate::{handlers::state::get_state, types::id::ID};
 
 /// Creates and returns all `/debug` routes.
-pub fn get_debug_routes(
+pub fn get_debug_routes_v2(
     db: ReamDB,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let db_filter = with_db(db);

--- a/crates/rpc/src/routes/debug.rs
+++ b/crates/rpc/src/routes/debug.rs
@@ -1,8 +1,13 @@
 use ream_storage::db::ReamDB;
-use warp::{filters::path::{end, param}, get, log, path, reply::Reply, Filter, Rejection};
+use warp::{
+    Filter, Rejection,
+    filters::path::{end, param},
+    get, log, path,
+    reply::Reply,
+};
 
-use crate::{handlers::state::get_state, types::id::ID};
 use super::with_db;
+use crate::{handlers::state::get_state, types::id::ID};
 
 /// Creates and returns all `/debug` routes.
 pub fn get_debug_routes(

--- a/crates/rpc/src/routes/mod.rs
+++ b/crates/rpc/src/routes/mod.rs
@@ -2,16 +2,16 @@ use std::sync::Arc;
 
 use beacon::get_beacon_routes;
 use config::get_config_routes;
-use node::get_node_routes;
 use debug::get_debug_routes;
+use node::get_node_routes;
 use ream_network_spec::networks::NetworkSpec;
 use ream_storage::db::ReamDB;
 use warp::{Filter, Rejection, path, reply::Reply};
 
 pub mod beacon;
 pub mod config;
-pub mod node;
 pub mod debug;
+pub mod node;
 
 /// Creates and returns all possible routes.
 pub fn get_routes(
@@ -29,8 +29,13 @@ pub fn get_routes(
 
     let debug_routes = get_debug_routes(db.clone());
 
-    let combined_routes = beacon_routes.or(node_routes).or(config_routes).or(debug_routes);
-    let versioned_base = eth_base_v1.or(eth_base_v2).and_then(|_| async { Ok::<_, Rejection>(()) });
+    let combined_routes = beacon_routes
+        .or(node_routes)
+        .or(config_routes)
+        .or(debug_routes);
+    let versioned_base = eth_base_v1
+        .or(eth_base_v2)
+        .and_then(|_| async { Ok::<_, Rejection>(()) });
     versioned_base.and(combined_routes).map(|_, reply| reply)
 }
 

--- a/crates/rpc/src/routes/mod.rs
+++ b/crates/rpc/src/routes/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use beacon::get_beacon_routes;
 use config::get_config_routes;
-use debug::get_debug_routes;
+use debug::get_debug_routes_v2;
 use node::get_node_routes;
 use ream_network_spec::networks::NetworkSpec;
 use ream_storage::db::ReamDB;
@@ -13,13 +13,11 @@ pub mod config;
 pub mod debug;
 pub mod node;
 
-/// Creates and returns all possible routes.
-pub fn get_routes(
+fn get_v1_routes(
     network_spec: Arc<NetworkSpec>,
     db: ReamDB,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let eth_base_v1 = path("eth").and(path("v1"));
-    let eth_base_v2 = path("eth").and(path("v2"));
 
     let beacon_routes = get_beacon_routes(network_spec.clone(), db.clone());
 
@@ -27,16 +25,26 @@ pub fn get_routes(
 
     let config_routes = get_config_routes(network_spec.clone());
 
-    let debug_routes = get_debug_routes(db.clone());
+    eth_base_v1.and(beacon_routes.or(node_routes).or(config_routes))
+}
 
-    let combined_routes = beacon_routes
-        .or(node_routes)
-        .or(config_routes)
-        .or(debug_routes);
-    let versioned_base = eth_base_v1
-        .or(eth_base_v2)
-        .and_then(|_| async { Ok::<_, Rejection>(()) });
-    versioned_base.and(combined_routes).map(|_, reply| reply)
+fn get_v2_routes(db: ReamDB) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    let eth_base_v2 = path("eth").and(path("v2"));
+
+    let debug_routes_v2 = get_debug_routes_v2(db.clone());
+
+    eth_base_v2.and(debug_routes_v2.or(warp::any().map(warp::reply)))
+}
+
+/// Creates and returns all possible routes.
+pub fn get_routes(
+    network_spec: Arc<NetworkSpec>,
+    db: ReamDB,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    let v1_routes = get_v1_routes(network_spec.clone(), db.clone());
+    let v2_routes = get_v2_routes(db.clone());
+
+    v2_routes.or(v1_routes)
 }
 
 /// Creates a filter for DB.

--- a/crates/rpc/src/types/id.rs
+++ b/crates/rpc/src/types/id.rs
@@ -8,7 +8,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ID {
-    Named(String),
+    Finalized,
+    Genesis,
+    Head,
+    Justified,
     Slot(u64),
     /// expected to be a 0x-prefixed hex string.
     Root(B256),
@@ -18,14 +21,22 @@ impl FromStr for ID {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.starts_with("0x") {
-            B256::from_str(s)
-                .map(ID::Root)
-                .map_err(|err| format!("Invalid hex root: {err}"))
-        } else {
-            s.parse::<u64>()
-                .map(ID::Slot)
-                .map_err(|err| format!("Invalid slot: {err}"))
+        match s.to_lowercase().as_str() {
+            "finalized" => Ok(ID::Finalized),
+            "genesis" => Ok(ID::Genesis),
+            "head" => Ok(ID::Head),
+            "justified" => Ok(ID::Justified),
+            _ => {
+                if s.starts_with("0x") {
+                    B256::from_str(s)
+                        .map(ID::Root)
+                        .map_err(|err| format!("Invalid hex root: {err}"))
+                } else {
+                    s.parse::<u64>()
+                        .map(ID::Slot)
+                        .map_err(|err| format!("Invalid slot: {err}"))
+                }
+            }
         }
     }
 }
@@ -33,7 +44,10 @@ impl FromStr for ID {
 impl fmt::Display for ID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ID::Named(path) => write!(f, "{path}"),
+            ID::Finalized => write!(f, "finalized"),
+            ID::Genesis => write!(f, "genesis"),
+            ID::Head => write!(f, "head"),
+            ID::Justified => write!(f, "justified"),
             ID::Slot(slot) => write!(f, "{slot}"),
             ID::Root(root) => write!(f, "0x{}", hex::encode(root)),
         }

--- a/crates/rpc/src/types/id.rs
+++ b/crates/rpc/src/types/id.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ID {
+    Named(String),
     Slot(u64),
     /// expected to be a 0x-prefixed hex string.
     Root(B256),
@@ -32,6 +33,7 @@ impl FromStr for ID {
 impl fmt::Display for ID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            ID::Named(path) => write!(f, "{path}"),
             ID::Slot(slot) => write!(f, "{slot}"),
             ID::Root(root) => write!(f, "0x{}", hex::encode(root)),
         }


### PR DESCRIPTION
wip closes #176 

This PR introduces
- Allow `state_id` to be passed as strings `head`, `justified`, `finalized`, `genesis`
- Creates a new base url with `eth/v2/...`
- Return BeaconState from the api endpoint implemented