### PR TITLE
feat: Implement /eth/v1/node/peers/{peer_id}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,6 +5038,7 @@ dependencies = [
  "ream-light-client",
  "ream-network-spec",
  "ream-node",
+ "ream-p2p",
  "ream-storage",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4968,6 +4968,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "futures",
+ "k256",
  "libp2p",
  "libp2p-identity",
  "libp2p-mplex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
+ "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
@@ -3355,6 +3356,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
+ "serde",
  "sha2 0.10.8",
  "tracing",
  "web-time",
@@ -3397,10 +3399,39 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sec1",
+ "serde",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.8",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tracing",
+ "uint 0.10.0",
+ "web-time",
 ]
 
 [[package]]
@@ -3901,6 +3932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
+ "serde",
  "unsigned-varint 0.8.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,7 @@ actix-web = "4.10.2"
 actix-web-lab = "0.24.1"
 alloy-consensus = { version = "1.0", default-features = false }
 alloy-primitives = { version = "1.1", features = ['serde'] }
-alloy-rlp = { version = "0.3.8", default-features = false, features = [
-    "derive",
-] }
+alloy-rlp = { version = "0.3.8", default-features = false, features = ["derive"] }
 alloy-rpc-types-eth = "1.0.7"
 anyhow = "1.0"
 async-trait = "0.1.86"
@@ -69,24 +67,7 @@ hashbrown = "0.15.3"
 itertools = "0.14"
 jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
