### PR TITLE
feat: add structure for NetworkManager + BlockByRange syncer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,15 +4405,27 @@ dependencies = [
  "ream-consensus",
  "ream-discv5",
  "ream-executor",
+ "ream-manager",
  "ream-network-spec",
  "ream-node",
  "ream-p2p",
  "ream-rpc",
  "ream-storage",
- "reqwest",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "ream-beacon-chain"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ream-consensus",
+ "ream-execution-engine",
+ "ream-fork-choice",
+ "ream-storage",
 ]
 
 [[package]]
@@ -4571,6 +4583,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ream-manager"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "discv5",
+ "ream-beacon-chain",
+ "ream-consensus",
+ "ream-discv5",
+ "ream-execution-engine",
+ "ream-executor",
+ "ream-network-spec",
+ "ream-p2p",
+ "ream-storage",
+ "ream-syncer",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "ream-merkle"
 version = "0.1.0"
 dependencies = [
@@ -4705,6 +4737,16 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "tree_hash",
+]
+
+[[package]]
+name = "ream-syncer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ream-beacon-chain",
+ "ream-p2p",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 default-members = ["bin/ream"]
 members = [
     "bin/ream",
+    "crates/common/beacon_chain",
     "crates/common/checkpoint_sync",
     "crates/common/consensus",
     "crates/common/execution_engine",
@@ -15,7 +16,9 @@ members = [
     "crates/crypto/bls",
     "crates/crypto/merkle",
     "crates/networking/discv5",
+    "crates/networking/manager",
     "crates/networking/p2p",
+    "crates/networking/syncer",
     "crates/rpc",
     "crates/runtime",
     "crates/storage",
@@ -78,8 +81,10 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 tree_hash = "0.10"
 tree_hash_derive = "0.10"
+url = "2.5"
 
 # ream dependencies
+ream-beacon-chain = { path = "crates/common/beacon_chain" } 
 ream-bls = { path = "crates/crypto/bls", features = ["zkcrypto"] } # Default feature is zkcrypto
 ream-checkpoint-sync = { path = "crates/common/checkpoint_sync" }
 ream-consensus = { path = "crates/common/consensus" }
@@ -88,6 +93,7 @@ ream-execution-engine = { path = "crates/common/execution_engine" }
 ream-executor = { path = "crates/common/executor" }
 ream-fork-choice = { path = "crates/common/fork_choice" }
 ream-light-client = { path = "crates/common/light_client" }
+ream-manager = { path = "crates/networking/manager" }
 ream-merkle = { path = "crates/crypto/merkle" }
 ream-network-spec = { path = "crates/common/network_spec" }
 ream-node = { path = "crates/common/node" }
@@ -95,6 +101,7 @@ ream-p2p = { path = "crates/networking/p2p" }
 ream-polynomial-commitments = { path = "crates/common/polynomial_commitments" }
 ream-rpc = { path = "crates/rpc" }
 ream-storage = { path = "crates/storage" }
+ream-syncer = { path = "crates/networking/syncer" }
 
 [patch.crates-io]
 ethereum_hashing = { git = "https://github.com/ReamLabs/ethereum_hashing.git" }

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -18,16 +18,17 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive", "env"] }
 discv5.workspace = true
 hashbrown.workspace = true
-reqwest.workspace = true
 tokio.workspace = true
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+url.workspace = true
 
 # ream dependencies
 ream-checkpoint-sync.workspace = true
 ream-consensus.workspace = true
 ream-discv5.workspace = true
 ream-executor.workspace = true 
+ream-manager.workspace = true
 ream-network-spec.workspace = true 
 ream-node.workspace = true
 ream-p2p.workspace = true 

--- a/bin/ream/src/cli.rs
+++ b/bin/ream/src/cli.rs
@@ -5,10 +5,11 @@ use std::{
 };
 
 use clap::{Parser, Subcommand};
+use ream_manager::config::ManagerConfig;
 use ream_network_spec::{cli::network_parser, networks::NetworkSpec};
 use ream_node::version::FULL_VERSION;
 use ream_p2p::bootnodes::Bootnodes;
-use reqwest::Url;
+use url::Url;
 
 const DEFAULT_DISABLE_DISCOVERY: bool = false;
 const DEFAULT_DISCOVERY_PORT: u16 = 9000;
@@ -83,19 +84,51 @@ pub struct NodeConfig {
 
     #[arg(
         default_value = "default",
-        long = "bootnodes",
+        long,
         help = "One or more comma-delimited base64-encoded ENR's of peers to initially connect to. Use 'default' to use the default bootnodes for the network. Use 'none' to disable bootnodes."
     )]
     pub bootnodes: Bootnodes,
 
-    #[arg(
-        long = "checkpoint-sync-url",
-        help = "Trusted RPC URL to initiate Checkpoint Sync."
-    )]
+    #[arg(long, help = "Trusted RPC URL to initiate Checkpoint Sync.")]
     pub checkpoint_sync_url: Option<Url>,
 
