### PR TITLE
feat: Implemented finality macro and tests

### DIFF
--- a/testing/ef-tests/src/macros/finality.rs
+++ b/testing/ef-tests/src/macros/finality.rs
@@ -1,0 +1,105 @@
+#[macro_export]
+macro_rules! test_finality {
+    ($path:ident) => {
+        paste::paste! {
+            #[cfg(test)]
+            #[allow(non_snake_case)]
+            mod [<tests_ $path>] {
+                use std::{fs, path::Path};
+
+                use ream_consensus::execution_engine::mock_engine::MockExecutionEngine;
+                use serde_yaml;
+
+                use super::*;
+
+                #[derive(Debug, serde::Deserialize)]
+                struct MetaData {
+                    blocks_count: usize,
+                    bls_setting: Option<usize>,
+                }
+
+                #[tokio::test]
+                async fn test_finality() {
+                    let base_path = format!(
+                        "mainnet/tests/mainnet/electra/finality/finality/pyspec_tests/{}",
+                        stringify!($path)
+                    );
+
+                    let mock_engine = MockExecutionEngine::new();
+
+                    for entry in std::fs::read_dir(&base_path).unwrap() {
+                        let entry = entry.unwrap();
+                        let case_dir = entry.path();
+                        if !case_dir.is_dir() {
+                            continue;
+                        }
+
+                        let case_name = case_dir.file_name().unwrap().to_str().unwrap();
+                        println!("Testing case: {}", case_name);
+
+                        let meta: MetaData = {
+                            let meta_path = case_dir.join("meta.yaml");
+                            let content =
+                                fs::read_to_string(meta_path).expect("Failed to read meta.yaml");
+                            serde_yaml::from_str(&content).expect("Failed to parse meta.yaml")
+                        };
+
+                        let mut state: BeaconState =
+                            utils::read_ssz_snappy(&case_dir.join("pre.ssz_snappy"))
+                                .expect("cannot find test asset (pre.ssz_snappy)");
+
+                        let mut result: Result<(), String> = Ok(());
+
+                        for i in 0..meta.blocks_count {
+                            let block_ssz = case_dir.join(format!("blocks_{i}.ssz_snappy"));
+                            let block_yaml = case_dir.join(format!("blocks_{i}.yaml"));
+
+                            let signed_block: SignedBeaconBlock = if block_ssz.exists() {
+                                utils::read_ssz_snappy(&block_ssz).expect(&format!("cannot find test asset (blocks_{i}.ssz_snappy)"))
+                            } else if block_yaml.exists() {
+                                let yaml = fs::read_to_string(&block_yaml)
+                                    .expect(&format!("cannot find test asset (blocks_{i}.yaml)"));
+                                serde_yaml::from_str(&yaml).expect(&format!("Failed to parse blocks_{i}.yaml"))
+                            } else {
+                                panic!("could not find blocks_{i}.ssz_snappy or blocks_{i}.yaml");
+                            };
+
+                            result = state.state_transition(&signed_block, true, &mock_engine)
+                                .await
+                                .map_err(|err| err.to_string());
+                        }
+
+                        let expected_post = utils::read_ssz_snappy::<BeaconState>(&case_dir.join("post.ssz_snappy"));
+
+                        match (result, expected_post) {
+                            (Ok(_), Ok(expected)) => {
+                                let locked_state = state;
+                                assert_eq!(
+                                    locked_state, expected,
+                                    "Post state mismatch in case {}",
+                                    case_name
+                                );
+                            }
+                            (Ok(_), Err(_)) => {
+                                panic!("Test case {} should have failed but succeeded", case_name);
+                            }
+                            (Err(err), Ok(_)) => {
+                                panic!(
+                                    "Test case {} should have succeeded but failed, err={:?}",
+                                    case_name, err
+                                );
+                            }
+                            (Err(_), Err(_)) => {
+                                // Expected: invalid operations result in an error and no post state.
+                                println!(
+                                    "Test case {} failed as expected, no post state available.",
+                                    case_name
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+}

--- a/testing/ef-tests/src/macros/mod.rs
+++ b/testing/ef-tests/src/macros/mod.rs
@@ -1,4 +1,5 @@
 pub mod epoch_processing;
+pub mod finality;
 pub mod fork_choice;
 pub mod merkle_proof;
 pub mod operations;

--- a/testing/ef-tests/tests/tests.rs
+++ b/testing/ef-tests/tests/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "ef-tests")]
 
 use ef_tests::{
-    test_consensus_type, test_epoch_processing, test_fork_choice, test_merkle_proof,
+    test_consensus_type, test_epoch_processing, test_finality, test_fork_choice, test_merkle_proof,
     test_merkle_proof_impl, test_operation, test_rewards, test_sanity_blocks, test_sanity_slots,
     test_shuffling, utils,
 };
@@ -225,3 +225,10 @@ test_merkle_proof!(
 
 // Testing random
 test_sanity_blocks!(test_random, "random/random");
+
+// Testing finality
+test_finality!(finality_no_updates_at_genesis);
+test_finality!(finality_rule_1);
+test_finality!(finality_rule_2);
+test_finality!(finality_rule_3);
+test_finality!(finality_rule_4);


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: https://github.com/ReamLabs/ream/issues/365
This PR implements testing for finality 

### How was it implemented/fixed?

Spec: https://github.com/ethereum/consensus-specs/tree/8fa1aaae5eaca6d9bdcea99658e834963557c20d/tests/formats/finality

### To-Do

- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
