### PR TITLE
feat: fix Beacon API content type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-lab"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33034dd88446a5deb20e42156dbfe43d07e0499345db3ae65b3f51854190531"
+dependencies = [
+ "actix-http",
+ "actix-router",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "actix-web-lab-derive",
+ "ahash",
+ "arc-swap",
+ "bytes",
+ "bytestring",
+ "csv",
+ "derive_more",
+ "form_urlencoded",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "impl-more",
+ "itertools 0.14.0",
+ "local-channel",
+ "mime",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "actix-web-lab-derive"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd80fa0bd6217e482112d9d87a05af8e0f8dec9e3aa51f34816f761c5cf7da7"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -463,6 +512,12 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "ark-ff"
@@ -1285,6 +1340,27 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4586,6 +4662,7 @@ name = "ream-rpc"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "actix-web-lab",
  "alloy-primitives",
  "ethereum_serde_utils",
  "ethereum_ssz",
@@ -5157,6 +5234,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5165,6 +5255,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -5668,6 +5768,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ version = "0.1.0"
 
 [workspace.dependencies]
 actix-web = "4.10.2"
+actix-web-lab = "0.24.1"
 alloy-consensus = { version = "0.15", default-features = false }
 alloy-primitives = { version = "1.1", features = ['serde'] }
 alloy-rlp = { version = "0.3.8", default-features = false, features = ["derive"] }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -20,6 +20,7 @@ ream-storage.workspace = true
 
 #misc
 actix-web.workspace = true
+actix-web-lab.workspace = true
 alloy-primitives.workspace = true
 ethereum_ssz.workspace = true
 ethereum_ssz_derive.workspace = true

--- a/crates/rpc/src/handlers/blob_sidecar.rs
+++ b/crates/rpc/src/handlers/blob_sidecar.rs
@@ -1,7 +1,8 @@
 use actix_web::{
     HttpResponse, Responder, get,
-    web::{Data, Path, Query},
+    web::{Data, Path},
 };
+use actix_web_lab::extract::Query;
 use ream_consensus::blob_sidecar::BlobIdentifier;
 use ream_storage::{db::ReamDB, tables::Table};
 use tracing::error;

--- a/crates/rpc/src/handlers/blob_sidecar.rs
+++ b/crates/rpc/src/handlers/blob_sidecar.rs
@@ -27,8 +27,7 @@ pub async fn get_blob_sidecars(
         for index in indices {
             if index >= &max_index {
                 return Err(ApiError::BadRequest(format!(
-                    "Invalid blob index: {index}, max index is {}",
-                    max_index
+                    "Invalid blob index: {index}, max index is {max_index}"
                 )));
             }
         }

--- a/crates/rpc/src/handlers/blob_sidecar.rs
+++ b/crates/rpc/src/handlers/blob_sidecar.rs
@@ -1,6 +1,6 @@
 use actix_web::{
     HttpResponse, Responder, get,
-    web::{Data, Json, Path},
+    web::{Data, Path, Query},
 };
 use ream_consensus::blob_sidecar::BlobIdentifier;
 use ream_storage::{db::ReamDB, tables::Table};
@@ -16,7 +16,7 @@ use crate::{
 pub async fn get_blob_sidecars(
     db: Data<ReamDB>,
     block_id: Path<ID>,
-    query: Json<BlobSidecarQuery>,
+    query: Query<BlobSidecarQuery>,
 ) -> Result<impl Responder, ApiError> {
     let beacon_block = get_beacon_block_from_id(block_id.into_inner(), &db).await?;
     let block_root = beacon_block.message.tree_hash_root();
@@ -27,7 +27,7 @@ pub async fn get_blob_sidecars(
             if index >= &max_index {
                 return Err(ApiError::BadRequest(format!(
                     "Invalid blob index: {index}, max index is {}",
-                    max_index - 1
+                    max_index
                 )));
             }
         }

--- a/crates/rpc/src/handlers/header.rs
+++ b/crates/rpc/src/handlers/header.rs
@@ -1,6 +1,6 @@
 use actix_web::{
     HttpResponse, Responder, get,
-    web::{Data, Json},
+    web::{Data, Query},
 };
 use alloy_primitives::B256;
 use ream_consensus::beacon_block_header::SignedBeaconBlockHeader;
@@ -39,8 +39,8 @@ impl HeaderData {
 #[get("/beacon/headers")]
 pub async fn get_headers(
     db: Data<ReamDB>,
-    slot: Json<SlotQuery>,
-    parent_root: Json<ParentRootQuery>,
+    slot: Query<SlotQuery>,
+    parent_root: Query<ParentRootQuery>,
 ) -> Result<impl Responder, ApiError> {
     let (header, root) = match (slot.slot, parent_root.parent_root) {
         (None, None) => {

--- a/crates/rpc/src/handlers/state.rs
+++ b/crates/rpc/src/handlers/state.rs
@@ -1,6 +1,6 @@
 use actix_web::{
     HttpResponse, Responder, get,
-    web::{Data, Json, Path},
+    web::{Data, Path, Query},
 };
 use alloy_primitives::B256;
 use ream_consensus::{checkpoint::Checkpoint, electra::beacon_state::BeaconState};
@@ -149,7 +149,7 @@ pub async fn get_state_finality_checkpoint(
 pub async fn get_state_randao(
     db: Data<ReamDB>,
     state_id: Path<ID>,
-    query: Json<EpochQuery>,
+    query: Query<EpochQuery>,
 ) -> Result<impl Responder, ApiError> {
     let state = get_state_from_id(state_id.into_inner(), &db).await?;
 

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -2,7 +2,7 @@ use actix_web::{
     HttpResponse, Responder, get, post,
     web::{Data, Json, Path},
 };
-use actix_web_lab::extract;
+use actix_web_lab::extract::Query;
 use alloy_primitives::map::HashSet;
 use ream_bls::PubKey;
 use ream_consensus::validator::Validator;
@@ -118,8 +118,8 @@ pub async fn validator_status(validator: &Validator, db: &ReamDB) -> Result<Stri
 pub async fn get_validators_from_state(
     db: Data<ReamDB>,
     state_id: Path<ID>,
-    id_query: extract::Query<IdQuery>,
-    status_query: extract::Query<StatusQuery>,
+    id_query: Query<IdQuery>,
+    status_query: Query<StatusQuery>,
 ) -> Result<impl Responder, ApiError> {
     println!("{:?}", id_query);
     if let Some(validator_ids) = &id_query.id {

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -121,7 +121,6 @@ pub async fn get_validators_from_state(
     id_query: Query<IdQuery>,
     status_query: Query<StatusQuery>,
 ) -> Result<impl Responder, ApiError> {
-    println!("{:?}", id_query);
     if let Some(validator_ids) = &id_query.id {
         if validator_ids.len() >= MAX_VALIDATOR_COUNT {
             return Err(ApiError::TooManyValidatorsIds);

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -1,6 +1,6 @@
 use actix_web::{
     HttpResponse, Responder, get, post,
-    web::{Data, Json, Path},
+    web::{Data, Json, Path, Query},
 };
 use alloy_primitives::map::HashSet;
 use ream_bls::PubKey;
@@ -117,8 +117,8 @@ pub async fn validator_status(validator: &Validator, db: &ReamDB) -> Result<Stri
 pub async fn get_validators_from_state(
     db: Data<ReamDB>,
     state_id: Path<ID>,
-    id_query: Json<IdQuery>,
-    status_query: Json<StatusQuery>,
+    id_query: Query<IdQuery>,
+    status_query: Query<StatusQuery>,
 ) -> Result<impl Responder, ApiError> {
     if let Some(validator_ids) = &id_query.id {
         if validator_ids.len() >= MAX_VALIDATOR_COUNT {

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -1,7 +1,8 @@
 use actix_web::{
     HttpResponse, Responder, get, post,
-    web::{Data, Json, Path, Query},
+    web::{Data, Json, Path},
 };
+use actix_web_lab::extract;
 use alloy_primitives::map::HashSet;
 use ream_bls::PubKey;
 use ream_consensus::validator::Validator;
@@ -117,9 +118,10 @@ pub async fn validator_status(validator: &Validator, db: &ReamDB) -> Result<Stri
 pub async fn get_validators_from_state(
     db: Data<ReamDB>,
     state_id: Path<ID>,
-    id_query: Query<IdQuery>,
-    status_query: Query<StatusQuery>,
+    id_query: extract::Query<IdQuery>,
+    status_query: extract::Query<StatusQuery>,
 ) -> Result<impl Responder, ApiError> {
+    println!("{:?}", id_query);
     if let Some(validator_ids) = &id_query.id {
         if validator_ids.len() >= MAX_VALIDATOR_COUNT {
             return Err(ApiError::TooManyValidatorsIds);

--- a/crates/rpc/src/types/query.rs
+++ b/crates/rpc/src/types/query.rs
@@ -1,5 +1,10 @@
+use std::fmt;
+
 use alloy_primitives::B256;
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Deserializer, Serialize,
+    de::{MapAccess, Visitor},
+};
 
 use super::id::ValidatorID;
 
@@ -33,7 +38,7 @@ pub struct IdQuery {
     pub id: Option<Vec<ValidatorID>>,
 }
 
-#[derive(Default, Debug, Deserialize)]
+#[derive(Default, Debug)]
 pub struct BlobSidecarQuery {
     pub indices: Option<Vec<u64>>,
 }
@@ -56,5 +61,50 @@ impl StatusQuery {
             Some(statuses) => statuses.contains(status),
             None => true, // If no statuses specified, accept all
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for BlobSidecarQuery {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BlobSidecarQueryVisitor;
+
+        impl<'de> Visitor<'de> for BlobSidecarQueryVisitor {
+            type Value = BlobSidecarQuery;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a map with zero or more indices fields")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<BlobSidecarQuery, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut indices = Vec::new();
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "indices" => {
+                            indices.push(map.next_value()?);
+                        }
+                        _ => {
+                            let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                Ok(BlobSidecarQuery {
+                    indices: if indices.is_empty() {
+                        None
+                    } else {
+                        Some(indices)
+                    },
+                })
+            }
+        }
+
+        deserializer.deserialize_map(BlobSidecarQueryVisitor)
     }
 }

--- a/crates/rpc/src/types/query.rs
+++ b/crates/rpc/src/types/query.rs
@@ -3,56 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use super::id::ValidatorID;
 
-macro_rules! impl_repeated_param_query {
-    ($name:ident, $field:ident, $ty:ty) => {
-        impl<'de> serde::Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct VisitorImpl;
-
-                impl<'de> serde::de::Visitor<'de> for VisitorImpl {
-                    type Value = $name;
-
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                        formatter.write_str(concat!(
-                            "a map with zero or more ",
-                            stringify!($field),
-                            " fields"
-                        ))
-                    }
-
-                    fn visit_map<M>(self, mut map: M) -> Result<$name, M::Error>
-                    where
-                        M: serde::de::MapAccess<'de>,
-                    {
-                        let mut values = Vec::new();
-
-                        while let Some(key) = map.next_key::<String>()? {
-                            if key == stringify!($field) {
-                                values.push(map.next_value::<$ty>()?);
-                            } else {
-                                let _ = map.next_value::<serde::de::IgnoredAny>()?;
-                            }
-                        }
-
-                        Ok($name {
-                            $field: if values.is_empty() {
-                                None
-                            } else {
-                                Some(values)
-                            },
-                        })
-                    }
-                }
-
-                deserializer.deserialize_map(VisitorImpl)
-            }
-        }
-    };
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EpochQuery {
     pub epoch: Option<u64>,
@@ -78,26 +28,20 @@ pub struct ParentRootQuery {
     pub parent_root: Option<B256>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Deserialize)]
 pub struct IdQuery {
     pub id: Option<Vec<ValidatorID>>,
 }
 
-impl_repeated_param_query!(IdQuery, id, ValidatorID);
-
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Deserialize)]
 pub struct BlobSidecarQuery {
     pub indices: Option<Vec<u64>>,
 }
 
-impl_repeated_param_query!(BlobSidecarQuery, indices, u64);
-
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Deserialize)]
 pub struct StatusQuery {
     pub status: Option<Vec<String>>,
 }
-
-impl_repeated_param_query!(StatusQuery, status, String);
 
 impl StatusQuery {
     pub fn has_status(&self) -> bool {


### PR DESCRIPTION
### What are you trying to achieve?

Fixes #405

### Details:

Some `GET` endpoints were using `Json` as their input which meant they need be passed in the `body` section of the request. As per spec, these endpoints should only have `Path` and `Query` types in the request i.e. the endpoints should look something like this:
```
http://localhost/eth/v1/beacon/blob_sidecars/head?indices=1&indices=4
```
But these were failing in Ream since they were in `Json` format. 
Solely switching from `Json` to `Query` type in `actix-web` does not do the trick because `actix` does not support duplicate name keys in the query as per this [discussion](https://github.com/actix/actix-web/issues/1301) .

Hence the only way to format it as per spec is to implement a custom deserializer ourselves(which I've done and changed it to a macro for ease of use).

Note: This issue pertains only to `GET` endpoints. `POST` endpoints generally require `body` so thats okay


### Testing: 

I've tested the updated implementations and they are all working as expected now.