-    #[arg(long = "purge-db", help = "Purges the database.")]
+    #[arg(long, help = "Purges the database.")]
     pub purge_db: bool,
+
+    #[arg(
+        long,
+        help = "The URL of the execution endpoint. This is used to send requests to the engine api.",
+        requires = "execution_jwt_secret"
+    )]
+    pub execution_endpoint: Option<Url>,
+
+    #[arg(
+        long,
+        help = "The JWT secret used to authenticate with the execution endpoint. This is used to send requests to the engine api.",
+        requires = "execution_endpoint"
+    )]
+    pub execution_jwt_secret: Option<PathBuf>,
+}
+
+impl From<NodeConfig> for ManagerConfig {
+    fn from(config: NodeConfig) -> Self {
+        Self {
+            http_address: config.http_address,
+            http_port: config.http_port,
+            http_allow_origin: config.http_allow_origin,
+            socket_address: config.socket_address,
+            socket_port: config.socket_port,
+            discovery_port: config.discovery_port,
+            disable_discovery: config.disable_discovery,
+            data_dir: config.data_dir,
+            ephemeral: config.ephemeral,
+            bootnodes: config.bootnodes,
+            checkpoint_sync_url: config.checkpoint_sync_url,
+            purge_db: config.purge_db,
+            execution_endpoint: config.execution_endpoint,
+            execution_jwt_secret: config.execution_jwt_secret,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/common/beacon_chain/Cargo.toml
+++ b/crates/common/beacon_chain/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ream-beacon-chain"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+
+# ream dependencies
+ream-consensus.workspace = true
+ream-execution-engine.workspace = true
+ream-fork-choice.workspace = true
+ream-storage.workspace = true

--- a/crates/common/beacon_chain/src/beacon_chain.rs
+++ b/crates/common/beacon_chain/src/beacon_chain.rs
@@ -1,0 +1,25 @@
+use ream_consensus::electra::beacon_block::SignedBeaconBlock;
+use ream_execution_engine::ExecutionEngine;
+use ream_fork_choice::{handlers::on_block, store::Store};
+use ream_storage::db::ReamDB;
+
+/// BeaconChain is the main struct which manages the nodes local beacon chain.
+pub struct BeaconChain {
+    pub store: Store,
+    pub execution_engine: Option<ExecutionEngine>,
+}
+
+impl BeaconChain {
+    /// Creates a new instance of `BeaconChain`.
+    pub fn new(db: ReamDB, execution_engine: Option<ExecutionEngine>) -> Self {
+        Self {
+            store: Store::new(db),
+            execution_engine,
+        }
+    }
+
+    pub async fn process_block(&mut self, signed_block: SignedBeaconBlock) -> anyhow::Result<()> {
+        on_block(&mut self.store, &signed_block, &self.execution_engine).await?;
+        Ok(())
+    }
+}

--- a/crates/common/beacon_chain/src/lib.rs
+++ b/crates/common/beacon_chain/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod beacon_chain;

--- a/crates/common/fork_choice/src/handlers.rs
+++ b/crates/common/fork_choice/src/handlers.rs
@@ -21,7 +21,7 @@ use crate::store::Store;
 pub async fn on_block(
     store: &mut Store,
     signed_block: &SignedBeaconBlock,
-    execution_engine: &impl ExecutionApi,
+    execution_engine: &Option<impl ExecutionApi>,
 ) -> anyhow::Result<()> {
     let block = &signed_block.message;
 

--- a/crates/networking/manager/Cargo.toml
+++ b/crates/networking/manager/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ream-manager"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+discv5.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+url.workspace = true
+
+# ream dependencies
+ream-beacon-chain.workspace = true
+ream-consensus.workspace = true
+ream-discv5.workspace = true
+ream-execution-engine.workspace = true
+ream-executor.workspace = true
+ream-network-spec.workspace = true
+ream-p2p.workspace = true
+ream-storage.workspace = true
+ream-syncer.workspace = true

--- a/crates/networking/manager/src/config.rs
+++ b/crates/networking/manager/src/config.rs
@@ -1,0 +1,21 @@
+use std::{net::IpAddr, path::PathBuf};
+
+use ream_p2p::bootnodes::Bootnodes;
+use url::Url;
+
+pub struct ManagerConfig {
+    pub http_address: IpAddr,
+    pub http_port: u16,
+    pub http_allow_origin: bool,
+    pub socket_address: IpAddr,
+    pub socket_port: u16,
+    pub discovery_port: u16,
+    pub disable_discovery: bool,
+    pub data_dir: Option<PathBuf>,
+    pub ephemeral: bool,
+    pub bootnodes: Bootnodes,
+    pub checkpoint_sync_url: Option<Url>,
+    pub purge_db: bool,
+    pub execution_endpoint: Option<Url>,
+    pub execution_jwt_secret: Option<PathBuf>,
+}

--- a/crates/networking/manager/src/lib.rs
+++ b/crates/networking/manager/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod service;

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+
+use ream_beacon_chain::beacon_chain::BeaconChain;
+use ream_consensus::constants::genesis_validators_root;
+use ream_discv5::{
+    config::DiscoveryConfig,
+    subnet::{AttestationSubnets, SyncCommitteeSubnets},
+};
+use ream_execution_engine::ExecutionEngine;
+use ream_executor::ReamExecutor;
+use ream_network_spec::networks::network_spec;
+use ream_p2p::{
+    channel::P2PMessages,
+    config::NetworkConfig,
+    gossipsub::{
+        configurations::GossipsubConfig,
+        topics::{GossipTopic, GossipTopicKind},
+    },
+    network::{Network, ReamNetworkEvent},
+};
+use ream_storage::db::ReamDB;
+use ream_syncer::block_range::BlockRangeSyncer;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tracing::info;
+
+use crate::config::ManagerConfig;
+
+pub struct ManagerService {
+    pub manager_receiver: mpsc::UnboundedReceiver<ReamNetworkEvent>,
+    pub p2p_sender: mpsc::UnboundedSender<P2PMessages>,
+    pub network_handle: JoinHandle<()>,
+    pub block_range_syncer: BlockRangeSyncer,
+}
+
+impl ManagerService {
+    pub async fn new(
+        async_executor: ReamExecutor,
+        config: ManagerConfig,
+        ream_db: ReamDB,
+    ) -> anyhow::Result<Self> {
+        let discv5_config = discv5::ConfigBuilder::new(discv5::ListenConfig::from_ip(
+            config.socket_address,
+            config.discovery_port,
+        ))
+        .build();
+
+        let bootnodes = config.bootnodes.to_enrs(network_spec().network.clone());
+        let discv5_config = DiscoveryConfig {
+            discv5_config,
+            bootnodes,
+            socket_address: config.socket_address,
+            socket_port: config.socket_port,
+            discovery_port: config.discovery_port,
+            disable_discovery: config.disable_discovery,
+            attestation_subnets: AttestationSubnets::new(),
+            sync_committee_subnets: SyncCommitteeSubnets::new(),
+        };
+
+        let mut gossipsub_config = GossipsubConfig::default();
+        gossipsub_config.set_topics(vec![GossipTopic {
+            fork: network_spec().fork_digest(genesis_validators_root()),
+            kind: GossipTopicKind::BeaconBlock,
+        }]);
+
+        let network_config = NetworkConfig {
+            socket_address: config.socket_address,
+            socket_port: config.socket_port,
+            discv5_config,
+            gossipsub_config,
+        };
+
+        let (manager_sender, manager_receiver) = mpsc::unbounded_channel();
+        let (p2p_sender, p2p_receiver) = mpsc::unbounded_channel();
+
+        let network = Network::init(async_executor, &network_config).await?;
+        let network_handle = tokio::spawn(async move {
+            network.start(manager_sender, p2p_receiver).await;
+        });
+
+        let execution_engine = if let (Some(execution_endpoint), Some(jwt_path)) =
+            (config.execution_endpoint, config.execution_jwt_secret)
+        {
+            Some(ExecutionEngine::new(execution_endpoint, jwt_path)?)
+        } else {
+            None
+        };
+        let beacon_chain = Arc::new(BeaconChain::new(ream_db, execution_engine));
+        let block_range_syncer = BlockRangeSyncer::new(beacon_chain, p2p_sender.clone());
+
+        Ok(Self {
+            manager_receiver,
+            p2p_sender,
+            network_handle,
+            block_range_syncer,
+        })
+    }
+
+    pub async fn start(self) {
+        let mut manager_receiver = self.manager_receiver;
+        loop {
+            tokio::select! {
+                Some(event) = manager_receiver.recv() => {
+                     info!("Received event: {:?}", event);
+                }
+            }
+        }
+    }
+}

--- a/crates/networking/p2p/src/channel.rs
+++ b/crates/networking/p2p/src/channel.rs
@@ -1,0 +1,18 @@
+use libp2p::PeerId;
+use tokio::sync::mpsc;
+
+use crate::req_resp::messages::ResponseMessage;
+
+pub enum P2PResponse {
+    ResponseMessage(ResponseMessage),
+    EndOfStream,
+}
+
+pub enum P2PMessages {
+    RequestBlockRange {
+        peer_id: PeerId,
+        start: u64,
+        count: u64,
+        callback: mpsc::Sender<anyhow::Result<P2PResponse>>,
+    },
+}

--- a/crates/networking/p2p/src/lib.rs
+++ b/crates/networking/p2p/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bootnodes;
+pub mod channel;
 pub mod config;
 pub mod constants;
 pub mod gossipsub;

--- a/crates/networking/p2p/src/req_resp/messages/beacon_blocks.rs
+++ b/crates/networking/p2p/src/req_resp/messages/beacon_blocks.rs
@@ -8,7 +8,17 @@ pub struct BeaconBlocksByRangeV2Request {
     pub start_slot: u64,
     pub count: u64,
     /// Deprecated, must be set to 1
-    pub step: u64,
+    step: u64,
+}
+
+impl BeaconBlocksByRangeV2Request {
+    pub fn new(start_slot: u64, count: u64) -> Self {
+        Self {
+            start_slot,
+            count,
+            step: 1,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Encode, Decode)]

--- a/crates/networking/syncer/Cargo.toml
+++ b/crates/networking/syncer/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ream-syncer"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+tokio.workspace = true
+
+# ream dependencies
+ream-beacon-chain.workspace = true
+ream-p2p.workspace = true

--- a/crates/networking/syncer/src/block_range/mod.rs
+++ b/crates/networking/syncer/src/block_range/mod.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use ream_beacon_chain::beacon_chain::BeaconChain;
+use ream_p2p::channel::P2PMessages;
+use tokio::sync::mpsc::UnboundedSender;
+
+pub struct BlockRangeSyncer {
+    pub beacon_chain: Arc<BeaconChain>,
+    pub p2p_sender: UnboundedSender<P2PMessages>,
+}
+
+impl BlockRangeSyncer {
+    pub fn new(beacon_chain: Arc<BeaconChain>, p2p_sender: UnboundedSender<P2PMessages>) -> Self {
+        Self {
+            beacon_chain,
+            p2p_sender,
+        }
+    }
+}

--- a/crates/networking/syncer/src/lib.rs
+++ b/crates/networking/syncer/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod block_range;

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,12 +1,12 @@
 use std::net::{IpAddr, SocketAddr};
 
 #[derive(Debug, Clone)]
-pub struct ServerConfig {
+pub struct RpcServerConfig {
     pub http_socket_address: SocketAddr,
     pub http_allow_origin: bool,
 }
 
-impl ServerConfig {
+impl RpcServerConfig {
     /// Creates a new instance from CLI arguments
     pub fn new(http_address: IpAddr, http_port: u16, http_allow_origin: bool) -> Self {
         Self {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,5 +1,5 @@
 use actix_web::{App, HttpServer, dev::ServerHandle, middleware, web::Data};
-use config::ServerConfig;
+use config::RpcServerConfig;
 use ream_storage::db::ReamDB;
 use tracing::info;
 
@@ -11,7 +11,7 @@ pub mod routes;
 pub mod types;
 
 /// Start the Beacon API server.
-pub async fn start_server(server_config: ServerConfig, db: ReamDB) -> std::io::Result<()> {
+pub async fn start_server(server_config: RpcServerConfig, db: ReamDB) -> std::io::Result<()> {
     info!(
         "starting HTTP server on {:?}",
         server_config.http_socket_address

--- a/testing/ef-tests/src/macros/fork_choice.rs
+++ b/testing/ef-tests/src/macros/fork_choice.rs
@@ -97,7 +97,7 @@ macro_rules! test_fork_choice {
                         stringify!($path)
                     );
 
-                    let mock_engine = MockExecutionEngine::new();
+                    let mock_engine = Some(MockExecutionEngine::new());
 
                     for entry in std::fs::read_dir(base_path).unwrap() {
                         let entry = entry.unwrap();

--- a/testing/ef-tests/src/macros/operations.rs
+++ b/testing/ef-tests/src/macros/operations.rs
@@ -89,8 +89,8 @@ macro_rules! test_operation {
             #[tokio::test]
             async fn test_operation() {
                 test_operation_impl!($operation_name, $operation_object, $input_name, |state: Arc<Mutex<BeaconState>>, input: $operation_object, case_dir: PathBuf| async move {
-                    let mock_engine = MockExecutionEngine::from_file(&case_dir.as_path().join("execution.yaml"))
-                        .expect("remove result");
+                    let mock_engine = Some(MockExecutionEngine::from_file(&case_dir.as_path().join("execution.yaml"))
+                        .expect("remove result"));
                     state.lock().await.process_execution_payload(&input, &mock_engine).await
                 });
             }

--- a/testing/ef-tests/src/macros/sanity_blocks.rs
+++ b/testing/ef-tests/src/macros/sanity_blocks.rs
@@ -24,7 +24,7 @@ macro_rules! test_sanity_blocks {
                         .unwrap()
                         .join(format!("mainnet/tests/mainnet/electra/{}/pyspec_tests", $path));
 
-                    let mock_engine = MockExecutionEngine::new();
+                    let mock_engine = Some(MockExecutionEngine::new());
 
                     for entry in std::fs::read_dir(&base_path).unwrap() {
                         let entry = entry.unwrap();


### PR DESCRIPTION
### What are you trying to achieve?

We want to be able to 
- handle inbound + outbound P2P messages
- make requests to the P2P layer for data so we can sync
- be able to handle on gossip events

There are a lot of people working on the P2P layer right now, this is the foundation so we can all work in parallel. Nothing is set in stone, but this should be enough so we don't bud heads. Normally I would propose this PR when I have a lot more done, but due to splitting work there is a high amount of value getting this in now 

### How was it implemented/fixed?

- Create a NetworkManager service which basically coordinates the operations of the Beacon Node
- Add BeaconChain an object which manages the chain
- Syncer crate where we will implement syncers 
- I added the interop between the NetworkManager/Syncers/P2P Layer
