### PR TITLE
feat: Add support for reading config.yaml into NetworkSpec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,6 +4325,7 @@ dependencies = [
  "clap",
  "discv5",
  "ream-checkpoint-sync",
+ "ream-consensus",
  "ream-discv5",
  "ream-executor",
  "ream-network-spec",
@@ -4504,7 +4505,12 @@ name = "ream-network-spec"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "anyhow",
+ "ethereum_serde_utils",
  "ream-consensus",
+ "serde",
+ "serde_yaml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4510,7 +4510,6 @@ dependencies = [
  "ream-consensus",
  "serde",
  "serde_yaml",
- "tracing",
 ]
 
 [[package]]

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 # ream dependencies
 ream-checkpoint-sync.workspace = true
+ream-consensus.workspace = true
 ream-discv5.workspace = true
 ream-executor.workspace = true 
 ream-network-spec.workspace = true 

--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -41,7 +41,7 @@ pub struct NodeConfig {
 
     #[arg(
         long,
-        help = "Choose mainnet, holesky, sepolia, hoodi or dev",
+        help = "Choose mainnet, holesky, sepolia, hoodi, dev or provide a path to a YAML config file",
         default_value = DEFAULT_NETWORK,
         value_parser = network_parser
     )]
@@ -121,7 +121,7 @@ mod tests {
 
         match cli.command {
             Commands::Node(config) => {
-                assert_eq!(config.network.network, Network::Mainnet);
+                assert_eq!(config.network.config_name, Network::Mainnet);
                 assert_eq!(config.verbosity, 2);
                 assert_eq!(
                     config.socket_address,

--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -121,7 +121,7 @@ mod tests {
 
         match cli.command {
             Commands::Node(config) => {
-                assert_eq!(config.network.config_name, Network::Mainnet);
+                assert_eq!(config.network.network, Network::Mainnet);
                 assert_eq!(config.verbosity, 2);
                 assert_eq!(
                     config.socket_address,

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -3,7 +3,8 @@ use std::env;
 use clap::Parser;
 use ream::cli::{Cli, Commands};
 use ream_checkpoint_sync::initialize_db_from_checkpoint;
-use ream_discv5::{config::DiscoveryConfig, eth2::EnrForkId, subnet::Subnets};
+use ream_consensus::constants::MAINNET_GENESIS_VALIDATORS_ROOT;
+use ream_discv5::{config::DiscoveryConfig, subnet::Subnets};
 use ream_executor::ReamExecutor;
 use ream_network_spec::networks::{network_spec, set_network_spec};
 use ream_p2p::{
@@ -59,7 +60,7 @@ async fn main() {
             ))
             .build();
 
-            let bootnodes = config.bootnodes.to_enrs(network_spec().network);
+            let bootnodes = config.bootnodes.to_enrs(network_spec().config_name.clone());
             let discv5_config = DiscoveryConfig {
                 discv5_config,
                 bootnodes,
@@ -72,7 +73,7 @@ async fn main() {
 
             let mut gossipsub_config = GossipsubConfig::default();
             gossipsub_config.set_topics(vec![GossipTopic {
-                fork: EnrForkId::electra().fork_digest,
+                fork: network_spec().fork_digest(MAINNET_GENESIS_VALIDATORS_ROOT),
                 kind: GossipTopicKind::BeaconBlock,
             }]);
 

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -60,7 +60,7 @@ async fn main() {
             ))
             .build();
 
-            let bootnodes = config.bootnodes.to_enrs(network_spec().config_name.clone());
+            let bootnodes = config.bootnodes.to_enrs(network_spec().network.clone());
             let discv5_config = DiscoveryConfig {
                 discv5_config,
                 bootnodes,

--- a/crates/common/checkpoint_sync/src/checkpoint.rs
+++ b/crates/common/checkpoint_sync/src/checkpoint.rs
@@ -5,7 +5,7 @@ pub fn get_checkpoint_sync_sources(checkpoint_sync_url: Option<Url>) -> Vec<Url>
     if let Some(checkpoint_sync_url) = checkpoint_sync_url {
         return vec![checkpoint_sync_url];
     }
-    let raw_urls: Vec<String> = match network_spec().network {
+    let raw_urls: Vec<String> = match network_spec().config_name {
         Network::Mainnet => serde_yaml::from_str(include_str!(
             "../resources/checkpoint_sync_sources/mainnet.yaml"
         ))
@@ -22,7 +22,7 @@ pub fn get_checkpoint_sync_sources(checkpoint_sync_url: Option<Url>) -> Vec<Url>
             "../resources/checkpoint_sync_sources/hoodi.yaml"
         ))
         .expect("should deserialize checkpoint sync sources"),
-        Network::Dev => vec![],
+        Network::Dev | Network::Custom(_) => vec![],
     };
 
     raw_urls

--- a/crates/common/checkpoint_sync/src/checkpoint.rs
+++ b/crates/common/checkpoint_sync/src/checkpoint.rs
@@ -5,7 +5,7 @@ pub fn get_checkpoint_sync_sources(checkpoint_sync_url: Option<Url>) -> Vec<Url>
     if let Some(checkpoint_sync_url) = checkpoint_sync_url {
         return vec![checkpoint_sync_url];
     }
-    let raw_urls: Vec<String> = match network_spec().config_name {
+    let raw_urls: Vec<String> = match network_spec().network {
         Network::Mainnet => serde_yaml::from_str(include_str!(
             "../resources/checkpoint_sync_sources/mainnet.yaml"
         ))

--- a/crates/common/checkpoint_sync/src/lib.rs
+++ b/crates/common/checkpoint_sync/src/lib.rs
@@ -78,7 +78,7 @@ pub async fn initialize_db_from_checkpoint(
     ensure!(block.message.state_root == state.state_root());
     let mut store = get_forkchoice_store(state, block.message, db)?;
 
-    let time = network_spec().genesis.genesis_time + SECONDS_PER_SLOT * (slot + 1);
+    let time = network_spec().min_genesis_time + SECONDS_PER_SLOT * (slot + 1);
     on_tick(&mut store, time)?;
     info!("Initial Sync complete");
 

--- a/crates/common/consensus/src/constants.rs
+++ b/crates/common/consensus/src/constants.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{aliases::B32, fixed_bytes};
+use alloy_primitives::{B256, aliases::B32, b256, fixed_bytes};
 
 pub const BASE_REWARDS_PER_EPOCH: u64 = 4;
 pub const BASE_REWARD_FACTOR: u64 = 64;
@@ -126,3 +126,8 @@ pub const PARTICIPATION_FLAG_WEIGHTS: [u64; NUM_FLAG_INDICES] = [
     TIMELY_TARGET_WEIGHT,
     TIMELY_HEAD_WEIGHT,
 ];
+
+/// todo: genesis validators root is apart of the state, refactor the code to dynamically determine
+/// this on startup
+pub const MAINNET_GENESIS_VALIDATORS_ROOT: B256 =
+    b256!("0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95");

--- a/crates/common/network_spec/Cargo.toml
+++ b/crates/common/network_spec/Cargo.toml
@@ -11,6 +11,11 @@ version.workspace = true
 
 [dependencies]
 alloy-primitives.workspace = true
+anyhow.workspace = true
+serde.workspace = true
+serde_yaml.workspace = true
+ethereum_serde_utils.workspace = true
+tracing.workspace = true
 
 # ream-dependencies
 ream-consensus.workspace = true

--- a/crates/common/network_spec/Cargo.toml
+++ b/crates/common/network_spec/Cargo.toml
@@ -12,10 +12,9 @@ version.workspace = true
 [dependencies]
 alloy-primitives.workspace = true
 anyhow.workspace = true
+ethereum_serde_utils.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
-ethereum_serde_utils.workspace = true
-tracing.workspace = true
 
 # ream-dependencies
 ream-consensus.workspace = true

--- a/crates/common/network_spec/src/b32_hex.rs
+++ b/crates/common/network_spec/src/b32_hex.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::aliases::B32;
-use serde::{Deserializer, Serializer, de::Error};
+use serde::{Deserializer, Serializer};
 use serde_utils::hex::{self, PrefixedHexVisitor};
 
 pub fn serialize<S>(hash: &B32, serializer: S) -> Result<S::Ok, S::Error>
@@ -14,16 +14,5 @@ where
     D: Deserializer<'de>,
 {
     let decoded = deserializer.deserialize_str(PrefixedHexVisitor)?;
-
-    if decoded.len() != 4 {
-        return Err(D::Error::custom(format!(
-            "expected {} bytes for array, got {}",
-            32,
-            decoded.len()
-        )));
-    }
-
-    let mut array = [0; 4];
-    array.copy_from_slice(&decoded);
-    Ok(array.into())
+    B32::try_from(decoded.as_slice()).map_err(serde::de::Error::custom)
 }

--- a/crates/common/network_spec/src/b32_hex.rs
+++ b/crates/common/network_spec/src/b32_hex.rs
@@ -1,0 +1,29 @@
+use alloy_primitives::aliases::B32;
+use serde::{Deserializer, Serializer, de::Error};
+use serde_utils::hex::{self, PrefixedHexVisitor};
+
+pub fn serialize<S>(hash: &B32, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&format!("0x{}", hex::encode(hash)))
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<B32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let decoded = deserializer.deserialize_str(PrefixedHexVisitor)?;
+
+    if decoded.len() != 4 {
+        return Err(D::Error::custom(format!(
+            "expected {} bytes for array, got {}",
+            32,
+            decoded.len()
+        )));
+    }
+
+    let mut array = [0; 4];
+    array.copy_from_slice(&decoded);
+    Ok(array.into())
+}

--- a/crates/common/network_spec/src/cli.rs
+++ b/crates/common/network_spec/src/cli.rs
@@ -1,4 +1,6 @@
-use std::sync::Arc;
+use std::{fs, sync::Arc};
+
+use tracing::info;
 
 use crate::networks::{DEV, HOLESKY, HOODI, MAINNET, NetworkSpec, SEPOLIA};
 
@@ -9,8 +11,12 @@ pub fn network_parser(network_string: &str) -> Result<Arc<NetworkSpec>, String> 
         "sepolia" => Ok(SEPOLIA.clone()),
         "hoodi" => Ok(HOODI.clone()),
         "dev" => Ok(DEV.clone()),
-        _ => Err(format!(
-            "Not a valid network: {network_string}, try mainnet, holesky, sepolia, hoodi, or dev"
-        )),
+        _ => {
+            let contents = fs::read_to_string(network_string)
+                .map_err(|err| format!("Failed to read file: {err}"))?;
+            Ok(Arc::new(serde_yaml::from_str(&contents).map_err(
+                |err| format!("Failed to parse YAML from: {err}"),
+            )?))
+        }
     }
 }

--- a/crates/common/network_spec/src/cli.rs
+++ b/crates/common/network_spec/src/cli.rs
@@ -1,7 +1,5 @@
 use std::{fs, sync::Arc};
 
-use tracing::info;
-
 use crate::networks::{DEV, HOLESKY, HOODI, MAINNET, NetworkSpec, SEPOLIA};
 
 pub fn network_parser(network_string: &str) -> Result<Arc<NetworkSpec>, String> {

--- a/crates/common/network_spec/src/fork_schedule.rs
+++ b/crates/common/network_spec/src/fork_schedule.rs
@@ -1,51 +1,13 @@
 use std::slice::Iter;
 
-use alloy_primitives::fixed_bytes;
 use ream_consensus::fork::Fork;
+use serde::{Deserialize, Serialize};
 
-macro_rules! fork_array {
-    // Entry
-    (
-        ( $first_ver:literal , $first_epoch:expr )
-        $( , ( $rest_ver:literal , $rest_epoch:expr ) )* $(,)?
-    ) => {
-        fork_array!(@internal (
-            Fork {
-                previous_version: fixed_bytes!($first_ver),
-                current_version:  fixed_bytes!($first_ver),
-                epoch:            $first_epoch,
-            }
-        ), $first_ver $( , $rest_ver , $rest_epoch )* )
-    };
-
-    // Recursive case
-    (@internal (
-        $( $forks:expr ),*
-    ), $prev_ver:literal , $curr_ver:literal , $curr_epoch:expr
-       $( , $tail_ver:literal , $tail_epoch:expr )* ) => {
-        fork_array!(@internal (
-            $( $forks ),* ,
-            Fork {
-                previous_version: fixed_bytes!($prev_ver),
-                current_version:  fixed_bytes!($curr_ver),
-                epoch:            $curr_epoch,
-            }
-        ), $curr_ver $( , $tail_ver , $tail_epoch )* )
-    };
-
-    // Final case
-    (@internal (
-        $( $forks:expr ),*
-    ), $last_ver:literal ) => {
-        [ $( $forks ),* ]
-    };
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ForkSchedule(pub [Fork; ForkSchedule::TOTAL]);
 
 impl ForkSchedule {
-    pub const TOTAL: usize = 1;
+    pub const TOTAL: usize = 6;
 
     pub const fn new(forks: [Fork; ForkSchedule::TOTAL]) -> Self {
         Self(forks)
@@ -58,57 +20,5 @@ impl ForkSchedule {
     pub fn scheduled(&self) -> impl Iterator<Item = &Fork> {
         self.iter()
             .filter(|fork| fork.epoch != Fork::UNSCHEDULED_EPOCH)
-    }
-}
-
-pub const MAINNET_FORK_SCHEDULE: ForkSchedule = ForkSchedule::new(fork_array!(
-    ("0x05000000", 364_032), // Electra
-));
-
-pub const HOLESKY_FORK_SCHEDULE: ForkSchedule = ForkSchedule::new(fork_array!(
-    ("0x06017000", 115_968), // Electra
-));
-
-pub const SEPOLIA_FORK_SCHEDULE: ForkSchedule = ForkSchedule::new(fork_array!(
-    ("0x90000074", 222_464), // Electra
-));
-
-pub const HOODI_FORK_SCHEDULE: ForkSchedule = ForkSchedule::new(fork_array!(
-    ("0x60000910", 2_048), // Electra
-));
-
-pub const DEV_FORK_SCHEDULE: ForkSchedule = ForkSchedule::new(fork_array!(
-    ("0x05000000", 364_032), // Electra
-));
-
-#[cfg(test)]
-mod tests {
-    use alloy_primitives::fixed_bytes;
-    use ream_consensus::fork::Fork;
-
-    #[test]
-    fn test_fork_array() {
-        let expected = [
-            Fork {
-                previous_version: fixed_bytes!("0x90000069"),
-                current_version: fixed_bytes!("0x90000069"),
-                epoch: 0,
-            },
-            Fork {
-                previous_version: fixed_bytes!("0x90000069"),
-                current_version: fixed_bytes!("0x90000070"),
-                epoch: 50,
-            },
-            Fork {
-                previous_version: fixed_bytes!("0x90000070"),
-                current_version: fixed_bytes!("0x90000071"),
-                epoch: 100,
-            },
-        ];
-
-        assert_eq!(
-            fork_array!(("0x90000069", 0), ("0x90000070", 50), ("0x90000071", 100)),
-            expected
-        );
     }
 }

--- a/crates/common/network_spec/src/lib.rs
+++ b/crates/common/network_spec/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod b32_hex;
 pub mod cli;
 pub mod fork_schedule;
 pub mod networks;

--- a/crates/common/network_spec/src/networks.rs
+++ b/crates/common/network_spec/src/networks.rs
@@ -63,7 +63,8 @@ pub fn network_spec() -> Arc<NetworkSpec> {
 #[serde(rename_all = "UPPERCASE")]
 pub struct NetworkSpec {
     pub preset_base: String,
-    pub config_name: Network,
+    #[serde(rename = "CONFIG_NAME")]
+    pub network: Network,
 
     // Transition
     pub terminal_total_difficulty: U256,
@@ -202,8 +203,9 @@ impl NetworkSpec {
 pub static MAINNET: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
         preset_base: "mainnet".to_string(),
-        config_name: Network::Mainnet,
-        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        network: Network::Mainnet,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000")
+            .expect("Could not get U256"),
         terminal_block_hash: b256!(
             "0x0000000000000000000000000000000000000000000000000000000000000000"
         ),
@@ -270,8 +272,9 @@ pub static MAINNET: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
 pub static HOLESKY: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
         preset_base: "mainnet".to_string(),
-        config_name: Network::Holesky,
-        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        network: Network::Holesky,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000")
+            .expect("Could not get U256"),
         terminal_block_hash: b256!(
             "0x0000000000000000000000000000000000000000000000000000000000000000"
         ),
@@ -338,8 +341,9 @@ pub static HOLESKY: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
 pub static SEPOLIA: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
         preset_base: "mainnet".to_string(),
-        config_name: Network::Sepolia,
-        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        network: Network::Sepolia,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000")
+            .expect("Could not get U256"),
         terminal_block_hash: b256!(
             "0x0000000000000000000000000000000000000000000000000000000000000000"
         ),
@@ -406,8 +410,9 @@ pub static SEPOLIA: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
 pub static HOODI: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
         preset_base: "mainnet".to_string(),
-        config_name: Network::Hoodi,
-        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        network: Network::Hoodi,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000")
+            .expect("Could not get U256"),
         terminal_block_hash: b256!(
             "0x0000000000000000000000000000000000000000000000000000000000000000"
         ),
@@ -474,8 +479,9 @@ pub static HOODI: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
 pub static DEV: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
         preset_base: "mainnet".to_string(),
-        config_name: Network::Dev,
-        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        network: Network::Dev,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000")
+            .expect("Could not get U256"),
         terminal_block_hash: b256!(
             "0x0000000000000000000000000000000000000000000000000000000000000000"
         ),

--- a/crates/common/network_spec/src/networks.rs
+++ b/crates/common/network_spec/src/networks.rs
@@ -1,30 +1,36 @@
-use std::sync::{Arc, LazyLock, OnceLock};
-
-use alloy_primitives::{Address, address, aliases::B32, b256, fixed_bytes};
-use ream_consensus::{fork_data::ForkData, genesis::Genesis};
-
-use crate::fork_schedule::{
-    DEV_FORK_SCHEDULE, ForkSchedule, HOLESKY_FORK_SCHEDULE, HOODI_FORK_SCHEDULE,
-    MAINNET_FORK_SCHEDULE, SEPOLIA_FORK_SCHEDULE,
+use std::{
+    str::FromStr,
+    sync::{Arc, LazyLock, OnceLock},
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+use alloy_primitives::{Address, B256, U256, address, aliases::B32, b256, fixed_bytes};
+use ream_consensus::{fork::Fork, fork_data::ForkData, misc::checksummed_address};
+use serde::Deserialize;
+
+use crate::fork_schedule::ForkSchedule;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Network {
     Mainnet,
     Holesky,
     Sepolia,
     Hoodi,
     Dev,
+    Custom(String),
 }
 
-impl Network {
-    pub fn chain_id(&self) -> u64 {
-        match self {
-            Network::Mainnet => 1,
-            Network::Holesky => 17000,
-            Network::Sepolia => 11155111,
-            Network::Hoodi => 560048,
-            Network::Dev => 1,
+impl<'de> Deserialize<'de> for Network {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match String::deserialize(deserializer)?.as_str() {
+            "mainnet" => Ok(Network::Mainnet),
+            "holesky" => Ok(Network::Holesky),
+            "sepolia" => Ok(Network::Sepolia),
+            "hoodi" => Ok(Network::Hoodi),
+            "dev" => Ok(Network::Dev),
+            custom => Ok(Network::Custom(custom.to_string())),
         }
     }
 }
@@ -53,103 +59,482 @@ pub fn network_spec() -> Arc<NetworkSpec> {
     NETWORK_SPEC.get().expect("NetworkSpec wasn't set").clone()
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
 pub struct NetworkSpec {
-    pub network: Network,
-    pub genesis: Genesis,
+    pub preset_base: String,
+    pub config_name: Network,
+
+    // Transition
+    pub terminal_total_difficulty: U256,
+    #[serde(with = "serde_utils::b256_hex")]
+    pub terminal_block_hash: B256,
+    pub terminal_block_hash_activation_epoch: u64,
+
+    // Genesis
+    pub min_genesis_active_validator_count: u64,
+    pub min_genesis_time: u64,
+    #[serde(with = "crate::b32_hex")]
+    pub genesis_fork_version: B32,
+    pub genesis_delay: u64,
+
+    // Forking
+    #[serde(with = "crate::b32_hex")]
+    pub altair_fork_version: B32,
+    pub altair_fork_epoch: u64,
+    #[serde(with = "crate::b32_hex")]
+    pub bellatrix_fork_version: B32,
+    pub bellatrix_fork_epoch: u64,
+    #[serde(with = "crate::b32_hex")]
+    pub capella_fork_version: B32,
+    pub capella_fork_epoch: u64,
+    #[serde(with = "crate::b32_hex")]
+    pub deneb_fork_version: B32,
+    pub deneb_fork_epoch: u64,
+    #[serde(with = "crate::b32_hex")]
+    pub electra_fork_version: B32,
+    pub electra_fork_epoch: u64,
+
+    // Time parameters
+    pub seconds_per_slot: u64,
+    pub seconds_per_eth1_block: u64,
+    pub min_validator_withdrawability_delay: u64,
+    pub shard_committee_period: u64,
+    pub eth1_follow_distance: u64,
+
+    // Validator cycle
+    pub inactivity_score_bias: u64,
+    pub inactivity_score_recovery_rate: u64,
+    pub ejection_balance: u64,
+    pub min_per_epoch_churn_limit: u64,
+    pub churn_limit_quotient: u64,
+    pub max_per_epoch_activation_churn_limit: u64,
+
+    // Fork choice
+    pub proposer_score_boost: u64,
+    pub reorg_head_weight_threshold: u64,
+    pub reorg_parent_weight_threshold: u64,
+    pub reorg_max_epochs_since_finalization: u64,
+
+    // Deposit contract
+    pub deposit_chain_id: u64,
+    pub deposit_network_id: u64,
+    #[serde(with = "checksummed_address")]
     pub deposit_contract_address: Address,
-    pub fork_schedule: ForkSchedule,
+
+    // Networking
+    pub max_payload_size: u64,
+    pub max_request_blocks: u64,
+    pub epochs_per_subnet_subscription: u64,
+    pub min_epochs_for_block_requests: u64,
+    pub ttfb_timeout: u64,
+    pub resp_timeout: u64,
+    pub attestation_propagation_slot_range: u64,
+    pub maximum_gossip_clock_disparity: u64,
+    #[serde(with = "crate::b32_hex")]
+    pub message_domain_invalid_snappy: B32,
+    #[serde(with = "crate::b32_hex")]
+    pub message_domain_valid_snappy: B32,
+    pub subnets_per_node: u64,
+    pub attestation_subnet_count: u64,
+    pub attestation_subnet_extra_bits: u64,
+    pub attestation_subnet_prefix_bits: u64,
+
+    // Deneb
+    pub max_request_blocks_deneb: u64,
+    pub max_request_blob_sidecars: u64,
+    pub min_epochs_for_blob_sidecars_requests: u64,
+    pub blob_sidecar_subnet_count: u64,
+
+    // Electra
+    pub min_per_epoch_churn_limit_electra: u64,
+    pub max_per_epoch_activation_exit_churn_limit: u64,
+    pub blob_sidecar_subnet_count_electra: u64,
+    pub max_blobs_per_block_electra: u64,
+    pub max_request_blob_sidecars_electra: u64,
 }
 
 impl NetworkSpec {
-    pub fn fork_digest(&self) -> B32 {
-        let Some(latest_fork) = self.fork_schedule.iter().last() else {
-            unreachable!("Fork schedule is empty");
-        };
+    pub fn fork_digest(&self, genesis_validators_root: B256) -> B32 {
         ForkData {
-            current_version: latest_fork.current_version,
-            genesis_validators_root: self.genesis.genesis_validators_root,
+            current_version: self.electra_fork_version,
+            genesis_validators_root,
         }
         .compute_fork_digest()
+    }
+
+    pub fn fork_schedule(&self) -> ForkSchedule {
+        ForkSchedule([
+            Fork {
+                previous_version: self.genesis_fork_version,
+                current_version: self.genesis_fork_version,
+                epoch: 0,
+            },
+            Fork {
+                previous_version: self.genesis_fork_version,
+                current_version: self.altair_fork_version,
+                epoch: self.altair_fork_epoch,
+            },
+            Fork {
+                previous_version: self.altair_fork_version,
+                current_version: self.bellatrix_fork_version,
+                epoch: self.bellatrix_fork_epoch,
+            },
+            Fork {
+                previous_version: self.bellatrix_fork_version,
+                current_version: self.capella_fork_version,
+                epoch: self.capella_fork_epoch,
+            },
+            Fork {
+                previous_version: self.capella_fork_version,
+                current_version: self.deneb_fork_version,
+                epoch: self.deneb_fork_epoch,
+            },
+            Fork {
+                previous_version: self.deneb_fork_version,
+                current_version: self.electra_fork_version,
+                epoch: self.electra_fork_epoch,
+            },
+        ])
     }
 }
 
 pub static MAINNET: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
-        network: Network::Mainnet,
-        genesis: Genesis {
-            genesis_time: 1606824023,
-            genesis_validators_root: b256!(
-                "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95"
-            ),
-            genesis_fork_version: fixed_bytes!("0x00000000"),
-        },
+        preset_base: "mainnet".to_string(),
+        config_name: Network::Mainnet,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        terminal_block_hash: b256!(
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ),
+        terminal_block_hash_activation_epoch: 18446744073709551615,
+        min_genesis_active_validator_count: 16384,
+        min_genesis_time: 1606824000,
+        genesis_fork_version: fixed_bytes!("0x00000000"),
+        genesis_delay: 604800,
+        altair_fork_version: fixed_bytes!("0x01000000"),
+        altair_fork_epoch: 74240,
+        bellatrix_fork_version: fixed_bytes!("0x02000000"),
+        bellatrix_fork_epoch: 144896,
+        capella_fork_version: fixed_bytes!("0x03000000"),
+        capella_fork_epoch: 194048,
+        deneb_fork_version: fixed_bytes!("0x04000000"),
+        deneb_fork_epoch: 269568,
+        electra_fork_version: fixed_bytes!("0x05000000"),
+        electra_fork_epoch: 364032,
+        seconds_per_slot: 12,
+        seconds_per_eth1_block: 14,
+        min_validator_withdrawability_delay: 256,
+        shard_committee_period: 256,
+        eth1_follow_distance: 2048,
+        inactivity_score_bias: 4,
+        inactivity_score_recovery_rate: 16,
+        ejection_balance: 16000000000,
+        min_per_epoch_churn_limit: 4,
+        churn_limit_quotient: 65536,
+        max_per_epoch_activation_churn_limit: 8,
+        proposer_score_boost: 40,
+        reorg_head_weight_threshold: 20,
+        reorg_parent_weight_threshold: 160,
+        reorg_max_epochs_since_finalization: 2,
+        deposit_chain_id: 1,
+        deposit_network_id: 1,
         deposit_contract_address: address!("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
-        fork_schedule: MAINNET_FORK_SCHEDULE,
+        max_payload_size: 10485760,
+        max_request_blocks: 1024,
+        epochs_per_subnet_subscription: 256,
+        min_epochs_for_block_requests: 33024,
+        ttfb_timeout: 5,
+        resp_timeout: 10,
+        attestation_propagation_slot_range: 32,
+        maximum_gossip_clock_disparity: 500,
+        message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
+        message_domain_valid_snappy: fixed_bytes!("0x01000000"),
+        subnets_per_node: 2,
+        attestation_subnet_count: 64,
+        attestation_subnet_extra_bits: 0,
+        attestation_subnet_prefix_bits: 6,
+        max_request_blocks_deneb: 128,
+        max_request_blob_sidecars: 768,
+        min_epochs_for_blob_sidecars_requests: 4096,
+        blob_sidecar_subnet_count: 6,
+        min_per_epoch_churn_limit_electra: 128000000000,
+        max_per_epoch_activation_exit_churn_limit: 256000000000,
+        blob_sidecar_subnet_count_electra: 9,
+        max_blobs_per_block_electra: 9,
+        max_request_blob_sidecars_electra: 1152,
     }
     .into()
 });
 
 pub static HOLESKY: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
-        network: Network::Holesky,
-        genesis: Genesis {
-            genesis_time: 1727505000,
-            genesis_validators_root: b256!(
-                "0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1"
-            ),
-            genesis_fork_version: fixed_bytes!("0x01017000"),
-        },
+        preset_base: "mainnet".to_string(),
+        config_name: Network::Holesky,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        terminal_block_hash: b256!(
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ),
+        terminal_block_hash_activation_epoch: 18446744073709551615,
+        min_genesis_active_validator_count: 16384,
+        min_genesis_time: 1695902100,
+        genesis_fork_version: fixed_bytes!("0x01017000"),
+        genesis_delay: 300,
+        altair_fork_version: fixed_bytes!("0x02017000"),
+        altair_fork_epoch: 0,
+        bellatrix_fork_version: fixed_bytes!("0x03017000"),
+        bellatrix_fork_epoch: 0,
+        capella_fork_version: fixed_bytes!("0x04017000"),
+        capella_fork_epoch: 256,
+        deneb_fork_version: fixed_bytes!("0x05017000"),
+        deneb_fork_epoch: 29696,
+        electra_fork_version: fixed_bytes!("0x06017000"),
+        electra_fork_epoch: 115968,
+        seconds_per_slot: 12,
+        seconds_per_eth1_block: 14,
+        min_validator_withdrawability_delay: 256,
+        shard_committee_period: 256,
+        eth1_follow_distance: 2048,
+        inactivity_score_bias: 4,
+        inactivity_score_recovery_rate: 16,
+        ejection_balance: 16000000000,
+        min_per_epoch_churn_limit: 4,
+        churn_limit_quotient: 65536,
+        max_per_epoch_activation_churn_limit: 8,
+        proposer_score_boost: 40,
+        reorg_head_weight_threshold: 20,
+        reorg_parent_weight_threshold: 160,
+        reorg_max_epochs_since_finalization: 2,
+        deposit_chain_id: 1,
+        deposit_network_id: 1,
         deposit_contract_address: address!("0x4242424242424242424242424242424242424242"),
-        fork_schedule: HOLESKY_FORK_SCHEDULE,
+        max_payload_size: 10485760,
+        max_request_blocks: 1024,
+        epochs_per_subnet_subscription: 256,
+        min_epochs_for_block_requests: 33024,
+        ttfb_timeout: 5,
+        resp_timeout: 10,
+        attestation_propagation_slot_range: 32,
+        maximum_gossip_clock_disparity: 500,
+        message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
+        message_domain_valid_snappy: fixed_bytes!("0x01000000"),
+        subnets_per_node: 2,
+        attestation_subnet_count: 64,
+        attestation_subnet_extra_bits: 0,
+        attestation_subnet_prefix_bits: 6,
+        max_request_blocks_deneb: 128,
+        max_request_blob_sidecars: 768,
+        min_epochs_for_blob_sidecars_requests: 4096,
+        blob_sidecar_subnet_count: 6,
+        min_per_epoch_churn_limit_electra: 128000000000,
+        max_per_epoch_activation_exit_churn_limit: 256000000000,
+        blob_sidecar_subnet_count_electra: 9,
+        max_blobs_per_block_electra: 9,
+        max_request_blob_sidecars_electra: 1152,
     }
     .into()
 });
 
 pub static SEPOLIA: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
-        network: Network::Sepolia,
-        genesis: Genesis {
-            genesis_time: 1655713800,
-            genesis_validators_root: b256!(
-                "0xd8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078"
-            ),
-            genesis_fork_version: fixed_bytes!("0x90000069"),
-        },
+        preset_base: "mainnet".to_string(),
+        config_name: Network::Sepolia,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        terminal_block_hash: b256!(
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ),
+        terminal_block_hash_activation_epoch: 18446744073709551615,
+        min_genesis_active_validator_count: 1300,
+        min_genesis_time: 1655647200,
+        genesis_fork_version: fixed_bytes!("0x90000069"),
+        genesis_delay: 86400,
+        altair_fork_version: fixed_bytes!("0x90000070"),
+        altair_fork_epoch: 50,
+        bellatrix_fork_version: fixed_bytes!("0x90000071"),
+        bellatrix_fork_epoch: 100,
+        capella_fork_version: fixed_bytes!("0x90000072"),
+        capella_fork_epoch: 56832,
+        deneb_fork_version: fixed_bytes!("0x90000073"),
+        deneb_fork_epoch: 132608,
+        electra_fork_version: fixed_bytes!("0x90000074"),
+        electra_fork_epoch: 222464,
+        seconds_per_slot: 12,
+        seconds_per_eth1_block: 14,
+        min_validator_withdrawability_delay: 256,
+        shard_committee_period: 256,
+        eth1_follow_distance: 2048,
+        inactivity_score_bias: 4,
+        inactivity_score_recovery_rate: 16,
+        ejection_balance: 16000000000,
+        min_per_epoch_churn_limit: 4,
+        churn_limit_quotient: 65536,
+        max_per_epoch_activation_churn_limit: 8,
+        proposer_score_boost: 40,
+        reorg_head_weight_threshold: 20,
+        reorg_parent_weight_threshold: 160,
+        reorg_max_epochs_since_finalization: 2,
+        deposit_chain_id: 1,
+        deposit_network_id: 1,
         deposit_contract_address: address!("0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D"),
-        fork_schedule: SEPOLIA_FORK_SCHEDULE,
+        max_payload_size: 10485760,
+        max_request_blocks: 1024,
+        epochs_per_subnet_subscription: 256,
+        min_epochs_for_block_requests: 33024,
+        ttfb_timeout: 5,
+        resp_timeout: 10,
+        attestation_propagation_slot_range: 32,
+        maximum_gossip_clock_disparity: 500,
+        message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
+        message_domain_valid_snappy: fixed_bytes!("0x01000000"),
+        subnets_per_node: 2,
+        attestation_subnet_count: 64,
+        attestation_subnet_extra_bits: 0,
+        attestation_subnet_prefix_bits: 6,
+        max_request_blocks_deneb: 128,
+        max_request_blob_sidecars: 768,
+        min_epochs_for_blob_sidecars_requests: 4096,
+        blob_sidecar_subnet_count: 6,
+        min_per_epoch_churn_limit_electra: 128000000000,
+        max_per_epoch_activation_exit_churn_limit: 256000000000,
+        blob_sidecar_subnet_count_electra: 9,
+        max_blobs_per_block_electra: 9,
+        max_request_blob_sidecars_electra: 1152,
     }
     .into()
 });
 
 pub static HOODI: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
-        network: Network::Hoodi,
-        genesis: Genesis {
-            genesis_time: 1742193600,
-            genesis_validators_root: b256!(
-                "0x212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f"
-            ),
-            genesis_fork_version: fixed_bytes!("0x10000910"),
-        },
+        preset_base: "mainnet".to_string(),
+        config_name: Network::Hoodi,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        terminal_block_hash: b256!(
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ),
+        terminal_block_hash_activation_epoch: 18446744073709551615,
+        min_genesis_active_validator_count: 16384,
+        min_genesis_time: 1742212800,
+        genesis_fork_version: fixed_bytes!("0x10000910"),
+        genesis_delay: 600,
+        altair_fork_version: fixed_bytes!("0x20000910"),
+        altair_fork_epoch: 0,
+        bellatrix_fork_version: fixed_bytes!("0x30000910"),
+        bellatrix_fork_epoch: 0,
+        capella_fork_version: fixed_bytes!("0x40000910"),
+        capella_fork_epoch: 0,
+        deneb_fork_version: fixed_bytes!("0x50000910"),
+        deneb_fork_epoch: 0,
+        electra_fork_version: fixed_bytes!("0x60000910"),
+        electra_fork_epoch: 2048,
+        seconds_per_slot: 12,
+        seconds_per_eth1_block: 14,
+        min_validator_withdrawability_delay: 256,
+        shard_committee_period: 256,
+        eth1_follow_distance: 2048,
+        inactivity_score_bias: 4,
+        inactivity_score_recovery_rate: 16,
+        ejection_balance: 16000000000,
+        min_per_epoch_churn_limit: 4,
+        churn_limit_quotient: 65536,
+        max_per_epoch_activation_churn_limit: 8,
+        proposer_score_boost: 40,
+        reorg_head_weight_threshold: 20,
+        reorg_parent_weight_threshold: 160,
+        reorg_max_epochs_since_finalization: 2,
+        deposit_chain_id: 1,
+        deposit_network_id: 1,
         deposit_contract_address: address!("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
-        fork_schedule: HOODI_FORK_SCHEDULE,
+        max_payload_size: 10485760,
+        max_request_blocks: 1024,
+        epochs_per_subnet_subscription: 256,
+        min_epochs_for_block_requests: 33024,
+        ttfb_timeout: 5,
+        resp_timeout: 10,
+        attestation_propagation_slot_range: 32,
+        maximum_gossip_clock_disparity: 500,
+        message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
+        message_domain_valid_snappy: fixed_bytes!("0x01000000"),
+        subnets_per_node: 2,
+        attestation_subnet_count: 64,
+        attestation_subnet_extra_bits: 0,
+        attestation_subnet_prefix_bits: 6,
+        max_request_blocks_deneb: 128,
+        max_request_blob_sidecars: 768,
+        min_epochs_for_blob_sidecars_requests: 4096,
+        blob_sidecar_subnet_count: 6,
+        min_per_epoch_churn_limit_electra: 128000000000,
+        max_per_epoch_activation_exit_churn_limit: 256000000000,
+        blob_sidecar_subnet_count_electra: 9,
+        max_blobs_per_block_electra: 9,
+        max_request_blob_sidecars_electra: 1152,
     }
     .into()
 });
 
 pub static DEV: LazyLock<Arc<NetworkSpec>> = LazyLock::new(|| {
     NetworkSpec {
-        network: Network::Dev,
-        genesis: Genesis {
-            genesis_time: 1606824023,
-            genesis_validators_root: b256!(
-                "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95"
-            ),
-            genesis_fork_version: fixed_bytes!("0x00000000"),
-        },
+        preset_base: "mainnet".to_string(),
+        config_name: Network::Dev,
+        terminal_total_difficulty: U256::from_str("58750000000000000000000").unwrap(),
+        terminal_block_hash: b256!(
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ),
+        terminal_block_hash_activation_epoch: 18446744073709551615,
+        min_genesis_active_validator_count: 16384,
+        min_genesis_time: 1606824000,
+        genesis_fork_version: fixed_bytes!("0x00000000"),
+        genesis_delay: 604800,
+        altair_fork_version: fixed_bytes!("0x01000000"),
+        altair_fork_epoch: 74240,
+        bellatrix_fork_version: fixed_bytes!("0x02000000"),
+        bellatrix_fork_epoch: 144896,
+        capella_fork_version: fixed_bytes!("0x03000000"),
+        capella_fork_epoch: 194048,
+        deneb_fork_version: fixed_bytes!("0x04000000"),
+        deneb_fork_epoch: 269568,
+        electra_fork_version: fixed_bytes!("0x05000000"),
+        electra_fork_epoch: 364032,
+        seconds_per_slot: 12,
+        seconds_per_eth1_block: 14,
+        min_validator_withdrawability_delay: 256,
+        shard_committee_period: 256,
+        eth1_follow_distance: 2048,
+        inactivity_score_bias: 4,
+        inactivity_score_recovery_rate: 16,
+        ejection_balance: 16000000000,
+        min_per_epoch_churn_limit: 4,
+        churn_limit_quotient: 65536,
+        max_per_epoch_activation_churn_limit: 8,
+        proposer_score_boost: 40,
+        reorg_head_weight_threshold: 20,
+        reorg_parent_weight_threshold: 160,
+        reorg_max_epochs_since_finalization: 2,
+        deposit_chain_id: 1,
+        deposit_network_id: 1,
         deposit_contract_address: address!("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
-        fork_schedule: DEV_FORK_SCHEDULE,
+        max_payload_size: 10485760,
+        max_request_blocks: 1024,
+        epochs_per_subnet_subscription: 256,
+        min_epochs_for_block_requests: 33024,
+        ttfb_timeout: 5,
+        resp_timeout: 10,
+        attestation_propagation_slot_range: 32,
+        maximum_gossip_clock_disparity: 500,
+        message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
+        message_domain_valid_snappy: fixed_bytes!("0x01000000"),
+        subnets_per_node: 2,
+        attestation_subnet_count: 64,
+        attestation_subnet_extra_bits: 0,
+        attestation_subnet_prefix_bits: 6,
+        max_request_blocks_deneb: 128,
+        max_request_blob_sidecars: 768,
+        min_epochs_for_blob_sidecars_requests: 4096,
+        blob_sidecar_subnet_count: 6,
+        min_per_epoch_churn_limit_electra: 128000000000,
+        max_per_epoch_activation_exit_churn_limit: 256000000000,
+        blob_sidecar_subnet_count_electra: 9,
+        max_blobs_per_block_electra: 9,
+        max_request_blob_sidecars_electra: 1152,
     }
     .into()
 });

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -21,6 +21,7 @@ use libp2p::{
         THandlerOutEvent, ToSwarm, dummy::ConnectionHandler,
     },
 };
+use ream_consensus::constants::MAINNET_GENESIS_VALIDATORS_ROOT;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
@@ -74,7 +75,10 @@ impl Discovery {
         enr_builder.udp4(config.discovery_port);
 
         let enr = enr_builder
-            .add_value(ENR_ETH2_KEY, &EnrForkId::electra())
+            .add_value(
+                ENR_ETH2_KEY,
+                &EnrForkId::electra(MAINNET_GENESIS_VALIDATORS_ROOT),
+            )
             .add_value(ATTESTATION_BITFIELD_ENR_KEY, &config.subnets)
             .build(&enr_local)
             .map_err(|err| anyhow!("Failed to build ENR: {err}"))?;

--- a/crates/networking/discv5/src/eth2.rs
+++ b/crates/networking/discv5/src/eth2.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Bytes, aliases::B32, bytes};
+use alloy_primitives::{B256, Bytes, aliases::B32, bytes};
 use alloy_rlp::{Decodable, Encodable};
 use ream_consensus::{constants::FAR_FUTURE_EPOCH, fork_data::ForkData};
 use ream_network_spec::networks::network_spec;
@@ -15,14 +15,14 @@ pub struct EnrForkId {
 }
 
 impl EnrForkId {
-    pub fn electra() -> Self {
-        let current_fork_version = network_spec().fork_schedule.0[0].current_version;
+    pub fn electra(genesis_validators_root: B256) -> Self {
+        let current_fork_version = network_spec().electra_fork_version;
         let next_fork_version = current_fork_version;
         let next_fork_epoch = FAR_FUTURE_EPOCH;
 
         let fork_digest = ForkData {
             current_version: current_fork_version,
-            genesis_validators_root: network_spec().genesis.genesis_validators_root,
+            genesis_validators_root,
         }
         .compute_fork_digest();
 

--- a/crates/networking/p2p/src/bootnodes.rs
+++ b/crates/networking/p2p/src/bootnodes.rs
@@ -48,7 +48,7 @@ impl Bootnodes {
                 serde_yaml::from_str(include_str!("../resources/bootnodes_hoodi.yaml"))
                     .expect("should deserialize bootnodes")
             }
-            Network::Dev => vec![],
+            Network::Dev | Network::Custom(_) => vec![],
         };
 
         match self {

--- a/crates/networking/p2p/src/req_resp/inbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/inbound_protocol.rs
@@ -15,6 +15,7 @@ use libp2p::{
     bytes::{Buf, BufMut},
     core::UpgradeInfo,
 };
+use ream_consensus::constants::MAINNET_GENESIS_VALIDATORS_ROOT;
 use ream_network_spec::networks::network_spec;
 use snap::{read::FrameDecoder, write::FrameEncoder};
 use ssz::{Decode, Encode};
@@ -134,7 +135,7 @@ impl Encoder<RespMessage> for InboundSSZSnappyCodec {
         }
 
         if self.protocol.protocol.has_context_bytes() && response_code == ResponseCode::Success {
-            dst.extend(network_spec().fork_digest());
+            dst.extend(network_spec().fork_digest(MAINNET_GENESIS_VALIDATORS_ROOT));
         }
 
         Uvi::<usize>::default().encode(bytes.len(), dst)?;

--- a/crates/networking/p2p/src/req_resp/outbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/outbound_protocol.rs
@@ -11,6 +11,7 @@ use futures::{
     prelude::{AsyncRead, AsyncWrite},
 };
 use libp2p::{OutboundUpgrade, bytes::Buf, core::UpgradeInfo};
+use ream_consensus::constants::MAINNET_GENESIS_VALIDATORS_ROOT;
 use ream_network_spec::networks::network_spec;
 use snap::{read::FrameDecoder, write::FrameEncoder};
 use ssz::{Decode, Encode};
@@ -144,7 +145,7 @@ impl Decoder for OutboundSSZSnappyCodec {
         }
 
         if let Some(context_bytes) = self.context_bytes {
-            if context_bytes != network_spec().fork_digest() {
+            if context_bytes != network_spec().fork_digest(MAINNET_GENESIS_VALIDATORS_ROOT) {
                 return Ok(Some(RespMessage::Error(ReqRespError::InvalidData(
                     "Invalid context bytes, we only support Electra".to_string(),
                 ))));

--- a/crates/rpc/src/handlers/block.rs
+++ b/crates/rpc/src/handlers/block.rs
@@ -8,10 +8,12 @@ use alloy_primitives::B256;
 use ream_consensus::{
     attester_slashing::AttesterSlashing,
     constants::{
-        EFFECTIVE_BALANCE_INCREMENT, PROPOSER_WEIGHT, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SIZE,
-        SYNC_REWARD_WEIGHT, WEIGHT_DENOMINATOR, WHISTLEBLOWER_REWARD_QUOTIENT,
+        EFFECTIVE_BALANCE_INCREMENT, MAINNET_GENESIS_VALIDATORS_ROOT, PROPOSER_WEIGHT,
+        SLOTS_PER_EPOCH, SYNC_COMMITTEE_SIZE, SYNC_REWARD_WEIGHT, WEIGHT_DENOMINATOR,
+        WHISTLEBLOWER_REWARD_QUOTIENT,
     },
     electra::{beacon_block::SignedBeaconBlock, beacon_state::BeaconState},
+    genesis::Genesis,
 };
 use ream_network_spec::networks::network_spec;
 use ream_storage::{
@@ -203,7 +205,11 @@ pub async fn get_beacon_block_from_id(
 /// Called by `/genesis` to get the Genesis Config of Beacon Chain.
 #[get("/beacon/genesis")]
 pub async fn get_genesis() -> Result<impl Responder, ApiError> {
-    Ok(HttpResponse::Ok().json(DataResponse::new(network_spec().genesis.clone())))
+    Ok(HttpResponse::Ok().json(DataResponse::new(Genesis {
+        genesis_time: network_spec().min_genesis_time,
+        genesis_validators_root: MAINNET_GENESIS_VALIDATORS_ROOT,
+        genesis_fork_version: network_spec().genesis_fork_version,
+    })))
 }
 
 /// Called by `/eth/v2/beacon/blocks/{block_id}/attestations` to get block attestations

--- a/crates/rpc/src/handlers/config.rs
+++ b/crates/rpc/src/handlers/config.rs
@@ -38,7 +38,7 @@ impl From<Arc<NetworkSpec>> for SpecConfig {
     fn from(network_spec: Arc<NetworkSpec>) -> Self {
         Self {
             deposit_contract_address: network_spec.deposit_contract_address,
-            deposit_network_id: network_spec.network.chain_id(),
+            deposit_network_id: network_spec.deposit_chain_id,
             domain_aggregate_and_proof: DOMAIN_AGGREGATE_AND_PROOF,
             inactivity_penalty_quotient: INACTIVITY_PENALTY_QUOTIENT_BELLATRIX,
         }
@@ -57,7 +57,7 @@ pub async fn get_config_deposit_contract() -> Result<impl Responder, ApiError> {
     let network_spec = network_spec();
     Ok(
         HttpResponse::Ok().json(DataResponse::new(DepositContract::new(
-            network_spec.network.chain_id(),
+            network_spec.deposit_chain_id,
             network_spec.deposit_contract_address,
         ))),
     )
@@ -66,7 +66,5 @@ pub async fn get_config_deposit_contract() -> Result<impl Responder, ApiError> {
 /// Called by `config/fork_schedule` to get fork schedule
 #[get("config/fork_schedule")]
 pub async fn get_fork_schedule() -> Result<impl Responder, ApiError> {
-    Ok(HttpResponse::Ok().json(DataResponse::new(
-        network_spec().fork_schedule.scheduled().collect::<Vec<_>>(),
-    )))
+    Ok(HttpResponse::Ok().json(DataResponse::new(network_spec().fork_schedule())))
 }


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: https://github.com/ReamLabs/ream/issues/394 

### How was it implemented/fixed?

I implemented support for reading config.yaml files into the NetworkSpec

In a followup PR I'm going to remove the hardcoded genesis_validators_root, this is required to support networks then mainnet https://github.com/ReamLabs/ream/issues/403