### PR TITLE
feat: add multiproof feature in `ream-merkle`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4476,6 +4476,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "ethereum_hashing",
+ "serde",
 ]
 
 [[package]]

--- a/crates/crypto/merkle/Cargo.toml
+++ b/crates/crypto/merkle/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 alloy-primitives.workspace = true
 anyhow.workspace = true
 ethereum_hashing.workspace = true
+serde.workspace = true
 
 [features]
 default = []

--- a/crates/crypto/merkle/Cargo.toml
+++ b/crates/crypto/merkle/Cargo.toml
@@ -14,7 +14,3 @@ alloy-primitives.workspace = true
 anyhow.workspace = true
 ethereum_hashing.workspace = true
 serde.workspace = true
-
-[features]
-default = []
-multiproof = []

--- a/crates/crypto/merkle/Cargo.toml
+++ b/crates/crypto/merkle/Cargo.toml
@@ -13,3 +13,7 @@ version.workspace = true
 alloy-primitives.workspace = true
 anyhow.workspace = true
 ethereum_hashing.workspace = true
+
+[features]
+default = []
+multiproof = []

--- a/crates/crypto/merkle/src/hash.rs
+++ b/crates/crypto/merkle/src/hash.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::B256;
 
 /// Common hashing function for Merkle trees.
