### PR TITLE
fix: preserve first error in loop execution

### DIFF
--- a/testing/ef-tests/src/macros/sanity_blocks.rs
+++ b/testing/ef-tests/src/macros/sanity_blocks.rs
@@ -61,10 +61,12 @@ macro_rules! test_sanity_blocks {
                         let signed_block: SignedBeaconBlock = utils::read_ssz_snappy(&block_path)
                             .expect(&format!("cannot find test asset (blocks_{i}.ssz_snappy)"));
 
-                        result = state
-                            .state_transition(&signed_block, validate_result, &mock_engine)
-                            .await
-                            .map_err(|err| err.to_string());
+                        if result.is_ok() {
+                            result = state
+                                .state_transition(&signed_block, validate_result, &mock_engine)
+                                .await
+                                .map_err(|err| err.to_string());
+                        }
                     }
 
                     let expected_post =
@@ -89,7 +91,6 @@ macro_rules! test_sanity_blocks {
                             );
                         }
                         (Err(_), None) => {
-                            // Expected: invalid operations result in an error and no post state.
                             println!(
                                 "Test case {} failed as expected, no post state available.",
                                 case_name

--- a/testing/ef-tests/src/macros/sanity_blocks.rs
+++ b/testing/ef-tests/src/macros/sanity_blocks.rs
@@ -91,6 +91,7 @@ macro_rules! test_sanity_blocks {
                             );
                         }
                         (Err(_), None) => {
+                            // Expected: invalid operations result in an error and no post state.
                             println!(
                                 "Test case {} failed as expected, no post state available.",
                                 case_name


### PR DESCRIPTION
fixed an issue where `result` was being overwritten on each loop iteration.
this could cause the first error to be lost if a later iteration succeeded.
now, the first encountered error is preserved correctly.