### PR TITLE
feat: implement /eth/v1/beacon/states/{state_id}/validator_identities

### DIFF
--- a/crates/crypto/bls/src/pubkey.rs
+++ b/crates/crypto/bls/src/pubkey.rs
@@ -9,7 +9,7 @@ use tree_hash_derive::TreeHash;
 
 use crate::errors::BLSError;
 
-#[derive(Debug, PartialEq, Clone, Encode, Decode, TreeHash, Default)]
+#[derive(Debug, PartialEq, Clone, Encode, Decode, TreeHash, Default, Eq, Hash)]
 pub struct PubKey {
     pub inner: FixedVector<u8, typenum::U48>,
 }

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -108,12 +108,7 @@ pub async fn post_validator_identities_from_state(
     state_id: Path<ID>,
     validator_ids: Json<Vec<ValidatorID>>,
 ) -> Result<impl Responder, ApiError> {
-    let state = match get_state_from_id(state_id.into_inner(), &db).await {
-        Ok(s) => s,
-        Err(_) => {
-            return Err(ApiError::NotFound(String::from("State not found")));
-        }
-    };
+    let state = get_state_from_id(state_id.into_inner(), &db).await?;
 
     let validator_ids_set: HashSet<ValidatorID> = validator_ids.into_inner().into_iter().collect();
 

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -2,6 +2,8 @@ use actix_web::{
     HttpResponse, Responder, get, post,
     web::{Data, Json, Path},
 };
+use alloy_primitives::map::HashSet;
+use ream_bls::PubKey;
 use ream_consensus::validator::Validator;
 use ream_storage::db::ReamDB;
 use serde::{Deserialize, Serialize};
@@ -89,6 +91,52 @@ pub async fn get_validator_from_state(
             validator,
         ))),
     )