-libp2p = { version = "0.55", default-features = false, features = [
-    "identify",
-    "yamux",
-    "noise",
-    "dns",
-    "serde",
-    "tcp",
-    "tokio",
-    "plaintext",
-    "secp256k1",
-    "macros",
-    "ecdsa",
-    "metrics",
-    "quic",
-    "upnp",
-    "gossipsub",
-    "ping",
-] }
+libp2p = { version = "0.55", default-features = false, features = ["identify", "yamux", "noise", "dns", "serde", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping"] }
 libp2p-identity = "0.2"
 libp2p-mplex = "0.43"
 parking_lot = "0.12.3"
@@ -102,14 +83,7 @@ snap = "1.1"
 ssz_types = "0.11"
 tempfile = "3.19"
 thiserror = "2.0.11"
-tokio = { version = "1.42", features = [
-    "rt",
-    "rt-multi-thread",
-    "sync",
-    "signal",
-    "time",
-    "macros",
-] }
+tokio = { version = "1.42", features = ["rt", "rt-multi-thread", "sync", "signal", "time", "macros"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
@@ -119,9 +93,7 @@ url = "2.5"
 
 # ream dependencies
 ream-beacon-chain = { path = "crates/common/beacon_chain" }
-ream-bls = { path = "crates/crypto/bls", features = [
-    "zkcrypto",
-] } # Default feature is zkcrypto
+ream-bls = { path = "crates/crypto/bls", features = ["zkcrypto"] } # Default feature is zkcrypto
 ream-checkpoint-sync = { path = "crates/common/checkpoint_sync" }
 ream-consensus = { path = "crates/common/consensus" }
 ream-discv5 = { path = "crates/networking/discv5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,14 @@ exclude = ["book/cli", "book/sources"]
 [workspace.package]
 authors = ["https://github.com/ReamLabs/ream/graphs/contributors"]
 edition = "2024"
-keywords = ["ethereum", "beam-chain", "blockchain", "consensus", "protocol", "ream"]
+keywords = [
+    "ethereum",
+    "beam-chain",
+    "blockchain",
+    "consensus",
+    "protocol",
+    "ream",
+]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ReamLabs/ream"
@@ -43,12 +50,14 @@ actix-web = "4.10.2"
 actix-web-lab = "0.24.1"
 alloy-consensus = { version = "1.0", default-features = false }
 alloy-primitives = { version = "1.1", features = ['serde'] }
-alloy-rlp = { version = "0.3.8", default-features = false, features = ["derive"] }
+alloy-rlp = { version = "0.3.8", default-features = false, features = [
+    "derive",
+] }
 alloy-rpc-types-eth = "1.0.7"
 anyhow = "1.0"
 async-trait = "0.1.86"
 clap = "4"
-directories = { version = "6.0.0" } 
+directories = { version = "6.0.0" }
 discv5 = { version = "0.9.0", features = ["libp2p"] }
 enr = "0.13.0"
 ethereum_hashing = { git = "https://github.com/ReamLabs/ethereum_hashing.git" }
@@ -60,7 +69,24 @@ hashbrown = "0.15.3"
 itertools = "0.14"
 jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
-libp2p = { version = "0.55", default-features = false, features = ["identify", "yamux", "noise", "dns", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping"] }
+libp2p = { version = "0.55", default-features = false, features = [
+    "identify",
+    "yamux",
+    "noise",
+    "dns",
+    "serde",
+    "tcp",
+    "tokio",
+    "plaintext",
+    "secp256k1",
+    "macros",
+    "ecdsa",
+    "metrics",
+    "quic",
+    "upnp",
+    "gossipsub",
+    "ping",
+] }
 libp2p-identity = "0.2"
 libp2p-mplex = "0.43"
 parking_lot = "0.12.3"
@@ -76,8 +102,15 @@ snap = "1.1"
 ssz_types = "0.11"
 tempfile = "3.19"
 thiserror = "2.0.11"
-tokio = { version = "1.42", features = ["rt", "rt-multi-thread", "sync", "signal", "time", "macros"] }
-tokio-util = { version = "0.7", features = ["compat"] } 
+tokio = { version = "1.42", features = [
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "signal",
+    "time",
+    "macros",
+] }
+tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tree_hash = "0.10"
@@ -85,8 +118,10 @@ tree_hash_derive = "0.10"
 url = "2.5"
 
 # ream dependencies
-ream-beacon-chain = { path = "crates/common/beacon_chain" } 
-ream-bls = { path = "crates/crypto/bls", features = ["zkcrypto"] } # Default feature is zkcrypto
+ream-beacon-chain = { path = "crates/common/beacon_chain" }
+ream-bls = { path = "crates/crypto/bls", features = [
+    "zkcrypto",
+] } # Default feature is zkcrypto
 ream-checkpoint-sync = { path = "crates/common/checkpoint_sync" }
 ream-consensus = { path = "crates/common/consensus" }
 ream-discv5 = { path = "crates/networking/discv5" }

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -18,10 +18,7 @@ enr.workspace = true
 ethereum_ssz.workspace = true
 ethereum_ssz_derive.workspace = true
 futures.workspace = true
-k256 = { version = "0.13", default-features = false, features = [
-    "ecdsa",
-    "arithmetic",
-] }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "arithmetic"] }
 libp2p.workspace = true
 libp2p-identity.workspace = true
 libp2p-mplex.workspace = true

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -18,6 +18,10 @@ enr.workspace = true
 ethereum_ssz.workspace = true
 ethereum_ssz_derive.workspace = true
 futures.workspace = true
+k256 = { version = "0.13", default-features = false, features = [
+    "ecdsa",
+    "arithmetic",
+] }
 libp2p.workspace = true
 libp2p-identity.workspace = true
 libp2p-mplex.workspace = true

--- a/crates/networking/p2p/src/constants.rs
+++ b/crates/networking/p2p/src/constants.rs
@@ -4,3 +4,10 @@ use alloy_primitives::{aliases::B32, fixed_bytes};
 pub const MAX_PAYLOAD_SIZE: u64 = 10485760;
 pub const MESSAGE_DOMAIN_VALID_SNAPPY: B32 = fixed_bytes!("0x01000000");
 pub const MESSAGE_DOMAIN_INVALID_SNAPPY: B32 = fixed_bytes!("0x00000000");
+
+pub const STATE_CONNECTED: &str = "connected";
+pub const STATE_CONNECTING: &str = "connecting";
+pub const STATE_DISCONNECTED: &str = "disconnected";
+pub const STATE_DISCONNECTING: &str = "disconnecting";
+pub const DIR_INBOUND: &str = "inbound";
+pub const DIR_OUTBOUND: &str = "outbound";

--- a/crates/networking/p2p/src/constants.rs
+++ b/crates/networking/p2p/src/constants.rs
@@ -4,10 +4,3 @@ use alloy_primitives::{aliases::B32, fixed_bytes};
 pub const MAX_PAYLOAD_SIZE: u64 = 10485760;
 pub const MESSAGE_DOMAIN_VALID_SNAPPY: B32 = fixed_bytes!("0x01000000");
 pub const MESSAGE_DOMAIN_INVALID_SNAPPY: B32 = fixed_bytes!("0x00000000");
-
-pub const STATE_CONNECTED: &str = "connected";
-pub const STATE_CONNECTING: &str = "connecting";
-pub const STATE_DISCONNECTED: &str = "disconnected";
-pub const STATE_DISCONNECTING: &str = "disconnecting";
-pub const DIR_INBOUND: &str = "inbound";
-pub const DIR_OUTBOUND: &str = "outbound";

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -92,8 +92,8 @@ impl Direction {
 pub struct CachedPeer {
     pub peer_id: PeerId,
     pub last_seen_p2p_address: Option<Multiaddr>,
-    pub state: &'static str, // "connected" | "connecting" | "disconnected" | "disconnecting"
-    pub direction: &'static str, // "inbound" | "outbound" | ""
+    pub state: ConnectionState,
+    pub direction: Option<Direction>,
     pub enr: Option<Enr>,
 }
 

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -642,6 +642,37 @@ mod tests {
     }
 
     #[test]
+    fn update_existing_row() {
+        set_network_spec(DEV.clone());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let net = rt.block_on(async {
+            create_network(
+                "127.0.0.1".parse().unwrap(),
+                0,
+                0,
+                vec![],
+                true,
+                vec![],
+            )
+            .await
+            .unwrap()
+        });
+
+        let peer_id = libp2p::PeerId::random();
+
+        net.upsert_peer(peer_id, None, "connecting", "outbound", None);
+
+        net.upsert_peer(peer_id, None, "connected", "outbound", None);
+
+        let snap = net.cached_peer(&peer_id).expect("row exists");
+
+        assert_eq!(snap.state, "connected");
+        assert_eq!(snap.direction, "outbound");
+    }
+
+    #[test]
     fn test_p2p_gossipsub() {
         let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);
         set_network_spec(DEV.clone());

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -142,7 +142,6 @@ impl Network {
         table
             .entry(peer_id)
             .and_modify(|row| {
-                // update only the fields we care about
                 if addr.is_some() {
                     row.last_seen_p2p_address = addr.clone();
                 }
@@ -445,6 +444,16 @@ impl Network {
     fn handle_discovered_peers(&mut self, peers: HashMap<Enr, Option<Instant>>) {
         info!("Discovered peers: {:?}", peers);
         for (enr, _) in peers {
+            if let Some(pid) = Network::peer_id_from_enr(&enr) {
+                self.upsert_peer(
+                    pid,
+                    None,
+                    "disconnected",
+                    "",
+                    Some(enr.clone()),
+                );
+            }
+
             let mut multiaddrs: Vec<Multiaddr> = Vec::new();
             if let Some(ip) = enr.ip4() {
                 if let Some(tcp) = enr.tcp4() {

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -323,8 +323,8 @@ impl Network {
                 if let Some(address_ref) = &address {
                     cached_peer.last_seen_p2p_address = Some(address_ref.clone());
                 }
-                cached_peer.state = state.clone();
-                cached_peer.direction = direction.clone();
+                cached_peer.state = state;
+                cached_peer.direction = direction;
                 if let Some(enr_ref) = &enr {
                     cached_peer.enr = Some(enr_ref.clone());
                 }

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -677,7 +677,7 @@ mod tests {
     use discv5::enr::CombinedKey;
     use k256::ecdsa::SigningKey;
     use libp2p_identity::{Keypair, PeerId};
-    use ream_discv5::{config::DiscoveryConfig, subnet::Subnets};
+    use ream_discv5::config::DiscoveryConfig;
     use ream_executor::ReamExecutor;
     use ream_network_spec::networks::{DEV, set_network_spec};
     use tokio::runtime::Runtime;

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -324,6 +324,12 @@ impl Network {
         // currently no-op for any network events
         info!("Event: {:?}", event);
         match event {
+            SwarmEvent::OutgoingConnectionError {
+                peer_id: Some(pid), ..
+            } => {
+                self.upsert_peer(pid, None, "disconnected", "outbound", None);
+                None
+            }
             SwarmEvent::ConnectionClosed {
                 peer_id, endpoint, ..
             } => {

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -335,7 +335,7 @@ impl Network {
                 };
 
                 self.upsert_peer(peer_id, addr, "connected", direction, None);
-                None // nothing to bubble up
+                None
             }
             SwarmEvent::Behaviour(behaviour_event) => match behaviour_event {
                 ReamBehaviourEvent::Identify(_) => None,

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -316,17 +316,17 @@ impl Network {
         direction: Direction,
         enr: Option<Enr>,
     ) {
-        let mut table = self.peer_table.write();
-        table
+        let mut peer_table = self.peer_table.write();
+        peer_table
             .entry(peer_id)
-            .and_modify(|row| {
-                if address.is_some() {
-                    row.last_seen_p2p_address = address.clone();
+            .and_modify(|cached_peer| {
+                if let Some(address_ref) = &address {
+                    cached_peer.last_seen_p2p_address = Some(address_ref.clone());
                 }
-                row.state = state.clone();
-                row.direction = direction.clone();
-                if enr.is_some() {
-                    row.enr = enr.clone();
+                cached_peer.state = state.clone();
+                cached_peer.direction = direction.clone();
+                if let Some(enr_ref) = &enr {
+                    cached_peer.enr = Some(enr_ref.clone());
                 }
             })
             .or_insert(CachedPeer {

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -53,6 +53,8 @@ use crate::{
     },
 };
 
+pub type PeerTable = Arc<RwLock<HashMap<PeerId, CachedPeer>>>;
+
 #[derive(Clone)]
 pub struct CachedPeer {
     pub peer_id: PeerId,
@@ -256,8 +258,8 @@ impl Network {
         self.request_id += 1;
         request_id
     }
-
-    pub fn peer_table(&self) -> Arc<RwLock<HashMap<PeerId, CachedPeer>>> {
+    
+    pub fn peer_table(&self) -> PeerTable {
         Arc::clone(&self.peer_table)
     }
 

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -763,9 +763,9 @@ mod tests {
     fn insert_then_read_returns_snapshot() {
         init_network_spec();
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
+        let tokio_runtime = Runtime::new().unwrap();
 
-        let mut net = rt.block_on(async {
+        let mut net = tokio_runtime.block_on(async {
             create_network("127.0.0.1".parse().unwrap(), 0, 0, vec![], true, vec![])
                 .await
                 .unwrap()
@@ -795,9 +795,9 @@ mod tests {
     fn update_existing_row() {
         init_network_spec();
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
+        let tokio_runtime = Runtime::new().unwrap();
 
-        let mut net = rt.block_on(async {
+        let mut net = tokio_runtime.block_on(async {
             create_network("127.0.0.1".parse().unwrap(), 0, 0, vec![], true, vec![])
                 .await
                 .unwrap()
@@ -831,9 +831,9 @@ mod tests {
     fn cached_peer_unknown_returns_none() {
         init_network_spec();
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
+        let tokio_runtime = Runtime::new().unwrap();
 
-        let net = rt.block_on(async {
+        let net = tokio_runtime.block_on(async {
             create_network("127.0.0.1".parse().unwrap(), 0, 0, vec![], true, vec![])
                 .await
                 .unwrap()
@@ -917,8 +917,8 @@ mod tests {
     fn test_peer_table_lifecycle() {
         init_network_spec();
 
-        let rt = Runtime::new().unwrap();
-        let mut network1 = rt
+        let tokio_runtime = Runtime::new().unwrap();
+        let mut network1 = tokio_runtime
             .block_on(create_network(
                 "127.0.0.1".parse().unwrap(),
                 9300,
@@ -929,7 +929,7 @@ mod tests {
             ))
             .unwrap();
 
-        let mut network2 = rt
+        let mut network2 = tokio_runtime
             .block_on(create_network(
                 "127.0.0.1".parse().unwrap(),
                 9302,
@@ -946,7 +946,7 @@ mod tests {
         let id1 = network1.peer_id();
         let id2 = network2.peer_id();
 
-        rt.block_on(async {
+        tokio_runtime.block_on(async {
             let n1 = async {
                 while let Some(ev) = network1.swarm.next().await {
                     network1.parse_swarm_event(ev);

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -324,6 +324,19 @@ impl Network {
         // currently no-op for any network events
         info!("Event: {:?}", event);
         match event {
+            SwarmEvent::ConnectionClosed {
+                peer_id, endpoint, ..
+            } => {
+                use libp2p::core::ConnectedPoint;
+
+                let direction = match endpoint {
+                    ConnectedPoint::Dialer { .. } => "outbound",
+                    ConnectedPoint::Listener { .. } => "inbound",
+                };
+
+                self.upsert_peer(peer_id, None, "disconnected", direction, None);
+                None
+            }
             SwarmEvent::ConnectionEstablished {
                 peer_id, endpoint, ..
             } => {

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -374,12 +374,13 @@ impl Network {
         info!("Event: {:?}", event);
         match event {
             SwarmEvent::OutgoingConnectionError {
-                peer_id: Some(pid), ..
+                peer_id: Some(peer_id),
+                ..
             } => {
                 self.upsert_peer(
-                    pid,
+                    peer_id,
                     None,
-                    ConnectionState::Connected,
+                    ConnectionState::Disconnected,
                     Direction::Outbound,
                     None,
                 );
@@ -499,9 +500,9 @@ impl Network {
     fn handle_discovered_peers(&mut self, peers: HashMap<Enr, Option<Instant>>) {
         info!("Discovered peers: {:?}", peers);
         for (enr, _) in peers {
-            if let Some(pid) = Network::peer_id_from_enr(&enr) {
+            if let Some(peer_id) = Network::peer_id_from_enr(&enr) {
                 self.upsert_peer(
-                    pid,
+                    peer_id,
                     None,
                     ConnectionState::Disconnected,
                     Direction::Unknown,

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -335,6 +335,12 @@ impl Network {
         // currently no-op for any network events
         info!("Event: {:?}", event);
         match event {
+            SwarmEvent::Dialing {
+                peer_id: Some(pid), ..
+            } => {
+                self.upsert_peer(pid, None, STATE_CONNECTING, DIR_OUTBOUND, None);
+                None
+            }
             SwarmEvent::OutgoingConnectionError {
                 peer_id: Some(pid), ..
             } => {

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -793,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    fn update_existing_row() {
+    fn update_existing_peer() {
         initialize_network_spec();
 
         let tokio_runtime = Runtime::new().unwrap();
@@ -822,7 +822,7 @@ mod tests {
             None,
         );
 
-        let cached_peer_snapshot = network.cached_peer(&peer_id).expect("row exists");
+        let cached_peer_snapshot = network.cached_peer(&peer_id).expect("peer exists in cache");
 
         assert_eq!(cached_peer_snapshot.state, ConnectionState::Connected);
         assert_eq!(cached_peer_snapshot.direction, Direction::Outbound);
@@ -953,7 +953,7 @@ mod tests {
                     network1.parse_swarm_event(event);
                     if matches!(
                         network1.cached_peer(&peer_id_network2),
-                        Some(row) if row.state == ConnectionState::Connected && row.direction == Direction::Inbound
+                        Some(peer) if peer.state == ConnectionState::Connected && peer.direction == Direction::Inbound
                     ) {
                         break;
                     }
@@ -965,7 +965,7 @@ mod tests {
                     network2.parse_swarm_event(event);
                     if matches!(
                         network2.cached_peer(&peer_id_network1),
-                        Some(row) if row.state == ConnectionState::Connected && row.direction == Direction::Outbound
+                        Some(peer) if peer.state == ConnectionState::Connected && peer.direction == Direction::Outbound
                     ) {
                         break;
                     }
@@ -982,10 +982,10 @@ mod tests {
 
         let peer_from_network_1 = network1
             .cached_peer(&peer_id_network2)
-            .expect("network1 row exists");
+            .expect("network1 peer exists");
         let peer_from_network_2 = network2
             .cached_peer(&peer_id_network1)
-            .expect("network2 row exists");
+            .expect("network2 peer exists");
 
         assert_eq!(peer_from_network_1.state, ConnectionState::Connected);
         assert_eq!(peer_from_network_1.direction, Direction::Inbound);

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -31,7 +31,7 @@ use libp2p::{
 };
 use libp2p_identity::{Keypair, PublicKey, secp256k1, secp256k1::PublicKey as LibSecpPk};
 use libp2p_mplex::{MaxBufferBehaviour, MplexConfig};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use ream_discv5::discovery::{DiscoveredPeers, Discovery, QueryType};
 use ream_executor::ReamExecutor;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -735,9 +735,9 @@ mod tests {
     }
 
     #[test]
-    fn peer_id_from_enr_matches_libp2p() {
-        let lp_kp = Keypair::generate_secp256k1();
-        let secret = lp_kp
+    fn peer_id_derived_from_enr_matches_libp2p() {
+        let libp2p_keypair = Keypair::generate_secp256k1();
+        let secret = libp2p_keypair
             .clone()
             .try_into_secp256k1()
             .unwrap()
@@ -748,7 +748,7 @@ mod tests {
         let enr_key = CombinedKey::Secp256k1(signing);
         let enr = Enr::builder().build(&enr_key).unwrap();
 
-        let expected = PeerId::from_public_key(&lp_kp.public());
+        let expected = PeerId::from_public_key(&libp2p_keypair.public());
         let actual = Network::peer_id_from_enr(&enr).expect("peer id");
 
         assert_eq!(expected, actual);

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -335,12 +335,6 @@ impl Network {
         // currently no-op for any network events
         info!("Event: {:?}", event);
         match event {
-            SwarmEvent::Dialing {
-                peer_id: Some(pid), ..
-            } => {
-                self.upsert_peer(pid, None, STATE_CONNECTING, DIR_OUTBOUND, None);
-                None
-            }
             SwarmEvent::OutgoingConnectionError {
                 peer_id: Some(pid), ..
             } => {

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -34,8 +34,8 @@ use libp2p_mplex::{MaxBufferBehaviour, MplexConfig};
 use parking_lot::{Mutex, RwLock};
 use ream_discv5::discovery::{DiscoveredPeers, Discovery, QueryType};
 use ream_executor::ReamExecutor;
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use serde::Serialize;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::{error, info, trace, warn};
 use tree_hash::TreeHash;
 use yamux::Config as YamuxConfig;
@@ -286,7 +286,7 @@ impl Network {
         self.request_id += 1;
         request_id
     }
-    
+
     pub fn peer_table(&self) -> PeerTable {
         Arc::clone(&self.peer_table)
     }
@@ -950,7 +950,7 @@ mod tests {
         tokio_runtime.block_on(async {
             let network1_poll_task = async {
                 while let Some(event) = network1.swarm.next().await {
-                    network1.parse_swarm_event(event);
+                    network1.parse_swarm_event(event).await;
                     if matches!(
                         network1.cached_peer(&peer_id_network2),
                         Some(peer) if peer.state == ConnectionState::Connected && peer.direction == Direction::Inbound
@@ -962,7 +962,7 @@ mod tests {
 
             let network2_poll_task = async {
                 while let Some(event) = network2.swarm.next().await {
-                    network2.parse_swarm_event(event);
+                    network2.parse_swarm_event(event).await;
                     if matches!(
                         network2.cached_peer(&peer_id_network1),
                         Some(peer) if peer.state == ConnectionState::Connected && peer.direction == Direction::Outbound

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -615,21 +615,6 @@ mod tests {
         Network::init(executor, &config).await
     }
 
-    async fn empty_network() -> Network {
-        use std::net::IpAddr;
-        let ip: IpAddr = "127.0.0.1".parse().unwrap();
-        create_network(
-            ip, // socket_address
-            0,
-            0,      // socket_port, discovery_port  (0 = OS-choose)
-            vec![], // no boot-nodes
-            true,   // disable_discovery
-            vec![], // no gossip topics
-        )
-        .await
-        .unwrap()
-    }
-
     #[test]
     fn test_p2p_gossipsub() {
         let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -692,11 +692,11 @@ mod tests {
         gossipsub::{configurations::GossipsubConfig, topics::GossipTopicKind},
     };
 
-    static INIT_NET_SPEC: Once = Once::new();
+    static HAS_NETWORK_SPEC_BEEN_INITIALIZED: Once = Once::new();
 
-    fn init_network_spec() {
+    fn initialize_network_spec() {
         let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);
-        INIT_NET_SPEC.call_once(|| {
+        HAS_NETWORK_SPEC_BEEN_INITIALIZED.call_once(|| {
             set_network_spec(DEV.clone());
         });
     }
@@ -761,7 +761,7 @@ mod tests {
 
     #[test]
     fn insert_then_read_returns_snapshot() {
-        init_network_spec();
+        initialize_network_spec();
 
         let tokio_runtime = Runtime::new().unwrap();
 
@@ -793,7 +793,7 @@ mod tests {
 
     #[test]
     fn update_existing_row() {
-        init_network_spec();
+        initialize_network_spec();
 
         let tokio_runtime = Runtime::new().unwrap();
 
@@ -829,7 +829,7 @@ mod tests {
 
     #[test]
     fn cached_peer_unknown_returns_none() {
-        init_network_spec();
+        initialize_network_spec();
 
         let tokio_runtime = Runtime::new().unwrap();
 
@@ -846,7 +846,7 @@ mod tests {
 
     #[test]
     fn test_p2p_gossipsub() {
-        init_network_spec();
+        initialize_network_spec();
 
         let runtime = Runtime::new().unwrap();
 
@@ -915,7 +915,7 @@ mod tests {
 
     #[test]
     fn test_peer_table_lifecycle() {
-        init_network_spec();
+        initialize_network_spec();
 
         let tokio_runtime = Runtime::new().unwrap();
         let mut network1 = tokio_runtime

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -771,7 +771,7 @@ mod tests {
                 .unwrap()
         });
 
-        let peer_id = libp2p::PeerId::random();
+        let peer_id = PeerId::random();
         let addr: libp2p::Multiaddr = "/ip4/1.2.3.4/tcp/9000".parse().unwrap();
 
         network.upsert_peer(
@@ -803,7 +803,7 @@ mod tests {
                 .unwrap()
         });
 
-        let peer_id = libp2p::PeerId::random();
+        let peer_id = PeerId::random();
 
         network.upsert_peer(
             peer_id,
@@ -839,7 +839,7 @@ mod tests {
                 .unwrap()
         });
 
-        let random_id = libp2p::PeerId::random();
+        let random_id = PeerId::random();
 
         assert!(network.cached_peer(&random_id).is_none());
     }

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -55,7 +55,7 @@ use crate::{
 
 pub type PeerTable = Arc<RwLock<HashMap<PeerId, CachedPeer>>>;
 
-#[derive(Clone, Serialize)]
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ConnectionState {
     Connected,
@@ -64,7 +64,7 @@ pub enum ConnectionState {
     Disconnecting,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Direction {
     Inbound,
@@ -970,17 +970,17 @@ mod tests {
             .expect("peer-table not updated in time");
         });
 
-        let row1 = network1
+        let peer_from_network_1 = network1
             .cached_peer(&peer_id_network2)
             .expect("network1 row exists");
-        let row2 = network2
+        let peer_from_network_2 = network2
             .cached_peer(&peer_id_network1)
             .expect("network2 row exists");
 
-        assert_eq!(row1.state, ConnectionState::Connected);
-        assert_eq!(row1.direction, Direction::Inbound);
+        assert_eq!(peer_from_network_1.state, ConnectionState::Connected);
+        assert_eq!(peer_from_network_1.direction, Direction::Inbound);
 
-        assert_eq!(row2.state, ConnectionState::Connected);
-        assert_eq!(row2.direction, Direction::Outbound);
+        assert_eq!(peer_from_network_2.state, ConnectionState::Connected);
+        assert_eq!(peer_from_network_2.direction, Direction::Outbound);
     }
 }

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -72,13 +72,22 @@ pub enum Direction {
     Unknown,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CachedPeer {
+    /// libp2p peer ID
     pub peer_id: PeerId,
+
+    /// Last known multiaddress observed for the peer
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_seen_p2p_address: Option<Multiaddr>,
+
+    /// Current known connection state
     pub state: ConnectionState,
+
+    /// Direction of the most recent connection (inbound/outbound)
     pub direction: Direction,
+
+    /// Ethereum Node Record (ENR), if known
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enr: Option<Enr>,
 }

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -621,6 +621,7 @@ mod tests {
     use super::*;
     use crate::{
         config::NetworkConfig,
+        constants::{DIR_OUTBOUND, STATE_CONNECTED, STATE_CONNECTING},
         gossipsub::{configurations::GossipsubConfig, topics::GossipTopicKind},
     };
 

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -105,7 +105,7 @@ pub struct Network {
     subscribed_topics: Arc<Mutex<HashSet<GossipTopic>>>,
     callbacks: HashMap<u64, mpsc::Sender<anyhow::Result<P2PResponse>>>,
     request_id: u64,
-    peer_table: Arc<RwLock<HashMap<PeerId, CachedPeer>>>,
+    peer_table: PeerTable,
 }
 
 struct Executor(ReamExecutor);

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -615,6 +615,21 @@ mod tests {
         Network::init(executor, &config).await
     }
 
+    async fn empty_network() -> Network {
+        use std::net::IpAddr;
+        let ip: IpAddr = "127.0.0.1".parse().unwrap();
+        create_network(
+            ip, // socket_address
+            0,
+            0,      // socket_port, discovery_port  (0 = OS-choose)
+            vec![], // no boot-nodes
+            true,   // disable_discovery
+            vec![], // no gossip topics
+        )
+        .await
+        .unwrap()
+    }
+
     #[test]
     fn test_p2p_gossipsub() {
         let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -677,7 +677,10 @@ mod tests {
     use discv5::enr::CombinedKey;
     use k256::ecdsa::SigningKey;
     use libp2p_identity::{Keypair, PeerId};
-    use ream_discv5::config::DiscoveryConfig;
+    use ream_discv5::{
+        config::DiscoveryConfig,
+        subnet::{AttestationSubnets, SyncCommitteeSubnets},
+    };
     use ream_executor::ReamExecutor;
     use ream_network_spec::networks::{DEV, set_network_spec};
     use tokio::runtime::Runtime;

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -673,10 +673,11 @@ pub fn build_transport(local_private_key: Keypair) -> io::Result<Boxed<(PeerId, 
 mod tests {
     use std::{net::IpAddr, sync::Once};
 
-    use alloy_primitives::aliases::B32;
+    use alloy_primitives::{B256, aliases::B32};
     use discv5::enr::CombinedKey;
     use k256::ecdsa::SigningKey;
     use libp2p_identity::{Keypair, PeerId};
+    use ream_consensus::constants::GENESIS_VALIDATORS_ROOT;
     use ream_discv5::{
         config::DiscoveryConfig,
         subnet::{AttestationSubnets, SyncCommitteeSubnets},
@@ -694,6 +695,7 @@ mod tests {
     static INIT_NET_SPEC: Once = Once::new();
 
     fn init_network_spec() {
+        let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);
         INIT_NET_SPEC.call_once(|| {
             set_network_spec(DEV.clone());
         });

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -33,5 +33,5 @@ ream-fork-choice.workspace = true
 ream-light-client.workspace = true
 ream-network-spec.workspace = true
 ream-node.workspace = true
-ream-storage.workspace = true
 ream-p2p.workspace = true
+ream-storage.workspace = true

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -34,4 +34,4 @@ ream-light-client.workspace = true
 ream-network-spec.workspace = true
 ream-node.workspace = true
 ream-storage.workspace = true
-ream_p2p.workspace = true
+ream-p2p.workspace = true

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -15,15 +15,15 @@ pub async fn get_peer(
     peer_table: Data<PeerTable>,
     peer_id: Path<String>,
 ) -> Result<impl Responder, ApiError> {
-    let raw_id: String = peer_id.into_inner();
-    let peer_id = PeerId::from_str(&raw_id)
-        .map_err(|_| ApiError::BadRequest(format!("Invalid peer ID: {raw_id}")))?;
+    let peer_id_str = peer_id.into_inner();
+    let peer_id = PeerId::from_str(&peer_id_str)
+        .map_err(|_| ApiError::BadRequest(format!("Invalid PeerId format: {}", peer_id_str)))?;
 
     let cached_peer = peer_table
         .read()
         .get(&peer_id)
         .cloned()
-        .ok_or_else(|| ApiError::NotFound(format!("Peer not found: {raw_id}")))?;
+        .ok_or_else(|| ApiError::NotFound(format!("Peer not found: {peer_id_str}")))?;
 
     Ok(HttpResponse::Ok().json(DataResponse::new(&cached_peer)))
 }

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -15,15 +15,15 @@ pub async fn get_peer(
     peer_table: Data<PeerTable>,
     peer_id: Path<String>,
 ) -> Result<impl Responder, ApiError> {
-    let id_raw = peer_id.into_inner();
-    let peer_id = PeerId::from_str(&id_raw)
-        .map_err(|_| ApiError::BadRequest(format!("Invalid peer ID: {id_raw}")))?;
+    let raw_id: String = peer_id.into_inner();
+    let peer_id = PeerId::from_str(&raw_id)
+        .map_err(|_| ApiError::BadRequest(format!("Invalid peer ID: {raw_id}")))?;
 
     let cached_peer = peer_table
         .read()
         .get(&peer_id)
         .cloned()
-        .ok_or_else(|| ApiError::NotFound(format!("Peer not found: {id_raw}")))?;
+        .ok_or_else(|| ApiError::NotFound(format!("Peer not found: {raw_id}")))?;
 
     Ok(HttpResponse::Ok().json(DataResponse::new(&cached_peer)))
 }

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -5,7 +5,7 @@ use actix_web::{
     web::{Data, Path},
 };
 use libp2p::PeerId;
-use ream_storage::db::ReamDB;
+use ream_p2p::network::Network;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -40,7 +40,10 @@ impl PeerData {
 
 /// Called by `/eth/v1/node/peers/{peer_id}` to return the current connection
 #[get("/node/peers/{peer_id}")]
-pub async fn get_peer(db: Data<ReamDB>, peer_id: Path<String>) -> Result<impl Responder, ApiError> {
+pub async fn get_peer(
+    net: Data<Network>,
+    peer_id: Path<String>,
+) -> Result<impl Responder, ApiError> {
     let peer_id_raw = peer_id.into_inner();
     PeerId::from_str(&peer_id_raw)
         .map_err(|_| ApiError::BadRequest(format!("Invalid peer ID: {peer_id_raw}")))?;

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -12,18 +12,18 @@ use crate::types::{errors::ApiError, response::DataResponse};
 /// GET /eth/v1/node/peers/{peer_id}
 #[get("/node/peers/{peer_id}")]
 pub async fn get_peer(
-    table: Data<PeerTable>,
+    peer_table: Data<PeerTable>,
     peer_id: Path<String>,
 ) -> Result<impl Responder, ApiError> {
     let id_raw = peer_id.into_inner();
     let peer_id = PeerId::from_str(&id_raw)
         .map_err(|_| ApiError::BadRequest(format!("Invalid peer ID: {id_raw}")))?;
 
-    let snap = table
+    let cached_peer = peer_table
         .read()
         .get(&peer_id)
         .cloned()
         .ok_or_else(|| ApiError::NotFound(format!("Peer not found: {id_raw}")))?;
 
-    Ok(HttpResponse::Ok().json(DataResponse::new(&snap)))
+    Ok(HttpResponse::Ok().json(DataResponse::new(&cached_peer)))
 }

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -48,7 +48,7 @@ pub async fn get_peer(
     PeerId::from_str(&peer_id_raw)
         .map_err(|_| ApiError::BadRequest(format!("Invalid peer ID: {peer_id_raw}")))?;
 
-    let (enr, last_seen, state, direction) = match mock_fetch_peer(&peer_id_raw, &db).await {
+    let (enr, last_seen, state, direction) = match mock_fetch_peer(&peer_id_raw, &net).await {
         Ok(tuple) => tuple,
         Err(ApiError::NotFound(_)) => {
             return Err(ApiError::NotFound(format!("Peer not found: {peer_id_raw}")));
@@ -65,7 +65,7 @@ pub async fn get_peer(
 
 async fn mock_fetch_peer(
     peer_id: &str,
-    _db: &ReamDB,
+    _db: &Network,
 ) -> Result<(Option<String>, String, String, String), ApiError> {
     if peer_id != "QmMockPeer_______" {
         return Err(ApiError::NotFound("peer".into()));

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -1,11 +1,7 @@
 use std::str::FromStr;
 
-use actix_web::{
-    HttpResponse, Responder, get,
-    web::{Data, Path},
-};
+use actix_web::{HttpResponse, Responder, get, web::Path};
 use libp2p::PeerId;
-use ream_p2p::network::Network;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -40,15 +36,12 @@ impl PeerData {
 
 /// Called by `/eth/v1/node/peers/{peer_id}` to return the current connection
 #[get("/node/peers/{peer_id}")]
-pub async fn get_peer(
-    net: Data<Network>,
-    peer_id: Path<String>,
-) -> Result<impl Responder, ApiError> {
+pub async fn get_peer(peer_id: Path<String>) -> Result<impl Responder, ApiError> {
     let peer_id_raw = peer_id.into_inner();
     PeerId::from_str(&peer_id_raw)
         .map_err(|_| ApiError::BadRequest(format!("Invalid peer ID: {peer_id_raw}")))?;
 
-    let (enr, last_seen, state, direction) = match mock_fetch_peer(&peer_id_raw, &net).await {
+    let (enr, last_seen, state, direction) = match mock_fetch_peer(&peer_id_raw).await {
         Ok(tuple) => tuple,
         Err(ApiError::NotFound(_)) => {
             return Err(ApiError::NotFound(format!("Peer not found: {peer_id_raw}")));
@@ -65,15 +58,14 @@ pub async fn get_peer(
 
 async fn mock_fetch_peer(
     peer_id: &str,
-    _db: &Network,
 ) -> Result<(Option<String>, String, String, String), ApiError> {
-    if peer_id != "QmMockPeer_______" {
+    if peer_id != "16Uiu2HAm1oEch6uXffoGZ32kPTiyjycfX9yDuBJSWtmagBSk9HTN" {
         return Err(ApiError::NotFound("peer".into()));
     }
 
     Ok((
         None,
-        "/ip4/127.0.0.1/tcp/9000/p2p/QmMockPeer".into(),
+        "/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAm1oEch6uXffoGZ32kPTiyjycfX9yDuBJSWtmagBSk9HTN".into(),
         "connected".into(),
         "outbound".into(),
     ))

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -15,15 +15,16 @@ pub async fn get_peer(
     peer_table: Data<PeerTable>,
     peer_id: Path<String>,
 ) -> Result<impl Responder, ApiError> {
-    let peer_id_str = peer_id.into_inner();
-    let peer_id = PeerId::from_str(&peer_id_str)
-        .map_err(|_| ApiError::BadRequest(format!("Invalid PeerId format: {}", peer_id_str)))?;
+    let peer_id = peer_id.into_inner();
+    let peer_id = PeerId::from_str(&peer_id).map_err(|err| {
+        ApiError::BadRequest(format!("Invalid PeerId format: {peer_id}, {err:?}"))
+    })?;
 
     let cached_peer = peer_table
         .read()
         .get(&peer_id)
         .cloned()
-        .ok_or_else(|| ApiError::NotFound(format!("Peer not found: {peer_id_str}")))?;
+        .ok_or_else(|| ApiError::NotFound(format!("Peer not found: {peer_id}")))?;
 
     Ok(HttpResponse::Ok().json(DataResponse::new(&cached_peer)))
 }

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -5,35 +5,9 @@ use actix_web::{
     web::{Data, Path},
 };
 use libp2p::PeerId;
-use ream_p2p::network::{CachedPeer, PeerTable};
-use serde::{Deserialize, Serialize};
+use ream_p2p::network::PeerTable;
 
 use crate::types::{errors::ApiError, response::DataResponse};
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PeerData {
-    peer_id: String,
-    enr: Option<String>,
-    last_seen_p2p_address: String,
-    state: String,
-    direction: String,
-}
-
-impl From<&CachedPeer> for PeerData {
-    fn from(p: &CachedPeer) -> Self {
-        Self {
-            peer_id: p.peer_id.to_string(),
-            enr: p.enr.as_ref().map(|e| e.to_base64()),
-            last_seen_p2p_address: p
-                .last_seen_p2p_address
-                .as_ref()
-                .map(|m| m.to_string())
-                .unwrap_or_default(),
-            state: p.state.as_str().to_string(),
-            direction: p.direction.as_str().to_string(),
-        }
-    }
-}
 
 /// GET /eth/v1/node/peers/{peer_id}
 #[get("/node/peers/{peer_id}")]
@@ -51,5 +25,5 @@ pub async fn get_peer(
         .cloned()
         .ok_or_else(|| ApiError::NotFound(format!("Peer not found: {id_raw}")))?;
 
-    Ok(HttpResponse::Ok().json(DataResponse::new(PeerData::from(&snap))))
+    Ok(HttpResponse::Ok().json(DataResponse::new(&snap)))
 }

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -1,12 +1,11 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use actix_web::{
     HttpResponse, Responder, get,
     web::{Data, Path},
 };
 use libp2p::PeerId;
-use parking_lot::RwLock;
-use ream_p2p::network::CachedPeer;
+use ream_p2p::network::{CachedPeer, PeerTable};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{errors::ApiError, response::DataResponse};
@@ -39,7 +38,7 @@ impl From<&CachedPeer> for PeerData {
 /// GET /eth/v1/node/peers/{peer_id}
 #[get("/node/peers/{peer_id}")]
 pub async fn get_peer(
-    table: Data<Arc<RwLock<HashMap<PeerId, CachedPeer>>>>,
+    table: Data<PeerTable>,
     peer_id: Path<String>,
 ) -> Result<impl Responder, ApiError> {
     let id_raw = peer_id.into_inner();

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -29,8 +29,8 @@ impl From<&CachedPeer> for PeerData {
                 .as_ref()
                 .map(|m| m.to_string())
                 .unwrap_or_default(),
-            state: p.state.to_string(),
-            direction: p.direction.to_string(),
+            state: p.state.as_str().to_string(),
+            direction: p.direction.as_str().to_string(),
         }
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -23,16 +23,14 @@ pub async fn start_server(
     );
     // create the stop handle container
     let stop_handle = Data::new(StopHandle::default());
-    let peer_table_data = Data::new(peer_table);
 
     let server = HttpServer::new(move || {
         let stop_handle = stop_handle.clone();
-        let peer_table = peer_table_data.clone();
         App::new()
             .wrap(middleware::Logger::default())
             .app_data(stop_handle)
             .app_data(Data::new(db.clone()))
-            .app_data(peer_table.clone())
+            .app_data(Data::new(peer_table.clone()))
             .configure(register_routers)
     })
     .bind(server_config.http_socket_address)?


### PR DESCRIPTION
### What are you trying to achieve?

Resolve [Implement /eth/v1/node/peers/{peer_id} #222](https://github.com/ReamLabs/ream/issues/222)

### How was it implemented/fixed?

- **New route** – Added `GET /node/peers/{peer_id}` to align with the beacon-node API spec.  
- **Input validation** – `peer_id` is parsed with `libp2p::PeerId::from_str`; invalid IDs fail fast with `ApiError::BadRequest`.  
- **Response shape** – Returns JSON-wrapped `PeerData`  
  ```json
  {
    "peer_id": "<peer_id>",
    "enr": null,
    "last_seen_p2p_address": "<p2p_address>",
    "state": "connected",
    "direction": "outbound"
  }

- **Error handling** – Parsing and lookup errors map to `ApiError::{BadRequest, NotFound, InternalError}` and are logged via `tracing` for easier debugging.  
- **Stub data source** – Introduced `mock_fetch_peer` as a temporary stand-in; it supplies hard-coded peer info while we wire up the real `Network` integration.

#### Example request

```bash
curl -X GET -H "Accept: application/json" http://localhost:5052/eth/v1/node/peers/16Uiu2HAmUaM4YkWtwpu6P299nZuDwTCyUsrXeArCynSS1irSjXAM
```

<details> <summary>Sample response</summary>

```json
{
  "data": {
    "peer_id": "16Uiu2HAm1oEch6uXffoGZ32kPTiyjycfX9yDuBJSWtmagBSk9HTN",
    "enr": null,
    "last_seen_p2p_address": "/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAm1oEch6uXffoGZ32kPTiyjycfX9yDuBJSWtmagBSk9HTN",
    "state": "connected",
    "direction": "outbound"
  }
}
```
</details> 

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Confirm that `PeerData` must be fetched directly from `p2p/src/network.rs::Network` (not from the database) for the `/node/peers/{peer_id}` endpoint.
- [x] Implement a read function (e.g., `fn cached_peer(&self, id: &PeerId) -> Option<CachedPeer>`) in `p2p/src/network.rs` to expose live peer data to the RPC layer.
- [x] Inject `Arc<Network>` into the RPC server (`start_server`) and register it with `App::app_data` so that handlers can call `network.cached_peer(...)`.