### PR TITLE
feat: dynamically initialized genesis_validators_root on start up, instead of using a hardcoded constant

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use clap::Parser;
 use ream::cli::{Cli, Commands};
 use ream_checkpoint_sync::initialize_db_from_checkpoint;
-use ream_consensus::constants::{genesis_validator_spec, set_genesis_validator_root};
+use ream_consensus::constants::{genesis_validators_root, set_genesis_validator_root};
 use ream_discv5::{config::DiscoveryConfig, subnet::Subnets};
 use ream_executor::ReamExecutor;
 use ream_network_spec::networks::{network_spec, set_network_spec};
@@ -99,7 +99,7 @@ async fn main() {
 
             let mut gossipsub_config = GossipsubConfig::default();
             gossipsub_config.set_topics(vec![GossipTopic {
-                fork: network_spec().fork_digest(genesis_validator_spec()),
+                fork: network_spec().fork_digest(genesis_validators_root()),
                 kind: GossipTopicKind::BeaconBlock,
             }]);
 

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use clap::Parser;
 use ream::cli::{Cli, Commands};
 use ream_checkpoint_sync::initialize_db_from_checkpoint;
-use ream_consensus::constants::MAINNET_GENESIS_VALIDATORS_ROOT;
+use ream_consensus::constants::{genesis_validator_spec, set_genesis_validator_root};
 use ream_discv5::{config::DiscoveryConfig, subnet::Subnets};
 use ream_executor::ReamExecutor;
 use ream_network_spec::networks::{network_spec, set_network_spec};
@@ -71,19 +71,6 @@ async fn main() {
                 subnets: Subnets::new(),
             };
 
-            let mut gossipsub_config = GossipsubConfig::default();
-            gossipsub_config.set_topics(vec![GossipTopic {
-                fork: network_spec().fork_digest(MAINNET_GENESIS_VALIDATORS_ROOT),
-                kind: GossipTopicKind::BeaconBlock,
-            }]);
-
-            let network_config = NetworkConfig {
-                socket_address: config.socket_address,
-                socket_port: config.socket_port,
-                discv5_config,
-                gossipsub_config,
-            };
-
             let ream_dir = setup_data_dir(APP_NAME, config.data_dir.clone(), config.ephemeral)
                 .expect("Unable to initialize database directory");
 
@@ -100,6 +87,28 @@ async fn main() {
                 .expect("Unable to initialize database from checkpoint");
 
             info!("Database Initialization completed");
+
+            set_genesis_validator_root(
+                ream_db
+                    .beacon_state_provider()
+                    .first()
+                    .expect("Failed to access beacon state provider")
+                    .expect("No beacon state found")
+                    .genesis_validators_root,
+            );
+
+            let mut gossipsub_config = GossipsubConfig::default();
+            gossipsub_config.set_topics(vec![GossipTopic {
+                fork: network_spec().fork_digest(genesis_validator_spec()),
+                kind: GossipTopicKind::BeaconBlock,
+            }]);
+
+            let network_config = NetworkConfig {
+                socket_address: config.socket_address,
+                socket_port: config.socket_port,
+                discv5_config,
+                gossipsub_config,
+            };
 
             let http_future = start_server(server_config, ream_db);
 

--- a/crates/common/consensus/src/constants.rs
+++ b/crates/common/consensus/src/constants.rs
@@ -142,7 +142,7 @@ pub static GENESIS_VALIDATORS_ROOT: OnceLock<B256> = OnceLock::new();
 pub fn set_genesis_validator_root(genesis_validator_root: B256) {
     GENESIS_VALIDATORS_ROOT
         .set(genesis_validator_root)
-        .expect("NetworkSpec should be set only once at the start of the application");
+        .expect("GENESIS_VALIDATORS_ROOT should be set only once at the start of the application");
 }
 
 /// Returns the static [B256] initialized by [set_genesis_validator_root].
@@ -153,5 +153,5 @@ pub fn set_genesis_validator_root(genesis_validator_root: B256) {
 pub fn genesis_validator_spec() -> B256 {
     *GENESIS_VALIDATORS_ROOT
         .get()
-        .expect("NetworkSpec wasn't set")
+        .expect("GENESIS_VALIDATORS_ROOT wasn't set")
 }

--- a/crates/common/consensus/src/constants.rs
+++ b/crates/common/consensus/src/constants.rs
@@ -134,14 +134,14 @@ pub static GENESIS_VALIDATORS_ROOT: OnceLock<B256> = OnceLock::new();
 /// MUST be called only once at the start of the application to initialize static
 /// [B256].
 ///
-/// The static `B256` can be accessed using [genesis_validator_spec].
+/// The static `B256` can be accessed using [genesis_validators_root].
 ///
 /// # Panics
 ///
 /// Panics if this function is called more than once.
-pub fn set_genesis_validator_root(genesis_validator_root: B256) {
+pub fn set_genesis_validator_root(genesis_validators_root: B256) {
     GENESIS_VALIDATORS_ROOT
-        .set(genesis_validator_root)
+        .set(genesis_validators_root)
         .expect("GENESIS_VALIDATORS_ROOT should be set only once at the start of the application");
 }
 
@@ -150,7 +150,7 @@ pub fn set_genesis_validator_root(genesis_validator_root: B256) {
 /// # Panics
 ///
 /// Panics if [set_genesis_validator_root] wasn't called before this function.
-pub fn genesis_validator_spec() -> B256 {
+pub fn genesis_validators_root() -> B256 {
     *GENESIS_VALIDATORS_ROOT
         .get()
         .expect("GENESIS_VALIDATORS_ROOT wasn't set")

--- a/crates/common/consensus/src/constants.rs
+++ b/crates/common/consensus/src/constants.rs
@@ -1,4 +1,6 @@
-use alloy_primitives::{B256, aliases::B32, b256, fixed_bytes};
+use std::sync::OnceLock;
+
+use alloy_primitives::{B256, aliases::B32, fixed_bytes};
 
 pub const BASE_REWARDS_PER_EPOCH: u64 = 4;
 pub const BASE_REWARD_FACTOR: u64 = 64;
@@ -127,7 +129,29 @@ pub const PARTICIPATION_FLAG_WEIGHTS: [u64; NUM_FLAG_INDICES] = [
     TIMELY_HEAD_WEIGHT,
 ];
 
-/// todo: genesis validators root is apart of the state, refactor the code to dynamically determine
-/// this on startup
-pub const MAINNET_GENESIS_VALIDATORS_ROOT: B256 =
-    b256!("0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95");
+pub static GENESIS_VALIDATORS_ROOT: OnceLock<B256> = OnceLock::new();
+
+/// MUST be called only once at the start of the application to initialize static
+/// [B256].
+///
+/// The static `B256` can be accessed using [genesis_validator_spec].
+///
+/// # Panics
+///
+/// Panics if this function is called more than once.
+pub fn set_genesis_validator_root(genesis_validator_root: B256) {
+    GENESIS_VALIDATORS_ROOT
+        .set(genesis_validator_root)
+        .expect("NetworkSpec should be set only once at the start of the application");
+}
+
+/// Returns the static [B256] initialized by [set_genesis_validator_root].
+///
+/// # Panics
+///
+/// Panics if [set_genesis_validator_root] wasn't called before this function.
+pub fn genesis_validator_spec() -> B256 {
+    *GENESIS_VALIDATORS_ROOT
+        .get()
+        .expect("NetworkSpec wasn't set")
+}

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -310,7 +310,9 @@ fn convert_to_enr(key: Keypair) -> anyhow::Result<CombinedKey> {
 mod tests {
     use std::net::Ipv4Addr;
 
+    use alloy_primitives::B256;
     use libp2p::identity::Keypair;
+    use ream_consensus::constants::GENESIS_VALIDATORS_ROOT;
     use ream_network_spec::networks::{DEV, set_network_spec};
 
     use super::*;
@@ -318,6 +320,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_initial_subnet_setup() -> anyhow::Result<()> {
+        let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);
         set_network_spec(DEV.clone());
         let key = Keypair::generate_secp256k1();
         let mut config = DiscoveryConfig::default();
@@ -339,6 +342,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_subnet_predicate() -> anyhow::Result<()> {
+        let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);
         let key = Keypair::generate_secp256k1();
         let mut config = DiscoveryConfig::default();
         config.subnets.enable_subnet(Subnet::Attestation(0))?; // Local node on subnet 0
@@ -360,6 +364,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_discovery_with_subnets() -> anyhow::Result<()> {
+        let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);
         let key = Keypair::generate_secp256k1();
         let discv5_config = discv5::ConfigBuilder::new(discv5::ListenConfig::default())
             .table_filter(|_| true)

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -21,7 +21,7 @@ use libp2p::{
         THandlerOutEvent, ToSwarm, dummy::ConnectionHandler,
     },
 };
-use ream_consensus::constants::MAINNET_GENESIS_VALIDATORS_ROOT;
+use ream_consensus::constants::genesis_validator_spec;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
@@ -75,10 +75,7 @@ impl Discovery {
         enr_builder.udp4(config.discovery_port);
 
         let enr = enr_builder
-            .add_value(
-                ENR_ETH2_KEY,
-                &EnrForkId::electra(MAINNET_GENESIS_VALIDATORS_ROOT),
-            )
+            .add_value(ENR_ETH2_KEY, &EnrForkId::electra(genesis_validator_spec()))
             .add_value(ATTESTATION_BITFIELD_ENR_KEY, &config.subnets)
             .build(&enr_local)
             .map_err(|err| anyhow!("Failed to build ENR: {err}"))?;

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -21,7 +21,7 @@ use libp2p::{
         THandlerOutEvent, ToSwarm, dummy::ConnectionHandler,
     },
 };
-use ream_consensus::constants::genesis_validator_spec;
+use ream_consensus::constants::genesis_validators_root;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
@@ -75,7 +75,7 @@ impl Discovery {
         enr_builder.udp4(config.discovery_port);
 
         let enr = enr_builder
-            .add_value(ENR_ETH2_KEY, &EnrForkId::electra(genesis_validator_spec()))
+            .add_value(ENR_ETH2_KEY, &EnrForkId::electra(genesis_validators_root()))
             .add_value(ATTESTATION_BITFIELD_ENR_KEY, &config.subnets)
             .build(&enr_local)
             .map_err(|err| anyhow!("Failed to build ENR: {err}"))?;

--- a/crates/networking/p2p/src/network.rs
+++ b/crates/networking/p2p/src/network.rs
@@ -357,7 +357,8 @@ pub fn build_transport(local_private_key: Keypair) -> io::Result<Boxed<(PeerId, 
 mod tests {
     use std::net::IpAddr;
 
-    use alloy_primitives::aliases::B32;
+    use alloy_primitives::{B256, aliases::B32};
+    use ream_consensus::constants::GENESIS_VALIDATORS_ROOT;
     use ream_discv5::{config::DiscoveryConfig, subnet::Subnets};
     use ream_executor::ReamExecutor;
     use ream_network_spec::networks::{DEV, set_network_spec};
@@ -408,6 +409,7 @@ mod tests {
 
     #[test]
     fn test_p2p_gossipsub() {
+        let _ = GENESIS_VALIDATORS_ROOT.set(B256::ZERO);
         set_network_spec(DEV.clone());
 
         let runtime = Runtime::new().unwrap();

--- a/crates/networking/p2p/src/req_resp/inbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/inbound_protocol.rs
@@ -15,7 +15,7 @@ use libp2p::{
     bytes::{Buf, BufMut},
     core::UpgradeInfo,
 };
-use ream_consensus::constants::MAINNET_GENESIS_VALIDATORS_ROOT;
+use ream_consensus::constants::genesis_validator_spec;
 use ream_network_spec::networks::network_spec;
 use snap::{read::FrameDecoder, write::FrameEncoder};
 use ssz::{Decode, Encode};
@@ -135,7 +135,7 @@ impl Encoder<RespMessage> for InboundSSZSnappyCodec {
         }
 
         if self.protocol.protocol.has_context_bytes() && response_code == ResponseCode::Success {
-            dst.extend(network_spec().fork_digest(MAINNET_GENESIS_VALIDATORS_ROOT));
+            dst.extend(network_spec().fork_digest(genesis_validator_spec()));
         }
 
         Uvi::<usize>::default().encode(bytes.len(), dst)?;

--- a/crates/networking/p2p/src/req_resp/inbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/inbound_protocol.rs
@@ -15,7 +15,7 @@ use libp2p::{
     bytes::{Buf, BufMut},
     core::UpgradeInfo,
 };
-use ream_consensus::constants::genesis_validator_spec;
+use ream_consensus::constants::genesis_validators_root;
 use ream_network_spec::networks::network_spec;
 use snap::{read::FrameDecoder, write::FrameEncoder};
 use ssz::{Decode, Encode};
@@ -135,7 +135,7 @@ impl Encoder<RespMessage> for InboundSSZSnappyCodec {
         }
 
         if self.protocol.protocol.has_context_bytes() && response_code == ResponseCode::Success {
-            dst.extend(network_spec().fork_digest(genesis_validator_spec()));
+            dst.extend(network_spec().fork_digest(genesis_validators_root()));
         }
 
         Uvi::<usize>::default().encode(bytes.len(), dst)?;

--- a/crates/networking/p2p/src/req_resp/outbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/outbound_protocol.rs
@@ -11,7 +11,7 @@ use futures::{
     prelude::{AsyncRead, AsyncWrite},
 };
 use libp2p::{OutboundUpgrade, bytes::Buf, core::UpgradeInfo};
-use ream_consensus::constants::MAINNET_GENESIS_VALIDATORS_ROOT;
+use ream_consensus::constants::genesis_validator_spec;
 use ream_network_spec::networks::network_spec;
 use snap::{read::FrameDecoder, write::FrameEncoder};
 use ssz::{Decode, Encode};
@@ -145,7 +145,7 @@ impl Decoder for OutboundSSZSnappyCodec {
         }
 
         if let Some(context_bytes) = self.context_bytes {
-            if context_bytes != network_spec().fork_digest(MAINNET_GENESIS_VALIDATORS_ROOT) {
+            if context_bytes != network_spec().fork_digest(genesis_validator_spec()) {
                 return Ok(Some(RespMessage::Error(ReqRespError::InvalidData(
                     "Invalid context bytes, we only support Electra".to_string(),
                 ))));

--- a/crates/networking/p2p/src/req_resp/outbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/outbound_protocol.rs
@@ -11,7 +11,7 @@ use futures::{
     prelude::{AsyncRead, AsyncWrite},
 };
 use libp2p::{OutboundUpgrade, bytes::Buf, core::UpgradeInfo};
-use ream_consensus::constants::genesis_validator_spec;
+use ream_consensus::constants::genesis_validators_root;
 use ream_network_spec::networks::network_spec;
 use snap::{read::FrameDecoder, write::FrameEncoder};
 use ssz::{Decode, Encode};
@@ -145,7 +145,7 @@ impl Decoder for OutboundSSZSnappyCodec {
         }
 
         if let Some(context_bytes) = self.context_bytes {
-            if context_bytes != network_spec().fork_digest(genesis_validator_spec()) {
+            if context_bytes != network_spec().fork_digest(genesis_validators_root()) {
                 return Ok(Some(RespMessage::Error(ReqRespError::InvalidData(
                     "Invalid context bytes, we only support Electra".to_string(),
                 ))));

--- a/crates/rpc/src/handlers/block.rs
+++ b/crates/rpc/src/handlers/block.rs
@@ -8,9 +8,9 @@ use alloy_primitives::B256;
 use ream_consensus::{
     attester_slashing::AttesterSlashing,
     constants::{
-        EFFECTIVE_BALANCE_INCREMENT, MAINNET_GENESIS_VALIDATORS_ROOT, PROPOSER_WEIGHT,
-        SLOTS_PER_EPOCH, SYNC_COMMITTEE_SIZE, SYNC_REWARD_WEIGHT, WEIGHT_DENOMINATOR,
-        WHISTLEBLOWER_REWARD_QUOTIENT,
+        EFFECTIVE_BALANCE_INCREMENT, PROPOSER_WEIGHT, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SIZE,
+        SYNC_REWARD_WEIGHT, WEIGHT_DENOMINATOR, WHISTLEBLOWER_REWARD_QUOTIENT,
+        genesis_validator_spec,
     },
     electra::{beacon_block::SignedBeaconBlock, beacon_state::BeaconState},
     genesis::Genesis,
@@ -207,7 +207,7 @@ pub async fn get_beacon_block_from_id(
 pub async fn get_genesis() -> Result<impl Responder, ApiError> {
     Ok(HttpResponse::Ok().json(DataResponse::new(Genesis {
         genesis_time: network_spec().min_genesis_time,
-        genesis_validators_root: MAINNET_GENESIS_VALIDATORS_ROOT,
+        genesis_validators_root: genesis_validator_spec(),
         genesis_fork_version: network_spec().genesis_fork_version,
     })))
 }

--- a/crates/rpc/src/handlers/block.rs
+++ b/crates/rpc/src/handlers/block.rs
@@ -10,7 +10,7 @@ use ream_consensus::{
     constants::{
         EFFECTIVE_BALANCE_INCREMENT, PROPOSER_WEIGHT, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SIZE,
         SYNC_REWARD_WEIGHT, WEIGHT_DENOMINATOR, WHISTLEBLOWER_REWARD_QUOTIENT,
-        genesis_validator_spec,
+        genesis_validators_root,
     },
     electra::{beacon_block::SignedBeaconBlock, beacon_state::BeaconState},
     genesis::Genesis,
@@ -207,7 +207,7 @@ pub async fn get_beacon_block_from_id(
 pub async fn get_genesis() -> Result<impl Responder, ApiError> {
     Ok(HttpResponse::Ok().json(DataResponse::new(Genesis {
         genesis_time: network_spec().min_genesis_time,
-        genesis_validators_root: genesis_validator_spec(),
+        genesis_validators_root: genesis_validators_root(),
         genesis_fork_version: network_spec().genesis_fork_version,
     })))
 }

--- a/crates/storage/src/tables/beacon_state.rs
+++ b/crates/storage/src/tables/beacon_state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use alloy_primitives::B256;
 use ream_consensus::electra::beacon_state::BeaconState;
-use redb::{Database, Durability, TableDefinition};
+use redb::{Database, Durability, ReadableTable, TableDefinition};
 
 use super::{SSZEncoding, Table};
 use crate::errors::StoreError;
@@ -39,5 +39,15 @@ impl Table for BeaconStateTable {
         drop(table);
         write_txn.commit()?;
         Ok(())
+    }
+}
+
+impl BeaconStateTable {
+    pub fn first(&self) -> Result<Option<BeaconState>, StoreError> {
+        let read_txn = self.db.begin_read()?;
+
+        let table = read_txn.open_table(BEACON_STATE_TABLE)?;
+        let result = table.first()?;
+        Ok(result.map(|res| res.1.value()))
     }
 }


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: https://github.com/ReamLabs/ream/issues/403

### How was it implemented/fixed?

https://doc.rust-lang.org/std/sync/struct.OnceLock.html

Replaced the hardcoded MAINNET_GENESIS_VALIDATORS_ROOT constant with a dynamically initialized genesis_validator_spec() on start up.
