### PR TITLE
fix: api returns 500 internal error

### DIFF
--- a/crates/rpc/src/routes/beacon.rs
+++ b/crates/rpc/src/routes/beacon.rs
@@ -4,10 +4,7 @@ use ream_network_spec::networks::NetworkSpec;
 use ream_storage::db::ReamDB;
 use warp::{
     Filter, Rejection,
-    filters::{
-        path::{end, param},
-        query::query,
-    },
+    filters::{path::end, query::query},
     get, log, path,
     reply::Reply,
 };
@@ -27,6 +24,7 @@ use crate::{
         id::{ID, ValidatorID},
         query::RandaoQuery,
     },
+    utils::error::parsed_param,
 };
 
 /// Creates and returns all `/beacon` routes.
@@ -46,7 +44,7 @@ pub fn get_beacon_routes(
 
     let fork = beacon_base
         .and(path("states"))
-        .and(param::<ID>())
+        .and(parsed_param::<ID>())
         .and(path("fork"))
         .and(end())
         .and(get())
@@ -56,7 +54,7 @@ pub fn get_beacon_routes(
 
     let state_root = beacon_base
         .and(path("states"))
-        .and(param::<ID>())
+        .and(parsed_param::<ID>())
         .and(path("root"))
         .and(end())
         .and(get())
@@ -66,7 +64,7 @@ pub fn get_beacon_routes(
 
     let randao = beacon_base
         .and(path("states"))
-        .and(param::<ID>())
+        .and(parsed_param::<ID>())
         .and(path("randao"))
         .and(query::<RandaoQuery>())
         .and(end())
@@ -79,7 +77,7 @@ pub fn get_beacon_routes(
 
     let checkpoint = beacon_base
         .and(path("states"))
-        .and(param::<ID>())
+        .and(parsed_param::<ID>())
         .and(path("finality_checkpoints"))
         .and(end())
         .and(get())
@@ -88,9 +86,9 @@ pub fn get_beacon_routes(
 
     let validator = beacon_base
         .and(path("states"))
-        .and(param::<ID>())
+        .and(parsed_param::<ID>())
         .and(path("validator"))
-        .and(param::<ValidatorID>())
+        .and(parsed_param::<ValidatorID>())
         .and(end())
         .and(get())
         .and(db_filter.clone())
@@ -103,7 +101,7 @@ pub fn get_beacon_routes(
 
     let block_root = beacon_base
         .and(path("blocks"))
-        .and(param::<ID>())
+        .and(parsed_param::<ID>())
         .and(path("root"))
         .and(end())
         .and(get())
@@ -112,7 +110,7 @@ pub fn get_beacon_routes(
         .with(log("block_root"));
     let block_rewards = beacon_base
         .and(path("blocks"))
-        .and(param::<ID>())
+        .and(parsed_param::<ID>())
         .and(path("rewards"))
         .and(end())
         .and(get())
@@ -138,7 +136,7 @@ pub fn get_beacon_routes_v2(
 
     beacon_base
         .and(path("blocks"))
-        .and(param::<ID>())
+        .and(parsed_param::<ID>())
         .and(path("attestations"))
         .and(end())
         .and(get())

--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -7,16 +7,28 @@ use crate::{
     dir,
     errors::StoreError,
     tables::{
-        beacon_block::BeaconBlockTable, beacon_state::BeaconStateTable,
-        block_timeliness::BlockTimelinessTable, checkpoint_states::CheckpointStatesTable,
-        equivocating_indices::EquivocatingIndicesField,
-        finalized_checkpoint::FinalizedCheckpointField, genesis_time::GenesisTimeField,
-        justified_checkpoint::JustifiedCheckpointField, latest_messages::LatestMessagesTable,
-        proposer_boost_root::ProposerBoostRootField, slot_index::SlotIndexTable,
-        state_root_index::StateRootIndexTable, time::TimeField,
-        unrealized_finalized_checkpoint::UnrealizedFinalizedCheckpointField,
-        unrealized_justifications::UnrealizedJustificationsTable,
-        unrealized_justified_checkpoint::UnrealizedJustifiedCheckpointField,
+        beacon_block::{BEACON_BLOCK_TABLE, BeaconBlockTable},
+        beacon_state::{BEACON_STATE_TABLE, BeaconStateTable},
+        block_timeliness::{BLOCK_TIMELINESS_TABLE, BlockTimelinessTable},
+        checkpoint_states::{CHECKPOINT_STATES_TABLE, CheckpointStatesTable},
+        equivocating_indices::{EQUIVOCATING_INDICES_FIELD, EquivocatingIndicesField},
+        finalized_checkpoint::{FINALIZED_CHECKPOINT_FIELD, FinalizedCheckpointField},
+        genesis_time::{GENESIS_TIME_FIELD, GenesisTimeField},
+        justified_checkpoint::{JUSTIFIED_CHECKPOINT_FIELD, JustifiedCheckpointField},
+        latest_messages::{LATEST_MESSAGES_TABLE, LatestMessagesTable},
+        proposer_boost_root::{PROPOSER_BOOST_ROOT_FIELD, ProposerBoostRootField},
+        slot_index::{SLOT_INDEX_TABLE, SlotIndexTable},
+        state_root_index::{STATE_ROOT_INDEX_TABLE, StateRootIndexTable},
+        time::{TIME_FIELD, TimeField},
+        unrealized_finalized_checkpoint::{
+            UNREALIZED_FINALIZED_CHECKPOINT_FIELD, UnrealizedFinalizedCheckpointField,
+        },
+        unrealized_justifications::{
+            UNREALIZED_JUSTIFICATIONS_TABLE, UnrealizedJustificationsTable,
+        },
+        unrealized_justified_checkpoint::{
+            UNREALIZED_JUSTIFED_CHECKPOINT_FIELD, UnrealizedJustifiedCheckpointField,
+        },
     },
 };
 
@@ -46,6 +58,25 @@ impl ReamDB {
             .set_cache_size(REDB_CACHE_SIZE)
             .create(&ream_file)
             .map_err(|err| StoreError::Database(err.into()))?;
+
+        let write_txn = db.begin_write()?;
+        write_txn.open_table(BEACON_BLOCK_TABLE)?;
+        write_txn.open_table(BEACON_STATE_TABLE)?;
+        write_txn.open_table(BLOCK_TIMELINESS_TABLE)?;
+        write_txn.open_table(CHECKPOINT_STATES_TABLE)?;
+        write_txn.open_table(EQUIVOCATING_INDICES_FIELD)?;
+        write_txn.open_table(FINALIZED_CHECKPOINT_FIELD)?;
+        write_txn.open_table(GENESIS_TIME_FIELD)?;
+        write_txn.open_table(JUSTIFIED_CHECKPOINT_FIELD)?;
+        write_txn.open_table(LATEST_MESSAGES_TABLE)?;
+        write_txn.open_table(PROPOSER_BOOST_ROOT_FIELD)?;
+        write_txn.open_table(SLOT_INDEX_TABLE)?;
+        write_txn.open_table(STATE_ROOT_INDEX_TABLE)?;
+        write_txn.open_table(TIME_FIELD)?;
+        write_txn.open_table(UNREALIZED_FINALIZED_CHECKPOINT_FIELD)?;
+        write_txn.open_table(UNREALIZED_JUSTIFICATIONS_TABLE)?;
+        write_txn.open_table(UNREALIZED_JUSTIFED_CHECKPOINT_FIELD)?;
+        write_txn.commit()?;
 
         Ok(Self { db: Arc::new(db) })
     }


### PR DESCRIPTION
Fixes an issue where the endpoints return `500 Internal Error` instead of `400 Not Found`

The issue: None of the tables were actually ever created since we never insert data(yet).
This fix will make it so that even if we dont insert data, it will atleast show StatusCode:400 instead of 500 which is a better output