### PR TITLE
ci: split common and ef-tests

### DIFF
--- a/.github/workflows/core-rust.yml
+++ b/.github/workflows/core-rust.yml
@@ -70,5 +70,12 @@ jobs:
     - name: Test
       run: cargo test --release --workspace -- --nocapture
 
+  ef-tests:
+    runs-on: ubuntu-latest
+    needs: [cargo-fmt, cargo-clippy]
+
+    steps:
+    - uses: actions/checkout@v4
+
     - name: Test consensus spec tests
       run: cd testing/ef-tests && make test


### PR DESCRIPTION
### What are you trying to achieve?

These tests take so long to run sequentially

### How was it implemented/fixed?

run them in parallel of one another