### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,5 @@
 ### To-Do
 
  <!-- Stay ahead of things, add list items here!  -->
+- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
 - [ ] Uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,12 @@
-### What was wrong?
+### What are you trying to achieve?
 
-### How was it fixed?
+ <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
+
+### How was it implemented/fixed?
+
+ <!-- List the approach you used, and/or changes made to the codebase  -->
 
 ### To-Do
 
-[//]: # (Stay ahead of things, add list items here!)
+ <!-- Stay ahead of things, add list items here!  -->
 - [ ] Uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@
 
  <!-- Stay ahead of things, add list items here!  -->
 - [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
-- [ ] Uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
+- [ ] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+### What was wrong?
+
+### How was it fixed?
+
+### To-Do
+
+[//]: # (Stay ahead of things, add list items here!)
+- [ ] Uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).


### PR DESCRIPTION
I am adding a pull request template as some of the PR's made have poor descriptions. This pull request template solves 3 key pain points

- a lot of people don't add context on why they are writing a PR
- a lot of people don't add context on how their PR solves the problem
- then a todo section so people can read about conventional commits