### PR TITLE
ci: require conventional commit to pass merge queue

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,6 +3,7 @@ name: Conventional Commits
 on:
   pull_request:
     branches: [ "master" ]
+  merge_group:
 
 jobs:
   conventional-commits:


### PR DESCRIPTION
### What are you trying to achieve?

A few PR's not using conventional commits in the title got through

### How was it implemented/fixed?

by making the conventional CI pass for the PR to be able to be merge. We should update systems to prevent mistakes like this