### PR TITLE
feat: Implement discv5 attestation subnet bitfield

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,10 +4047,14 @@ dependencies = [
 name = "ream-discv5"
 version = "0.1.0"
 dependencies = [
+ "alloy-rlp",
  "anyhow",
  "discv5",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "futures",
  "libp2p",
+ "ssz_types",
  "tokio",
  "tracing",
 ]

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use clap::Parser;
 use ream::cli::{Cli, Commands};
-use ream_discv5::config::NetworkConfig;
+use ream_discv5::{config::NetworkConfig, subnet::Subnets};
 use ream_executor::ReamExecutor;
 use ream_p2p::network::Network;
 use ream_rpc::{config::ServerConfig, start_server};
@@ -51,6 +51,7 @@ async fn main() {
                 socket_port: config.socket_port,
                 disable_discovery: config.disable_discovery,
                 total_peers: 0,
+                subnets: Subnets::new(),
             };
 
             let _ream_db = ReamDB::new(config.data_dir, config.ephemeral)

--- a/crates/networking/discv5/Cargo.toml
+++ b/crates/networking/discv5/Cargo.toml
@@ -10,9 +10,13 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+alloy-rlp.workspace = true
 anyhow.workspace = true
+ethereum_ssz.workspace = true
+ethereum_ssz_derive.workspace = true
 discv5.workspace = true
 futures.workspace = true
 libp2p.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+ssz_types.workspace = true

--- a/crates/networking/discv5/src/config.rs
+++ b/crates/networking/discv5/src/config.rs
@@ -1,8 +1,11 @@
-use std::net::IpAddr;
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::Duration,
+};
 
 use discv5::Enr;
 