-pub(crate) fn hash_concat(h1: &[u8], h2: &[u8]) -> B256 {
+pub fn hash_concat(h1: &[u8], h2: &[u8]) -> B256 {
     ethereum_hashing::hash32_concat(h1, h2).into()
 }

--- a/crates/crypto/merkle/src/hash.rs
+++ b/crates/crypto/merkle/src/hash.rs
@@ -1,0 +1,6 @@
+use alloy_primitives::B256;
+
+/// Common hashing function for Merkle trees.
+pub(crate) fn hash_concat(h1: &[u8], h2: &[u8]) -> B256 {
+    ethereum_hashing::hash32_concat(h1, h2).into()
+}

--- a/crates/crypto/merkle/src/index.rs
+++ b/crates/crypto/merkle/src/index.rs
@@ -1,0 +1,31 @@
+/// ``LeafIndex`` is the index of a leaf in the **bottom** layer of the ``tree``.
+pub(crate) type LeafIndex = u64;
+
+/// ``GeneralizedIndex`` is the index of a node in the ``tree``.
+pub(crate) type GeneralizedIndex = u64;
+
+/// Return the given bit of a generalized index.
+/// Note: It is fine to pass ``LeafIndex`` to this function,
+/// as the result will be the same.
+pub(crate) fn get_generalized_index_bit(index: GeneralizedIndex, position: u64) -> bool {
+    (index & (1 << position)) > 0
+}
+
+pub(crate) fn generalized_index_child(
+    index: GeneralizedIndex,
+    right_side: bool,
+) -> GeneralizedIndex {
+    index * 2 + right_side as GeneralizedIndex
+}
+
+pub(crate) fn get_subtree_index(generalized_index: GeneralizedIndex) -> LeafIndex {
+    generalized_index % (1 << (generalized_index as f64).log2().floor() as u64)
+}
+
+/// Return the generalized index of the leaf index with ``depth``.
+pub(crate) fn generalized_index_from_leaf_index(
+    leaf_index: LeafIndex,
+    depth: u64,
+) -> GeneralizedIndex {
+    leaf_index + (1 << depth)
+}

--- a/crates/crypto/merkle/src/index.rs
+++ b/crates/crypto/merkle/src/index.rs
@@ -4,16 +4,16 @@ pub fn get_generalized_index_bit(index: u64, position: u64) -> bool {
     (index & (1 << position)) > 0
 }
 
-pub const fn generalized_index_sibling(index: u64) -> u64 {
-    index ^ 1
+pub const fn generalized_index_sibling(generalized_index: u64) -> u64 {
+    generalized_index ^ 1
 }
 
-pub fn generalized_index_child(index: u64, right_side: bool) -> u64 {
-    index * 2 + right_side as u64
+pub fn generalized_index_child(generalized_index: u64, right_side: bool) -> u64 {
+    generalized_index * 2 + right_side as u64
 }
 
-pub const fn generalized_index_parent(index: u64) -> u64 {
-    index / 2
+pub const fn generalized_index_parent(generalized_index: u64) -> u64 {
+    generalized_index / 2
 }
 
 pub fn get_subtree_index(generalized_index: u64) -> u64 {
@@ -27,8 +27,8 @@ pub fn generalized_index_from_leaf_index(leaf_index: u64, depth: u64) -> u64 {
 
 /// Get the generalized indices of the sister chunks along the
 /// path from the chunk with the given tree index to the root.
-fn get_branch_indices(tree_index: u64) -> Vec<u64> {
-    let mut focus = generalized_index_sibling(tree_index);
+fn get_branch_indices(generalized_index: u64) -> Vec<u64> {
+    let mut focus = generalized_index_sibling(generalized_index);
     let mut result = vec![focus];
     while focus > 1 {
         focus = generalized_index_sibling(generalized_index_parent(focus));
@@ -40,8 +40,8 @@ fn get_branch_indices(tree_index: u64) -> Vec<u64> {
 
 /// Get the generalized indices of the chunks along
 /// the path from the chunk with the given tree index to the root.
-fn get_path_indices(tree_index: u64) -> Vec<u64> {
-    let mut focus = tree_index;
+fn get_path_indices(generalized_index: u64) -> Vec<u64> {
+    let mut focus = generalized_index;
     let mut result = vec![focus];
     while focus > 1 {
         focus = generalized_index_parent(focus);
@@ -56,11 +56,11 @@ fn get_path_indices(tree_index: u64) -> Vec<u64> {
 /// Note that the decreasing order is chosen deliberately
 /// to ensure equivalence to the order of hashes in a regular
 /// single-item Merkle proof in the single-item case.
-pub fn get_helper_indices(indices: &[u64]) -> Vec<u64> {
+pub fn get_helper_indices(generalized_indices: &[u64]) -> Vec<u64> {
     let mut all_helper_indices = HashSet::new();
     let mut all_path_indices = HashSet::new();
 
-    for index in indices {
+    for index in generalized_indices {
         all_helper_indices.extend(get_branch_indices(*index).iter());
         all_path_indices.extend(get_path_indices(*index).iter());
     }

--- a/crates/crypto/merkle/src/index.rs
+++ b/crates/crypto/merkle/src/index.rs
@@ -115,5 +115,6 @@ mod multiproof_helpers {
 
 #[cfg(feature = "multiproof")]
 pub use multiproof_helpers::{
-    generalized_index_parent, generalized_index_sibling, get_helper_indices,
+    generalized_index_from_leaf_index, generalized_index_parent, generalized_index_sibling,
+    get_helper_indices,
 };

--- a/crates/crypto/merkle/src/index.rs
+++ b/crates/crypto/merkle/src/index.rs
@@ -1,39 +1,33 @@
 use std::collections::HashSet;
 
-/// ``GeneralizedIndex`` is the index of a node in the ``tree``.
-pub type GeneralizedIndex = u64;
-
-/// Return the given bit of a generalized index.
-/// Note: It is fine to pass ``LeafIndex`` to this function,
-/// as the result will be the same.
-pub fn get_generalized_index_bit(index: GeneralizedIndex, position: u64) -> bool {
+pub fn get_generalized_index_bit(index: u64, position: u64) -> bool {
     (index & (1 << position)) > 0
 }
 
-pub const fn generalized_index_sibling(index: GeneralizedIndex) -> GeneralizedIndex {
+pub const fn generalized_index_sibling(index: u64) -> u64 {
     index ^ 1
 }
 
-pub fn generalized_index_child(index: GeneralizedIndex, right_side: bool) -> GeneralizedIndex {
-    index * 2 + right_side as GeneralizedIndex
+pub fn generalized_index_child(index: u64, right_side: bool) -> u64 {
+    index * 2 + right_side as u64
 }
 
-pub const fn generalized_index_parent(index: GeneralizedIndex) -> GeneralizedIndex {
+pub const fn generalized_index_parent(index: u64) -> u64 {
     index / 2
 }
 
-pub fn get_subtree_index(generalized_index: GeneralizedIndex) -> GeneralizedIndex {
+pub fn get_subtree_index(generalized_index: u64) -> u64 {
     generalized_index % (1 << (generalized_index as f64).log2().floor() as u64)
 }
 
 /// Return the generalized index of the leaf index with ``depth``.
-pub fn generalized_index_from_leaf_index(leaf_index: u64, depth: u64) -> GeneralizedIndex {
+pub fn generalized_index_from_leaf_index(leaf_index: u64, depth: u64) -> u64 {
     leaf_index + (1 << depth)
 }
 
 /// Get the generalized indices of the sister chunks along the
 /// path from the chunk with the given tree index to the root.
-fn get_branch_indices(tree_index: GeneralizedIndex) -> Vec<GeneralizedIndex> {
+fn get_branch_indices(tree_index: u64) -> Vec<u64> {
     let mut focus = generalized_index_sibling(tree_index);
     let mut result = vec![focus];
     while focus > 1 {
@@ -46,7 +40,7 @@ fn get_branch_indices(tree_index: GeneralizedIndex) -> Vec<GeneralizedIndex> {
 
 /// Get the generalized indices of the chunks along
 /// the path from the chunk with the given tree index to the root.
-fn get_path_indices(tree_index: GeneralizedIndex) -> Vec<GeneralizedIndex> {
+fn get_path_indices(tree_index: u64) -> Vec<u64> {
     let mut focus = tree_index;
     let mut result = vec![focus];
     while focus > 1 {
@@ -62,7 +56,7 @@ fn get_path_indices(tree_index: GeneralizedIndex) -> Vec<GeneralizedIndex> {
 /// Note that the decreasing order is chosen deliberately
 /// to ensure equivalence to the order of hashes in a regular
 /// single-item Merkle proof in the single-item case.
-pub fn get_helper_indices(indices: &[GeneralizedIndex]) -> Vec<GeneralizedIndex> {
+pub fn get_helper_indices(indices: &[u64]) -> Vec<u64> {
     let mut all_helper_indices = HashSet::new();
     let mut all_path_indices = HashSet::new();
 
@@ -71,10 +65,10 @@ pub fn get_helper_indices(indices: &[GeneralizedIndex]) -> Vec<GeneralizedIndex>
         all_path_indices.extend(get_path_indices(*index).iter());
     }
 
-    let mut all_branch_indices: Vec<GeneralizedIndex> = all_helper_indices
+    let mut all_branch_indices = all_helper_indices
         .difference(&all_path_indices)
         .cloned()
-        .collect();
+        .collect::<Vec<_>>();
 
     all_branch_indices.sort_by(|a: &u64, b: &u64| b.cmp(a)); // descending order
     all_branch_indices

--- a/crates/crypto/merkle/src/index.rs
+++ b/crates/crypto/merkle/src/index.rs
@@ -1,6 +1,3 @@
-/// ``LeafIndex`` is the index of a leaf in the **bottom** layer of the ``tree``.
-pub(crate) type LeafIndex = u64;
-
 /// ``GeneralizedIndex`` is the index of a node in the ``tree``.
 pub(crate) type GeneralizedIndex = u64;
 
@@ -18,14 +15,105 @@ pub(crate) fn generalized_index_child(
     index * 2 + right_side as GeneralizedIndex
 }
 
-pub(crate) fn get_subtree_index(generalized_index: GeneralizedIndex) -> LeafIndex {
+pub(crate) fn get_subtree_index(generalized_index: GeneralizedIndex) -> GeneralizedIndex {
     generalized_index % (1 << (generalized_index as f64).log2().floor() as u64)
 }
 
-/// Return the generalized index of the leaf index with ``depth``.
-pub(crate) fn generalized_index_from_leaf_index(
-    leaf_index: LeafIndex,
-    depth: u64,
-) -> GeneralizedIndex {
-    leaf_index + (1 << depth)
+#[cfg(feature = "multiproof")]
+mod multiproof_helpers {
+    //! https://ethereum.github.io/consensus-specs/ssz/merkle-proofs/#merkle-multiproofs
+
+    use std::collections::HashSet;
+
+    use super::GeneralizedIndex;
+
+    pub const fn generalized_index_sibling(index: GeneralizedIndex) -> GeneralizedIndex {
+        index ^ 1
+    }
+
+    pub const fn generalized_index_parent(index: GeneralizedIndex) -> GeneralizedIndex {
+        index / 2
+    }
+
+    /// Return the generalized index of the leaf index with ``depth``.
+    pub fn generalized_index_from_leaf_index(leaf_index: u64, depth: u64) -> GeneralizedIndex {
+        leaf_index + (1 << depth)
+    }
+
+    /// Get the generalized indices of the sister chunks along the
+    /// path from the chunk with the given tree index to the root.
+    fn get_branch_indices(tree_index: GeneralizedIndex) -> Vec<GeneralizedIndex> {
+        let mut focus = generalized_index_sibling(tree_index);
+        let mut result = vec![focus];
+        while focus > 1 {
+            focus = generalized_index_sibling(generalized_index_parent(focus));
+            result.push(focus);
+        }
+        result.pop();
+        result
+    }
+
+    /// Get the generalized indices of the chunks along
+    /// the path from the chunk with the given tree index to the root.
+    fn get_path_indices(tree_index: GeneralizedIndex) -> Vec<GeneralizedIndex> {
+        let mut focus = tree_index;
+        let mut result = vec![focus];
+        while focus > 1 {
+            focus = generalized_index_parent(focus);
+            result.push(focus);
+        }
+        result.pop();
+        result
+    }
+
+    /// Get the generalized indices of all "extra" chunks in the tree needed to
+    /// prove the chunks with the given generalized indices.
+    /// Note that the decreasing order is chosen deliberately
+    /// to ensure equivalence to the order of hashes in a regular
+    /// single-item Merkle proof in the single-item case.
+    pub fn get_helper_indices(indices: &[GeneralizedIndex]) -> Vec<GeneralizedIndex> {
+        let mut all_helper_indices = HashSet::new();
+        let mut all_path_indices = HashSet::new();
+
+        for index in indices {
+            all_helper_indices.extend(get_branch_indices(*index).iter());
+            all_path_indices.extend(get_path_indices(*index).iter());
+        }
+
+        let mut all_branch_indices: Vec<GeneralizedIndex> = all_helper_indices
+            .difference(&all_path_indices)
+            .cloned()
+            .collect();
+
+        all_branch_indices.sort_by(|a: &u64, b: &u64| b.cmp(a)); // descending order
+        all_branch_indices
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        const DEPTH: u64 = 3;
+
+        #[test]
+        /// See this [illustration](https://hackmd.io/_uploads/H1ZVOVille.png).
+        fn test_get_helper_indices() {
+            let leaf_indices = vec![2, 7];
+            let generalized_indices = leaf_indices
+                .iter()
+                .map(|&index| generalized_index_from_leaf_index(index, DEPTH))
+                .collect::<Vec<_>>();
+            let helper_indices = get_helper_indices(&generalized_indices);
+            assert_eq!(helper_indices.len(), 4);
+            assert_eq!(helper_indices[0], 14);
+            assert_eq!(helper_indices[1], 11);
+            assert_eq!(helper_indices[2], 6);
+            assert_eq!(helper_indices[3], 4);
+        }
+    }
 }
+
+#[cfg(feature = "multiproof")]
+pub use multiproof_helpers::{
+    generalized_index_parent, generalized_index_sibling, get_helper_indices,
+};

--- a/crates/crypto/merkle/src/lib.rs
+++ b/crates/crypto/merkle/src/lib.rs
@@ -140,19 +140,19 @@ mod tests {
         assert!(is_valid_normalized_merkle_branch(
             leaves[1],
             &proof_1,
-            1 + (1 << depth),
+            (1 << depth) + 1,
             root
         ));
         assert!(is_valid_normalized_merkle_branch(
             leaves[2],
             &proof_2,
-            2 + (1 << depth),
+            (1 << depth) + 2,
             root
         ));
         assert!(is_valid_normalized_merkle_branch(
             leaves[3],
             &proof_3,
-            3 + (1 << depth),
+            (1 << depth) + 3,
             root
         ));
     }

--- a/crates/crypto/merkle/src/lib.rs
+++ b/crates/crypto/merkle/src/lib.rs
@@ -1,5 +1,8 @@
 //! https://ethereum.github.io/consensus-specs/ssz/merkle-proofs
 
+#[cfg(feature = "multiproof")]
+pub mod multiproof;
+
 use alloy_primitives::B256;
 use anyhow::ensure;
 
@@ -132,7 +135,7 @@ mod tests {
         assert!(is_valid_normalized_merkle_branch(
             leaves[0],
             &proof_0,
-            0 + (1 << depth),
+            1 << depth,
             root
         ));
         assert!(is_valid_normalized_merkle_branch(

--- a/crates/crypto/merkle/src/lib.rs
+++ b/crates/crypto/merkle/src/lib.rs
@@ -1,6 +1,5 @@
 //! https://ethereum.github.io/consensus-specs/ssz/merkle-proofs
 
-#[cfg(feature = "multiproof")]
 pub mod multiproof;
 
 use alloy_primitives::B256;
@@ -113,10 +112,10 @@ mod tests {
 
         let depth = (leaves.len() as f64).log2().ceil() as u64;
 
-        let node_2: B256 = hash_concat(leaves[0].as_slice(), leaves[1].as_slice());
-        let node_3: B256 = hash_concat(leaves[2].as_slice(), leaves[3].as_slice());
+        let node_2 = hash_concat(leaves[0].as_slice(), leaves[1].as_slice());
+        let node_3 = hash_concat(leaves[2].as_slice(), leaves[3].as_slice());
 
-        let root: B256 = hash_concat(node_2.as_slice(), node_3.as_slice());
+        let root = hash_concat(node_2.as_slice(), node_3.as_slice());
 
         let tree = merkle_tree(&leaves, depth).unwrap();
 

--- a/crates/crypto/merkle/src/lib.rs
+++ b/crates/crypto/merkle/src/lib.rs
@@ -97,8 +97,6 @@ pub fn is_valid_normalized_merkle_branch(
 
 #[cfg(test)]
 mod tests {
-    use crate::index::generalized_index_from_leaf_index;
-
     use super::*;
 
     #[test]
@@ -134,25 +132,25 @@ mod tests {
         assert!(is_valid_normalized_merkle_branch(
             leaves[0],
             &proof_0,
-            generalized_index_from_leaf_index(0, depth),
+            0 + (1 << depth),
             root
         ));
         assert!(is_valid_normalized_merkle_branch(
             leaves[1],
             &proof_1,
-            generalized_index_from_leaf_index(1, depth),
+            1 + (1 << depth),
             root
         ));
         assert!(is_valid_normalized_merkle_branch(
             leaves[2],
             &proof_2,
-            generalized_index_from_leaf_index(2, depth),
+            2 + (1 << depth),
             root
         ));
         assert!(is_valid_normalized_merkle_branch(
             leaves[3],
             &proof_3,
-            generalized_index_from_leaf_index(3, depth),
+            3 + (1 << depth),
             root
         ));
     }

--- a/crates/crypto/merkle/src/lib.rs
+++ b/crates/crypto/merkle/src/lib.rs
@@ -3,17 +3,11 @@
 use alloy_primitives::B256;
 use anyhow::ensure;
 
-fn get_generalized_index_bit(index: u64, position: u64) -> bool {
-    (index & (1 << position)) > 0
-}
+mod hash;
+mod index;
 
-fn get_generalized_index_child(index: u64, right_side: bool) -> u64 {
-    index * 2 + right_side as u64
-}
-
-fn get_subtree_index(generalized_index: u64) -> u64 {
-    generalized_index % (1 << (generalized_index as f64).log2().floor() as u64)
-}
+use hash::hash_concat;
+use index::{generalized_index_child, get_generalized_index_bit, get_subtree_index};
 
 pub fn merkle_tree(leaves: &[B256], depth: u64) -> anyhow::Result<Vec<B256>> {
     let num_of_leaves = leaves.len();
@@ -30,7 +24,7 @@ pub fn merkle_tree(leaves: &[B256], depth: u64) -> anyhow::Result<Vec<B256>> {
     for i in (1..bottom_length).rev() {
         let left = tree[i * 2].as_slice();
         let right = tree[i * 2 + 1].as_slice();
-        tree[i] = ethereum_hashing::hash32_concat(left, right).into();
+        tree[i] = hash_concat(left, right);
     }
 
     Ok(tree)
@@ -46,8 +40,8 @@ pub fn generate_proof(tree: &[B256], index: u64, depth: u64) -> anyhow::Result<V
 
     while current_depth > 0 {
         let (left_child_index, right_child_index) = (
-            get_generalized_index_child(current_index, false),
-            get_generalized_index_child(current_index, true),
+            generalized_index_child(current_index, false),
+            generalized_index_child(current_index, true),
         );
 
         if get_generalized_index_bit(index, current_depth - 1) {
@@ -76,13 +70,9 @@ pub fn is_valid_merkle_branch(
     let mut value = leaf;
     for i in 0..depth {
         if get_generalized_index_bit(index, i) {
-            value =
-                ethereum_hashing::hash32_concat(branch[i as usize].as_slice(), value.as_slice())
-                    .into();
+            value = hash_concat(branch[i as usize].as_slice(), value.as_slice());
         } else {
-            value =
-                ethereum_hashing::hash32_concat(value.as_slice(), branch[i as usize].as_slice())
-                    .into();
+            value = hash_concat(value.as_slice(), branch[i as usize].as_slice());
         }
     }
     value == root
@@ -107,6 +97,8 @@ pub fn is_valid_normalized_merkle_branch(
 
 #[cfg(test)]
 mod tests {
+    use crate::index::generalized_index_from_leaf_index;
+
     use super::*;
 
     #[test]
@@ -118,15 +110,12 @@ mod tests {
             B256::from_slice(&[0xDD; 32]),
         ];
 
-        let depth = (leaves.len() as f64).log2().floor() as u64;
+        let depth = (leaves.len() as f64).log2().ceil() as u64;
 
-        let node_2: B256 =
-            ethereum_hashing::hash32_concat(leaves[0].as_slice(), leaves[1].as_slice()).into();
-        let node_3: B256 =
-            ethereum_hashing::hash32_concat(leaves[2].as_slice(), leaves[3].as_slice()).into();
+        let node_2: B256 = hash_concat(leaves[0].as_slice(), leaves[1].as_slice());
+        let node_3: B256 = hash_concat(leaves[2].as_slice(), leaves[3].as_slice());
 
-        let root: B256 =
-            ethereum_hashing::hash32_concat(node_2.as_slice(), node_3.as_slice()).into();
+        let root: B256 = hash_concat(node_2.as_slice(), node_3.as_slice());
 
         let tree = merkle_tree(&leaves, depth).unwrap();
 
@@ -145,25 +134,25 @@ mod tests {
         assert!(is_valid_normalized_merkle_branch(
             leaves[0],
             &proof_0,
-            2 * depth,
+            generalized_index_from_leaf_index(0, depth),
             root
         ));
         assert!(is_valid_normalized_merkle_branch(
             leaves[1],
             &proof_1,
-            2 * depth + 1,
+            generalized_index_from_leaf_index(1, depth),
             root
         ));
         assert!(is_valid_normalized_merkle_branch(
             leaves[2],
             &proof_2,
-            2 * depth + 2,
+            generalized_index_from_leaf_index(2, depth),
             root
         ));
         assert!(is_valid_normalized_merkle_branch(
             leaves[3],
             &proof_3,
-            2 * depth + 3,
+            generalized_index_from_leaf_index(3, depth),
             root
         ));
     }

--- a/crates/crypto/merkle/src/multiproof.rs
+++ b/crates/crypto/merkle/src/multiproof.rs
@@ -1,7 +1,5 @@
 //! https://ethereum.github.io/consensus-specs/ssz/merkle-proofs/#merkle-multiproofs
 
-#![cfg(feature = "multiproof")]
-
 use std::collections::{BTreeMap, HashMap};
 
 use alloy_primitives::B256;

--- a/crates/crypto/merkle/src/multiproof.rs
+++ b/crates/crypto/merkle/src/multiproof.rs
@@ -1,0 +1,160 @@
+//! https://ethereum.github.io/consensus-specs/ssz/merkle-proofs/#merkle-multiproofs
+
+#![cfg(feature = "multiproof")]
+
+use std::collections::{BTreeMap, HashMap};
+
+use alloy_primitives::B256;
+use anyhow::ensure;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    hash_concat,
+    index::{
+        GeneralizedIndex, generalized_index_from_leaf_index, generalized_index_parent,
+        generalized_index_sibling, get_helper_indices,
+    },
+};
+
+/// Multiproof is a structure that contains the leaves to be verified with
+/// their corresponding proofs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Multiproof {
+    /// The leaves to be verified.
+    /// Keyed by their generalized indices.
+    pub leaves: HashMap<GeneralizedIndex, B256>,
+
+    /// The proof nodes.
+    /// Keyed by their generalized indices.
+    /// Keys of ``proofs`` will be sorted in descending order when generating a single proof.
+    pub proofs: BTreeMap<GeneralizedIndex, B256>,
+}
+
+impl Multiproof {
+    /// Generate a multiproof for the given tree and indices.
+    pub fn generate<const DEPTH: u64>(tree: &[B256], indices: &[u64]) -> anyhow::Result<Self> {
+        let bottom_length: u64 = 1 << DEPTH;
+
+        ensure!(!indices.is_empty(), "Indices cannot be empty");
+        for &index in indices {
+            ensure!(index < bottom_length, "Index out of bounds");
+        }
+
+        let generalized_indices: Vec<GeneralizedIndex> = indices
+            .iter()
+            .map(|&index| generalized_index_from_leaf_index(index, DEPTH))
+            .collect();
+        let helper_indices: Vec<GeneralizedIndex> = get_helper_indices(&generalized_indices);
+
+        let leaves: HashMap<GeneralizedIndex, B256> = generalized_indices
+            .iter()
+            .map(|&g| (g, tree[g as usize]))
+            .collect::<HashMap<_, _>>();
+        let proofs: BTreeMap<GeneralizedIndex, B256> = helper_indices
+            .iter()
+            .map(|&g| (g, tree[g as usize]))
+            .collect();
+
+        Ok(Self { leaves, proofs })
+    }
+
+    /// Return the root of the multiproof.
+    ///
+    /// Most code in this function is borrowed from ssz_rs crate.
+    /// https://github.com/ralexstokes/ssz-rs/blob/main/ssz-rs/src/merkleization/multiproofs.rs
+    pub fn calculate_root(&self) -> anyhow::Result<B256> {
+        let leaf_indices = self.leaves.keys().cloned().collect::<Vec<_>>();
+        let helper_indices = get_helper_indices(&leaf_indices);
+
+        ensure!(
+            self.proofs.len() == helper_indices.len(),
+            "Invalid proof: proof and helper indices length mismatch"
+        );
+
+        // ``objects`` is a map of all the indices to their corresponding nodes (hash values).
+        let mut objects = HashMap::new();
+        for (index, node) in self.leaves.iter().chain(self.proofs.iter()) {
+            objects.insert(*index, *node);
+        }
+
+        let mut keys = objects.keys().cloned().collect::<Vec<_>>();
+        keys.sort_by(|a, b| b.cmp(a)); // Sort in descending order
+
+        let mut pos = 0;
+        while pos < keys.len() {
+            let key = keys.get(pos).unwrap();
+
+            let key_present = objects.contains_key(key);
+            let sibling_present = objects.contains_key(&generalized_index_sibling(*key));
+            let parent_index = generalized_index_parent(*key);
+            let parent_missing = !objects.contains_key(&parent_index);
+
+            let should_compute = key_present && sibling_present && parent_missing;
+            if should_compute {
+                let right_index = key | 1;
+                let left_index = generalized_index_sibling(right_index);
+                let left_input = objects
+                    .get(&left_index)
+                    .ok_or_else(|| anyhow::anyhow!("Missing left node at index {}", left_index))?;
+                let right_input = objects.get(&right_index).ok_or_else(|| {
+                    anyhow::anyhow!("Missing right node at index {}", right_index)
+                })?;
+
+                *objects.entry(parent_index).or_default() =
+                    hash_concat(left_input.as_slice(), right_input.as_slice());
+                keys.push(parent_index);
+            }
+            pos += 1;
+        }
+
+        let root = *objects.get(&1).expect("contains index");
+        Ok(root)
+    }
+
+    /// Verify the multiproof against the given root.
+    pub fn verify(&self, root: B256) -> anyhow::Result<()> {
+        let calculated = self.calculate_root()?;
+        ensure!(
+            calculated == root,
+            "Invalid proof: expected root {root:?}, but got {calculated:?}"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merkle_tree;
+
+    const DEPTH: u64 = 3;
+
+    #[test]
+    fn test_generate_and_verify_multiproof() {
+        let leaves = vec![
+            B256::from_slice(&[0xAA; 32]),
+            B256::from_slice(&[0xBB; 32]),
+            B256::from_slice(&[0xCC; 32]),
+            B256::from_slice(&[0xDD; 32]),
+            B256::from_slice(&[0xEE; 32]),
+            B256::from_slice(&[0xFF; 32]),
+            B256::from_slice(&[0x11; 32]),
+            B256::from_slice(&[0x22; 32]),
+        ];
+        let tree = merkle_tree(&leaves, DEPTH).unwrap();
+
+        let target_indices = vec![2, 7];
+        let multiproof = Multiproof::generate::<DEPTH>(&tree, &target_indices).unwrap();
+
+        let root = tree[1];
+
+        assert_eq!(multiproof.leaves.len(), target_indices.len());
+
+        // We need four nodes to prove those two leaves.
+        // See this [illustration](https://hackmd.io/_uploads/H1ZVOVille.png).
+        assert_eq!(multiproof.proofs.len(), 4);
+
+        // Should succeed to verify the multiproof.
+        multiproof.verify(root).unwrap();
+    }
+}

--- a/crates/crypto/merkle/src/multiproof.rs
+++ b/crates/crypto/merkle/src/multiproof.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use alloy_primitives::B256;
-use anyhow::ensure;
+use anyhow::{anyhow, ensure};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -34,10 +34,10 @@ impl Multiproof {
         let bottom_length: u64 = 1 << DEPTH;
 
         ensure!(!indices.is_empty(), "Indices cannot be empty");
-        for &index in indices {
-            ensure!(index < bottom_length, "Index out of bounds");
-        }
-
+        ensure!(
+            indices.iter().all(|&index| index < bottom_length),
+            "Index out of bounds"
+        );
         let generalized_indices = indices
             .iter()
             .map(|&index| generalized_index_from_leaf_index(index, DEPTH))
@@ -46,20 +46,17 @@ impl Multiproof {
 
         let leaves = generalized_indices
             .iter()
-            .map(|&g| (g, tree[g as usize]))
+            .map(|&generalized_index| (generalized_index, tree[generalized_index as usize]))
             .collect::<HashMap<u64, B256>>();
         let proofs = helper_indices
             .iter()
-            .map(|&g| (g, tree[g as usize]))
+            .map(|&generalized_index| (generalized_index, tree[generalized_index as usize]))
             .collect::<BTreeMap<u64, B256>>();
 
         Ok(Self { leaves, proofs })
     }
 
     /// Return the root of the multiproof.
-    ///
-    /// Note: This function is a Rust port of the original function
-    /// (``calculate_multi_merkle_root()``) at spec code: https://github.com/ethereum/consensus-specs/blob/c27589872ac2dbafb566dcf7896c3fa975f00fe9/ssz/merkle-proofs.md?plain=1#L318-L341
     pub fn calculate_root(&self) -> anyhow::Result<B256> {
         let leaf_indices = self.leaves.keys().cloned().collect::<Vec<_>>();
         let helper_indices = get_helper_indices(&leaf_indices);
@@ -78,13 +75,14 @@ impl Multiproof {
         }
 
         let mut keys = objects.keys().cloned().collect::<Vec<_>>();
-        keys.sort_by(|a, b| b.cmp(a)); // Sort in descending order
+        // Sort in descending order
+        keys.sort_by(|a, b| b.cmp(a));
 
-        let mut pos = 0;
-        while pos < keys.len() {
+        let mut position = 0;
+        while position < keys.len() {
             let key = keys
-                .get(pos)
-                .ok_or_else(|| anyhow::anyhow!("Missing key at position {}", pos))?;
+                .get(position)
+                .ok_or_else(|| anyhow!("Missing key at position {position}"))?;
             let parent_index = generalized_index_parent(*key);
 
             let key_present = objects.contains_key(key);
@@ -96,30 +94,30 @@ impl Multiproof {
                 let left_index = generalized_index_sibling(right_index);
                 let left_input = objects
                     .get(&left_index)
-                    .ok_or_else(|| anyhow::anyhow!("Missing left node at index {}", left_index))?;
-                let right_input = objects.get(&right_index).ok_or_else(|| {
-                    anyhow::anyhow!("Missing right node at index {}", right_index)
-                })?;
+                    .ok_or_else(|| anyhow!("Missing left node at index {left_index}"))?;
+                let right_input = objects
+                    .get(&right_index)
+                    .ok_or_else(|| anyhow!("Missing right node at index {right_index}"))?;
 
                 *objects.entry(parent_index).or_default() =
                     hash_concat(left_input.as_slice(), right_input.as_slice());
                 keys.push(parent_index);
             }
-            pos += 1;
+            position += 1;
         }
 
         let root = *objects
             .get(&1)
-            .ok_or_else(|| anyhow::anyhow!("Missing root node at index 1"))?;
+            .ok_or_else(|| anyhow!("Missing root node at index 1"))?;
         Ok(root)
     }
 
     /// Verify the multiproof against the given root.
-    pub fn verify(&self, root: B256) -> anyhow::Result<()> {
-        let calculated = self.calculate_root()?;
+    pub fn verify(&self, expected_root: B256) -> anyhow::Result<()> {
+        let calculated_root = self.calculate_root()?;
         ensure!(
-            calculated == root,
-            "Invalid proof: expected root {root:?}, but got {calculated:?}"
+            calculated_root == expected_root,
+            "Invalid proof: expected root {expected_root:?}, but got {calculated_root:?}"
         );
         Ok(())
     }


### PR DESCRIPTION
### What are you trying to achieve?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

This PR adds a [multiproof](https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs) feature in our merkle package, `ream-merkle`. This feature will be used in passing `BeaconState` partially to the zkVM.

### How was it implemented/fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

For general understanding, reading [my note](https://hackmd.io/@reamlabs/B1SJuEoxle#Merkle-Multiproof) might be helpful. Also, you can see an [example](https://hackmd.io/@reamlabs/B1SJuEoxle#Example-first) of using this multiproof.

It modifies slightly the code from [`ssz_rs`](https://github.com/ralexstokes/ssz-rs/blob/main/ssz-rs/src/merkleization/multiproofs.rs) which implements the Python-like [spec code](https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md#merkle-multiproofs) into Rust.


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
