### PR TITLE
feat: make NetworkSpec a global, instead of passing it everywhere

### DIFF
--- a/crates/common/network_spec/src/networks.rs
+++ b/crates/common/network_spec/src/networks.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, OnceLock};
 
 use alloy_primitives::{Address, address, b256, fixed_bytes};
 use ream_consensus::genesis::Genesis;
@@ -27,6 +27,30 @@ impl Network {
             Network::Dev => 1,
         }
     }
+}
+
+static NETWORK_SPEC: OnceLock<Arc<NetworkSpec>> = OnceLock::new();
+
+/// MUST be called only once at the start of the application to initialize static [NetworkSpec].
+///
+/// The static `NetworkSpec` can be accessed using [network_spec].
+///
+/// # Panics
+///
+/// Panics if this function is called more than once.
+pub fn set_network_spec(network_spec: Arc<NetworkSpec>) {
+    NETWORK_SPEC
+        .set(network_spec)
+        .expect("NetworkSpec should be set only once at the start of the application");
+}
+
+/// Returns the static [NetworkSpec] initialized by [set_network_spec].
+///
+/// # Panics
+///
+/// Panics if [set_network_spec] wasn't called before this function.
+pub fn network_spec() -> Arc<NetworkSpec> {
+    NETWORK_SPEC.get().expect("NetworkSpec wasn't set").clone()
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/rpc/src/handlers/block.rs
+++ b/crates/rpc/src/handlers/block.rs
@@ -13,7 +13,7 @@ use ream_consensus::{
     },
     electra::{beacon_block::SignedBeaconBlock, beacon_state::BeaconState},
 };
-use ream_network_spec::networks::NetworkSpec;
+use ream_network_spec::networks::network_spec;
 use ream_storage::{
     db::ReamDB,
     tables::{Field, Table},
@@ -202,8 +202,8 @@ pub async fn get_beacon_block_from_id(
 
 /// Called by `/genesis` to get the Genesis Config of Beacon Chain.
 #[get("/beacon/genesis")]
-pub async fn get_genesis(network_spec: Data<NetworkSpec>) -> Result<impl Responder, ApiError> {
-    Ok(HttpResponse::Ok().json(DataResponse::new(network_spec.genesis.clone())))
+pub async fn get_genesis() -> Result<impl Responder, ApiError> {
+    Ok(HttpResponse::Ok().json(DataResponse::new(network_spec().genesis.clone())))
 }
 
 /// Called by `/eth/v2/beacon/blocks/{block_id}/attestations` to get block attestations

--- a/crates/rpc/src/handlers/config.rs
+++ b/crates/rpc/src/handlers/config.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use actix_web::{HttpResponse, Responder, get, web::Data};
+use actix_web::{HttpResponse, Responder, get};
 use alloy_primitives::{Address, aliases::B32};
 use ream_consensus::constants::{
     DOMAIN_AGGREGATE_AND_PROOF, INACTIVITY_PENALTY_QUOTIENT_BELLATRIX,
 };
-use ream_network_spec::networks::NetworkSpec;
+use ream_network_spec::networks::{NetworkSpec, network_spec};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{errors::ApiError, response::DataResponse};
@@ -47,17 +47,14 @@ impl From<Arc<NetworkSpec>> for SpecConfig {
 
 /// Called by `config/spec` to get specification configuration.
 #[get("config/spec")]
-pub async fn get_config_spec(network_spec: Data<NetworkSpec>) -> Result<impl Responder, ApiError> {
-    let spec_config = SpecConfig::from(network_spec.into_inner());
-
-    Ok(HttpResponse::Ok().json(DataResponse::new(spec_config)))
+pub async fn get_config_spec() -> Result<impl Responder, ApiError> {
+    Ok(HttpResponse::Ok().json(DataResponse::new(SpecConfig::from(network_spec()))))
 }
 
 /// Called by `/deposit_contract` to get the Genesis Config of Beacon Chain.
 #[get("config/deposit_contract")]
-pub async fn get_config_deposit_contract(
-    network_spec: Data<NetworkSpec>,
-) -> Result<impl Responder, ApiError> {
+pub async fn get_config_deposit_contract() -> Result<impl Responder, ApiError> {
+    let network_spec = network_spec();
     Ok(
         HttpResponse::Ok().json(DataResponse::new(DepositContract::new(
             network_spec.network.chain_id(),
@@ -68,10 +65,8 @@ pub async fn get_config_deposit_contract(
 
 /// Called by `config/fork_schedule` to get fork schedule
 #[get("config/fork_schedule")]
-pub async fn get_fork_schedule(
-    network_spec: Data<NetworkSpec>,
-) -> Result<impl Responder, ApiError> {
+pub async fn get_fork_schedule() -> Result<impl Responder, ApiError> {
     Ok(HttpResponse::Ok().json(DataResponse::new(
-        network_spec.fork_schedule.scheduled().collect::<Vec<_>>(),
+        network_spec().fork_schedule.scheduled().collect::<Vec<_>>(),
     )))
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,8 +1,5 @@
-use std::sync::Arc;
-
 use actix_web::{App, HttpServer, dev::ServerHandle, middleware, web::Data};
 use config::ServerConfig;
-use ream_network_spec::networks::NetworkSpec;
 use ream_storage::db::ReamDB;
 use tracing::info;
 
@@ -14,11 +11,7 @@ pub mod routes;
 pub mod types;
 
 /// Start the Beacon API server.
-pub async fn start_server(
-    server_config: ServerConfig,
-    network_spec: Arc<NetworkSpec>,
-    db: ReamDB,
-) -> std::io::Result<()> {
+pub async fn start_server(server_config: ServerConfig, db: ReamDB) -> std::io::Result<()> {
     info!(
         "starting HTTP server on {:?}",
         server_config.http_socket_address
@@ -31,7 +24,6 @@ pub async fn start_server(
         App::new()
             .wrap(middleware::Logger::default())
             .app_data(stop_handle)
-            .app_data(Data::from(network_spec.clone()))
             .app_data(Data::new(db.clone()))
             .configure(register_routers)
     })


### PR DESCRIPTION
### What are you trying to achieve?

We are going to passing NetworkSpec everywhere, it is something we would only be setting at configuration so we can use a OnceLock, to initialize the global then use it.


### How was it implemented/fixed?

Switching to `OnceLock` instead of passing a Arc<> everywhere