-use crate::subnet::Subnets; // Updated import
+use crate::subnet::{Subnet, Subnets};
 
 pub struct NetworkConfig {
     pub discv5_config: discv5::Config,
@@ -12,4 +15,81 @@ pub struct NetworkConfig {
     pub disable_discovery: bool,
     pub total_peers: usize,
     pub subnets: Subnets,
+}
+
+/// Helper function to determine if the IpAddr is a global address or not. The `is_global()`
+/// function is not yet stable on IpAddr.
+#[allow(clippy::nonminimal_bool)]
+fn is_global_ipv4(addr: &Ipv4Addr) -> bool {
+    // check if this address is 192.0.0.9 or 192.0.0.10. These addresses are the only two
+    // globally routable addresses in the 192.0.0.0/24 range.
+    if u32::from_be_bytes(addr.octets()) == 0xc0000009
+        || u32::from_be_bytes(addr.octets()) == 0xc000000a
+    {
+        return true;
+    }
+    !addr.is_private()
+            && !addr.is_loopback()
+            && !addr.is_link_local()
+            && !addr.is_broadcast()
+            && !addr.is_documentation()
+            // shared
+            && !(addr.octets()[0] == 100 && (addr.octets()[1] & 0b1100_0000 == 0b0100_0000)) &&!(addr.octets()[0] & 240 == 240 && !addr.is_broadcast())
+            // addresses reserved for future protocols (`192.0.0.0/24`)
+            // reserved
+            && !(addr.octets()[0] == 192 && addr.octets()[1] == 0 && addr.octets()[2] == 0)
+            // Make sure the address is not in 0.0.0.0/8
+            && addr.octets()[0] != 0
+}
+
+impl Default for NetworkConfig {
+    fn default() -> Self {
+        let mut subnets = Subnets::new();
+        // Enable attestation subnets 0 and 1 as a reasonable default
+        subnets.enable_subnet(Subnet::Attestation(0));
+        subnets.enable_subnet(Subnet::Attestation(1));
+
+        let filter_rate_limiter = Some(
+            discv5::RateLimiterBuilder::new()
+                .total_n_every(10, Duration::from_secs(1)) // Allow bursts, average 10 per second
+                .ip_n_every(9, Duration::from_secs(1)) // Allow bursts, average 9 per second
+                .node_n_every(8, Duration::from_secs(1)) // Allow bursts, average 8 per second
+                .build()
+                .expect("The total rate limit has been specified"),
+        );
+
+        let discv5_listen_config =
+            discv5::ListenConfig::from_ip(Ipv4Addr::UNSPECIFIED.into(), 9000);
+
+        // discv5 configuration
+        let discv5_config = discv5::ConfigBuilder::new(discv5_listen_config)
+            .enable_packet_filter()
+            .session_cache_capacity(5000)
+            .request_timeout(Duration::from_secs(2))
+            .query_peer_timeout(Duration::from_secs(2))
+            .query_timeout(Duration::from_secs(30))
+            .request_retries(1)
+            .enr_peer_update_min(10)
+            .query_parallelism(8)
+            .disable_report_discovered_peers()
+            .ip_limit() // limits /24 IP's in buckets.
+            .incoming_bucket_limit(8) // half the bucket size
+            .filter_rate_limiter(filter_rate_limiter)
+            .filter_max_bans_per_ip(Some(5))
+            .filter_max_nodes_per_ip(Some(10))
+            .table_filter(|enr| enr.ip4().is_some_and(|ip| is_global_ipv4(&ip))) // Filter non-global IPs
+            .ban_duration(Some(Duration::from_secs(3600)))
+            .ping_interval(Duration::from_secs(300))
+            .build();
+
+        Self {
+            discv5_config,
+            bootnodes: Vec::new(),
+            socket_address: IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
+            socket_port: 9000,
+            disable_discovery: false,
+            total_peers: 10,
+            subnets,
+        }
+    }
 }

--- a/crates/networking/discv5/src/config.rs
+++ b/crates/networking/discv5/src/config.rs
@@ -2,16 +2,14 @@ use std::net::IpAddr;
 
 use discv5::Enr;
 
+use crate::subnet::Subnets; // Updated import
+
 pub struct NetworkConfig {
     pub discv5_config: discv5::Config,
-
     pub bootnodes: Vec<Enr>,
-
     pub socket_address: IpAddr,
-
     pub socket_port: u16,
-
     pub disable_discovery: bool,
-
     pub total_peers: usize,
+    pub subnets: Subnets,
 }

--- a/crates/networking/discv5/src/lib.rs
+++ b/crates/networking/discv5/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
 pub mod discovery;
+pub mod subnet;

--- a/crates/networking/discv5/src/subnet.rs
+++ b/crates/networking/discv5/src/subnet.rs
@@ -1,0 +1,132 @@
+use alloy_rlp::bytes::Bytes;
+use discv5::Enr;
+use ssz::Decode;
+use ssz_types::{BitVector, typenum::U64};
+use tracing::trace;
+
+pub const ATTESTATION_BITFIELD_ENR_KEY: &str = "attnets";
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Subnet {
+    Attestation(u8),
+    SyncCommittee(u8),
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Subnets {
+    attestation_bits: Option<BitVector<U64>>,
+}
+
+impl Subnets {
+    pub fn new() -> Self {
+        Self {
+            attestation_bits: None,
+        }
+    }
+
+    pub fn enable_subnet(&mut self, subnet: Subnet) {
+        match subnet {
+            Subnet::Attestation(id) if id < 64 => {
+                let bits = self.attestation_bits.get_or_insert(BitVector::new());
+                bits.set(id as usize, true)
+                    .expect("Subnet ID within bounds");
+            }
+            Subnet::Attestation(_) => {}
+            Subnet::SyncCommittee(_) => unimplemented!("SyncCommittee support not yet implemented"),
+        }
+    }
+
+    pub fn disable_subnet(&mut self, subnet: Subnet) {
+        match subnet {
+            Subnet::Attestation(id) if id < 64 => {
+                if let Some(bits) = &mut self.attestation_bits {
+                    bits.set(id as usize, false)
+                        .expect("Subnet ID within bounds");
+                }
+            }
+            Subnet::Attestation(_) => {}
+            Subnet::SyncCommittee(_) => unimplemented!("SyncCommittee support not yet implemented"),
+        }
+    }
+
+    pub fn is_active(&self, subnet: Subnet) -> bool {
+        match subnet {
+            Subnet::Attestation(id) if id < 64 => self
+                .attestation_bits
+                .as_ref()
+                .is_some_and(|bits| bits.get(id as usize).unwrap_or(false)),
+            Subnet::Attestation(_) => false,
+            Subnet::SyncCommittee(_) => unimplemented!("SyncCommittee support not yet implemented"),
+        }
+    }
+
+    pub fn attestation_bytes(&self) -> Option<Vec<u8>> {
+        self.attestation_bits
+            .as_ref()
+            .map(|bits| bits.clone().into_bytes().into_vec())
+    }
+
+    pub fn from_enr(enr: &Enr) -> Self {
+        let attestation_bits = enr
+            .get_decodable(ATTESTATION_BITFIELD_ENR_KEY)
+            .and_then(|res| res.ok())
+            .and_then(|bytes: Bytes| BitVector::<U64>::from_ssz_bytes(&bytes).ok());
+
+        Self { attestation_bits }
+    }
+}
+
+pub fn subnet_predicate(subnets: Vec<Subnet>) -> impl Fn(&Enr) -> bool + Send + Sync {
+    move |enr: &Enr| {
+        let subnets_state = Subnets::from_enr(enr);
+        let attestation_bits = match &subnets_state.attestation_bits {
+            Some(bits) => bits,
+            None => {
+                trace!(
+                    "Peer rejected: invalid or missing attnets field; peer_id: {}",
+                    enr.node_id()
+                );
+                return false;
+            }
+        };
+
+        let mut matches_subnet = false;
+        for subnet in &subnets {
+            match subnet {
+                Subnet::Attestation(id) => {
+                    if *id >= 64 {
+                        trace!(
+                            "Peer rejected: subnet ID {} exceeds attestation bitfield length; peer_id: {}",
+                            id,
+                            enr.node_id()
+                        );
+                        return false;
+                    }
+                    matches_subnet |= match attestation_bits.get(*id as usize) {
+                        Ok(true) => true,
+                        Ok(false) => {
+                            trace!(
+                                "Peer found but not on subnet {}; peer_id: {}",
+                                id,
+                                enr.node_id()
+                            );
+                            false
+                        }
+                        Err(_) => {
+                            trace!(
+                                "Peer rejected: invalid attestation bitfield index; subnet_id: {}, peer_id: {}",
+                                id,
+                                enr.node_id()
+                            );
+                            false
+                        }
+                    };
+                }
+                Subnet::SyncCommittee(_) => {
+                    unimplemented!("SyncCommittee support not yet implemented")
+                }
+            }
+        }
+        matches_subnet
+    }
+}

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -68,7 +68,7 @@ impl Network {
 
         let discovery = {
             let mut discovery = Discovery::new(Keypair::from(local_key.clone()), config).await?;
-            discovery.discover_peers(16);
+            discovery.discover_peers(16, None);
             discovery
         };
 


### PR DESCRIPTION
## Description 

This PR implements Discv5 p2p discovery domain Attestation subnet bitfield as per the spec => https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#attestation-subnet-bitfield

## Details

- Add support for attestation subnet bitfield
- Add tests to cover discovery peers and Attestation subnet bitfield related cases
- Add initial subnet config to `NetworkConfig` as we need `SubnetService` to be implemented to read and update Subnet details from beacon chain.

Closes #245 