### PR TITLE
feat: implement process_sync_committee_contributions

### DIFF
--- a/crates/common/validator/src/sync_committee.rs
+++ b/crates/common/validator/src/sync_committee.rs
@@ -9,17 +9,8 @@ use ream_consensus::{
     misc::compute_epoch_at_slot,
     sync_aggregate::SyncAggregate,
 };
-use ssz_types::{BitVector, typenum::U128};
 
 use crate::constants::SYNC_COMMITTEE_SUBNET_COUNT;
-
-pub struct SyncCommitteeContribution {
-    pub slot: u64,
-    pub beacon_block_root: B256,
-    pub subcommittee_index: u64,
-    pub aggregation_bits: BitVector<U128>,
-    pub signature: BLSSignature,
-}
 
 pub fn compute_sync_committee_period(epoch: u64) -> u64 {
     epoch / EPOCHS_PER_SYNC_COMMITTEE_PERIOD

--- a/crates/common/validator/src/sync_committee.rs
+++ b/crates/common/validator/src/sync_committee.rs
@@ -9,7 +9,7 @@ use ream_consensus::{
     misc::compute_epoch_at_slot,
     sync_aggregate::SyncAggregate,
 };
-use ssz_types::{BitVector, typenum::U64};
+use ssz_types::{BitVector, typenum::U128};
 
 use crate::constants::SYNC_COMMITTEE_SUBNET_COUNT;
 
@@ -17,7 +17,7 @@ pub struct SyncCommitteeContribution {
     pub slot: u64,
     pub beacon_block_root: B256,
     pub subcommittee_index: u64,
-    pub aggregation_bits: BitVector<U64>,
+    pub aggregation_bits: BitVector<U128>,
     pub signature: BLSSignature,
 }
 

--- a/crates/common/validator/src/sync_committee.rs
+++ b/crates/common/validator/src/sync_committee.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use alloy_primitives::B256;
 use anyhow::{bail, ensure};
 use ream_bls::{BLSSignature, traits::Aggregatable};
 use ream_consensus::{
@@ -9,8 +8,11 @@ use ream_consensus::{
     misc::compute_epoch_at_slot,
     sync_aggregate::SyncAggregate,
 };
+use ssz_types::BitVector;
 
-use crate::constants::SYNC_COMMITTEE_SUBNET_COUNT;
+use crate::{
+    constants::SYNC_COMMITTEE_SUBNET_COUNT, contribution_and_proof::SyncCommitteeContribution,
+};
 
 pub fn compute_sync_committee_period(epoch: u64) -> u64 {
     epoch / EPOCHS_PER_SYNC_COMMITTEE_PERIOD


### PR DESCRIPTION
### What are you trying to achieve?

I implemented the process_sync_committee_contributions method as per the Altair Honest Validator Spec.
Fixes #410 

### How was it implemented/fixed?

I reviewed the pseudocode provided in the [Altair Validator Spec](https://github.com/ethereum/consensus-specs/blob/a94d85bb3b33f84a5830eb98945b790b02ae80e8/specs/altair/validator.md#sync-committee-1
)
I created the necessary struct [SyncCommitteeContribution](https://github.com/ethereum/consensus-specs/blob/a94d85bb3b33f84a5830eb98945b790b02ae80e8/specs/altair/validator.md#synccommitteecontribution) as per the spec with appropriate types.

I chose aggregation_bits as BitVector<U64> as the constants were u64. Please let me know if a different type is more appropriate.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