+}
+
+#[derive(Debug, Serialize)]
+struct ValidatorIdentity {
+    #[serde(with = "serde_utils::quoted_u64")]
+    index: u64,
+    pubkey: PubKey,
+    #[serde(with = "serde_utils::quoted_u64")]
+    activation_epoch: u64,
+}
+
+#[post("/beacon/states/{state_id}/validator_identities")]
+pub async fn post_validator_identities_from_state(
+    db: Data<ReamDB>,
+    state_id: Path<ID>,
+    validator_ids: Json<Vec<ValidatorID>>,
+) -> Result<impl Responder, ApiError> {
+    let state = match get_state_from_id(state_id.into_inner(), &db).await {
+        Ok(s) => s,
+        Err(_) => {
+            return Err(ApiError::NotFound(String::from("State not found")));
+        }
+    };
+
+    let validator_ids_set: HashSet<ValidatorID> = validator_ids.into_inner().into_iter().collect();
+
+    let validator_identities: Vec<ValidatorIdentity> = state
+        .validators
+        .iter()
+        .enumerate()
+        .filter_map(|(index, validator)| {
+            if validator_ids_set.contains(&ValidatorID::Address(validator.pubkey.clone()))
+                || validator_ids_set.contains(&ValidatorID::Index(index as u64))
+            {
+                Some(ValidatorIdentity {
+                    index: index as u64,
+                    pubkey: validator.pubkey.clone(),
+                    activation_epoch: validator.activation_epoch,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok(HttpResponse::Ok().json(BeaconResponse::new(validator_identities)))
 }
 
 pub async fn validator_status(validator: &Validator, db: &ReamDB) -> Result<String, ApiError> {

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -122,8 +122,8 @@ pub async fn post_validator_identities_from_state(
         .iter()
         .enumerate()
         .filter_map(|(index, validator)| {
-            if validator_ids_set.contains(&ValidatorID::Address(validator.pubkey.clone()))
-                || validator_ids_set.contains(&ValidatorID::Index(index as u64))
+            if validator_ids_set.contains(&ValidatorID::Index(index as u64))
+                || validator_ids_set.contains(&ValidatorID::Address(validator.pubkey.clone()))
             {
                 Some(ValidatorIdentity {
                     index: index as u64,

--- a/crates/rpc/src/routes/beacon.rs
+++ b/crates/rpc/src/routes/beacon.rs
@@ -9,7 +9,10 @@ use crate::handlers::{
         get_pending_partial_withdrawals, get_state_finality_checkpoint, get_state_fork,
         get_state_randao, get_state_root,
     },
-    validator::{get_validator_from_state, get_validators_from_state, post_validators_from_state},
+    validator::{
+        get_validator_from_state, get_validators_from_state, post_validator_identities_from_state,
+        post_validators_from_state,
+    },
 };
 
 /// Creates and returns all `/beacon` routes.
@@ -21,6 +24,7 @@ pub fn register_beacon_routes(cfg: &mut ServiceConfig) {
         .service(get_validator_from_state)
         .service(get_validators_from_state)
         .service(post_validators_from_state)
+        .service(post_validator_identities_from_state)
         .service(get_genesis)
         .service(get_headers)
         .service(get_block_root)

--- a/crates/rpc/src/types/id.rs
+++ b/crates/rpc/src/types/id.rs
@@ -66,7 +66,7 @@ impl fmt::Display for ID {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ValidatorID {
     Index(u64),
     /// expected to be a 0x-prefixed hex string.
@@ -108,7 +108,7 @@ impl Display for ValidatorID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ValidatorID::Index(i) => write!(f, "{i}"),
-            ValidatorID::Address(pub_key) => write!(f, "0x{:?}", pub_key.to_bytes()),
+            ValidatorID::Address(pub_key) => write!(f, "0x{}", hex::encode(pub_key.to_bytes())),
         }
     }
 }


### PR DESCRIPTION
### Description  
* Closes [Implement /eth/v1/beacon/states/{state_id}/validator_identities #190](https://github.com/ReamLabs/ream/issues/190)  
* This pull request implements the Beacon API endpoint:  **POST** `/eth/v1/beacon/states/{state_id}/validator_identities`  
* Response data contains **no duplicate entries** and is **sorted by index** in ascending order.
* Octet (SSZ) response is not supported, consistent with `/eth/v2/beacon/blocks/{block_id}` and `/eth/v2/debug/beacon/states/{state_id}`. It appears the main SSZ implementation for response data doesn't exist yet?
* The spec: [https://ethereum.github.io/beacon-APIs/#/Beacon/postStateValidatorIdentities](https://ethereum.github.io/beacon-APIs/#/Beacon/postStateValidatorIdentities)

### Example Requests & Responses
> **Note**: Without the mocked data, the current behavior returns 404 for the successful case.
> With real or mocked data, the successful case should match the "Mocked Data" example below.

> **Note**: The `pubkey` field should have the `0x` prefix, but that will be addressed later.

<details>

#### ❌ Error Cases

- **POST** `/eth/v1/beacon/states/invalid_state_id/validator_identities`  
  **Body** (JSON array):
  ```json
  []
  ```
  **Response**:
  ```json
  {
    "code": 400,
    "message": "Invalid state ID: invalid_state_id"
  }
  ```

- **POST** `/eth/v1/beacon/states/1/validator_identities`  
  **Body**: *(none)*  
  **Response**:
  ```json
  {
    "code": 400,
    "message": "EOF while parsing a value at line 1 column 0"
  }
  ```

- **POST** `/eth/v1/beacon/states/1/validator_identities`  
  **Body** (JSON array):
  ```json
  []
  ```
  **Response**:
  ```json
  {
    "code": 404, // should be 200 here, with empty array data
    "message": "State not found"
  }
  ```

- **POST** `/eth/v1/beacon/states/1/validator_identities`  
  **Body** (JSON array):
  ```json
  [1]
  ```
  **Response**:
  ```json
  {
    "code": 400, // the spec states that the body is array<string>
    "message": "invalid type: integer `1`, expected a string at line 1 column 2"
  }
  ```

- **POST** `/eth/v1/beacon/states/1/validator_identities`  
  **Body** (JSON array):
  ```json
  ["1"]
  ```
  **Response**:
  ```json
  {
    "code": 404, // should be 200 here, with data array of length 1
    "message": "State not found"
  }
  ```

- **POST** `/eth/v1/beacon/states/1/validator_identities`  
  **Body** (JSON array):
  ```json
  [
    "1",
    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
  ]
  ```
  **Response**:
  ```json
  {
    "code": 404, // should be 200 here, with data array of length 2
    "message": "State not found"
  }
  ```

#### ✅ Successful Case (Mocked Data)

- **POST** `/eth/v1/beacon/states/1/validator_identities`  
  **Body** (JSON array):
  ```json
  [
    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
    "0"
  ]
  ```
  **Response**:
  ```json
  {
    "data": [
      {
        "activation_epoch": "11",
        "index": "0",
        "pubkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
      },
      {
        "activation_epoch": "22",
        "index": "1",
        "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
      }
    ],
    "execution_optimistic": false,
    "finalized": false
  }
  ```
</details>

### Handle `BodyDeserializeError` in `handle_rejection`

<details>

An `if` clause has been added to handle `BodyDeserializeError` in the `handle_rejection` function.  
If a request body fails to deserialize, the server will now return a **400 Bad Request** response instead of **500 Internal Server Error**.

</details>

### Custom `Deserialize` for `ValidatorID`

<details>

A custom `Deserialize` function has been added for `ValidatorID`. This ensures validator indices (e.g., `"3"`) and pubkeys (e.g., `"0xaaaa..."`) are accepted only as strings, in line with the API spec.

```rust
impl<'de> Deserialize<'de> for ValidatorID {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: Deserializer<'de>,
    {
        let string = String::deserialize(deserializer)?;
        ValidatorID::from_str(&string).map_err(|e| serde::de::Error::custom(format!("{e}")))
    }
}
```

#### Concerns

There is a chance that this change could affect other areas of the code that rely on `ValidatorID`. However, after testing with queries, path parameters, and JSON bodies, the following cases appear to work as expected:

- **Query parameters** (`warp::query`) with non-array values  
- **Path parameters** using `parsed_param::<ValidatorID>()`  
- **Body** using `warp::body::json::<Vec<ValidatorID>>()`

I also tried to parse query parameters that include array values or repeated keys (e.g., multiple `?id=` entries) into a vector, but it seems that **`serde_urlencoded`** does not support this. But I’m not entirely sure because I’m not very familiar with Warp and Serde, so I could be wrong here.

</details>

### Additional Notes and Fixes

<details>

#### 1. Fix `Display` Implementation for `ValidatorID`

The `Display` implementation for `ValidatorID::Address` has been updated from:

```rust
ValidatorID::Address(pub_key) => write!(f, "0x{:?}", pub_key.to_bytes()),
```

to:

```rust
ValidatorID::Address(pub_key) => write!(f, "0x{}", hex::encode(pub_key.to_bytes())),
```

Previously, the `Display` output looked like this:

```
0x[170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 
170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170]
```

Now, it displays as:

```
0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

This change is included in this PR as it is a method of `ValidatorID`, which is being modified here, and the implementation is also under the `rpc` folder.

---

#### 2. `pubkey` Missing `0x` Prefix in JSON Response

The `pubkey` field is currently returned without a `0x` prefix in the JSON responses for both:

- `POST /eth/v1/beacon/states/{state_id}/validator_identities`
- `GET /eth/v1/beacon/states/{state_id}/validator/{validator_id}`

as shown in the `Example Requests & Responses` section.

This has not been fixed in this PR, as it may be outside the scope of this PR.  
A potential fix would be to update the `Serialize` implementation for `PubKey` to add `0x` to the encoded value.

</details>
