### PR TITLE
feat: impl /headers/{block_id} endpoint

### DIFF
--- a/crates/rpc/src/handlers/header.rs
+++ b/crates/rpc/src/handlers/header.rs
@@ -4,10 +4,7 @@ use actix_web::{
 };
 use alloy_primitives::B256;
 use ream_consensus::beacon_block_header::SignedBeaconBlockHeader;
-use ream_storage::{
-    db::ReamDB,
-    tables::{Field, Table},
-};
+use ream_storage::{db::ReamDB, tables::Table};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 use tree_hash::TreeHash;
@@ -46,18 +43,7 @@ pub async fn get_headers(
     parent_root: Query<ParentRootQuery>,
 ) -> Result<impl Responder, ApiError> {
     let (header, root) = match (slot.slot, parent_root.parent_root) {
-        (None, None) => {
-            let slot = db
-                .slot_index_provider()
-                .get_highest_slot()
-                .map_err(|err| {
-                    error!("Failed to get headers, error: {err:?}");
-                    ApiError::InternalError
-                })?
-                .ok_or_else(|| ApiError::NotFound(String::from("Unable to fetch latest slot")))?;
-
-            get_header_from_slot(slot, &db).await?
-        }
+        (None, None) => get_header_from_slot(None, &db).await?,
         (None, Some(parent_root)) => {
             // get parent block to have access to `slot`
             let parent_block = db
@@ -71,7 +57,7 @@ pub async fn get_headers(
 
             // fetch block header at `slot+1`
             let (child_header, child_block_root) =
-                get_header_from_slot(parent_block.message.slot + 1, &db).await?;
+                get_header_from_slot(Some(parent_block.message.slot + 1), &db).await?;
 
             if child_header.message.parent_root != parent_root {
                 return Err(ApiError::NotFound(format!(
@@ -81,9 +67,9 @@ pub async fn get_headers(
 
             (child_header, child_block_root)
         }
-        (Some(slot), None) => get_header_from_slot(slot, &db).await?,
+        (Some(slot), None) => get_header_from_slot(Some(slot), &db).await?,
         (Some(slot), Some(parent_root)) => {
-            let (header, root) = get_header_from_slot(slot, &db).await?;
+            let (header, root) = get_header_from_slot(Some(slot), &db).await?;
             if header.message.parent_root == parent_root {
                 (header, root)
             } else {
@@ -103,67 +89,32 @@ pub async fn get_headers_from_block(
     block_id: Path<ID>,
     db: Data<ReamDB>,
 ) -> Result<impl Responder, ApiError> {
-    let slot = match block_id.into_inner() {
-        ID::Finalized => {
-            let finalized_checkpoint = db.finalized_checkpoint_provider().get().map_err(|err| {
-                error!("Failed to get block by block_root, error: {err:?}");
-                ApiError::InternalError
-            })?;
+    let block = get_beacon_block_from_id(block_id.into_inner(), &db).await?;
+    let header = block.signed_header();
 
-            db.beacon_block_provider()
-                .get(finalized_checkpoint.root)
-                .map_err(|err| {
-                    error!("Failed to get headers, error: {err:?}");
-                    ApiError::InternalError
-                })?
-                .ok_or_else(|| ApiError::NotFound(String::from("Unable to fetch parent block")))?
-                .message
-                .slot
-        }
-        ID::Justified => {
-            let justified_checkpoint = db.justified_checkpoint_provider().get().map_err(|err| {
-                error!("Failed to get block by block_root, error: {err:?}");
-                ApiError::InternalError
-            })?;
-
-            db.beacon_block_provider()
-                .get(justified_checkpoint.root)
-                .map_err(|err| {
-                    error!("Failed to get headers, error: {err:?}");
-                    ApiError::InternalError
-                })?
-                .ok_or_else(|| ApiError::NotFound(String::from("Unable to fetch parent block")))?
-                .message
-                .slot
-        }
-        ID::Head | ID::Genesis => {
-            return Err(ApiError::NotFound(
-                "This ID type is currently not supported: genesis".to_string(),
-            ));
-        }
-        ID::Slot(slot) => slot,
-        ID::Root(root) => {
-            db.beacon_block_provider()
-                .get(root)
-                .map_err(|err| {
-                    error!("Failed to get headers, error: {err:?}");
-                    ApiError::InternalError
-                })?
-                .ok_or_else(|| ApiError::NotFound(String::from("Unable to fetch parent block")))?
-                .message
-                .slot
-        }
-    };
-
-    let (header, root) = get_header_from_slot(slot, &db).await?;
-
-    Ok(HttpResponse::Ok().json(BeaconResponse::new(HeaderData::new(root, true, header))))
+    Ok(HttpResponse::Ok().json(BeaconResponse::new(HeaderData::new(
+        header.message.tree_hash_root(),
+        true,
+        header,
+    ))))
 }
 
 pub async fn get_header_from_slot(
-    slot: u64,
+    slot: Option<u64>,
     db: &ReamDB,
 ) -> Result<(SignedBeaconBlockHeader, B256), ApiError> {
+    let slot = match slot {
+        Some(slot) => slot,
+        None => db
+            .slot_index_provider()
+            .get_highest_slot()
+            .map_err(|err| {
+                error!("Failed to get headers, error: {err:?}");
+                ApiError::InternalError
+            })?
+            .ok_or_else(|| ApiError::NotFound(String::from("Unable to fetch latest slot")))?,
+    };
+
     let beacon_block = get_beacon_block_from_id(ID::Slot(slot), db).await?;
 
     let header = beacon_block.signed_header();

--- a/crates/rpc/src/routes/beacon.rs
+++ b/crates/rpc/src/routes/beacon.rs
@@ -6,7 +6,7 @@ use crate::handlers::{
         get_block_attestations, get_block_from_id, get_block_rewards, get_block_root, get_genesis,
     },
     committee::get_committees,
-    header::get_headers,
+    header::{get_headers, get_headers_from_block},
     state::{
         get_pending_consolidations, get_pending_deposits, get_pending_partial_withdrawals,
         get_state_finality_checkpoint, get_state_fork, get_state_randao, get_state_root,
@@ -25,6 +25,7 @@ pub fn register_beacon_routes(cfg: &mut ServiceConfig) {
         .service(get_committees)
         .service(get_genesis)
         .service(get_headers)
+        .service(get_headers_from_block)
         .service(get_pending_consolidations)
         .service(get_pending_deposits)
         .service(get_pending_partial_withdrawals)


### PR DESCRIPTION
### What are you trying to achieve?

Closes #197 

### How was it implemented/fixed?

Adds endpoint for fetching header based on block root.
[Spec](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeader)
Can be called using:
```
http://127.0.0.1:5052/eth/v1/beacon/headers/<block_id>
```
