### PR TITLE
feat: implement get_aggregate_and_proof and get_aggregate_and_proof_signature

### DIFF
--- a/crates/common/validator/src/aggregate_and_proof.rs
+++ b/crates/common/validator/src/aggregate_and_proof.rs
@@ -1,12 +1,47 @@
-use ream_bls::BLSSignature;
-use ream_consensus::attestation::Attestation;
+use ream_bls::{BLSSignature, PrivateKey, traits::Signable};
+use ream_consensus::{
+    attestation::Attestation,
+    constants::DOMAIN_AGGREGATE_AND_PROOF,
+    electra::beacon_state::BeaconState,
+    misc::{compute_epoch_at_slot, compute_signing_root},
+};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
+
+use crate::attestation::get_slot_signature;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct AggregateAndProof {
     pub aggregator_index: u64,
     pub aggregate: Attestation,
     pub selection_proof: BLSSignature,
+}
+
+pub fn get_aggregate_and_proof(
+    state: &BeaconState,
+    aggregator_index: u64,
+    aggregate: Attestation,
+    private_key: PrivateKey,
+) -> anyhow::Result<AggregateAndProof> {
+    Ok(AggregateAndProof {
+        aggregator_index,
+        aggregate: aggregate.clone(),
+        selection_proof: get_slot_signature(state, aggregate.data.slot, private_key)?,
+    })
+}
+
+pub fn get_aggregate_and_proof_signature(
+    state: &BeaconState,
+    aggregate_and_proof: AggregateAndProof,
+    private_key: PrivateKey,
+) -> anyhow::Result<BLSSignature> {
+    let domain = state.get_domain(
+        DOMAIN_AGGREGATE_AND_PROOF,
+        Some(compute_epoch_at_slot(
+            aggregate_and_proof.aggregate.data.slot,
+        )),
+    );
+    let signing_root = compute_signing_root(aggregate_and_proof, domain);
+    Ok(private_key.sign(signing_root.as_ref())?)
 }

--- a/crates/common/validator/src/aggregate_and_proof.rs
+++ b/crates/common/validator/src/aggregate_and_proof.rs
@@ -24,10 +24,11 @@ pub fn get_aggregate_and_proof(
     aggregate: Attestation,
     private_key: PrivateKey,
 ) -> anyhow::Result<AggregateAndProof> {
+    let slot = aggregate.data.slot;
     Ok(AggregateAndProof {
         aggregator_index,
-        aggregate: aggregate.clone(),
-        selection_proof: get_slot_signature(state, aggregate.data.slot, private_key)?,
+        aggregate,
+        selection_proof: get_slot_signature(state, slot, private_key)?,
     })
 }
 

--- a/crates/common/validator/src/aggregate_and_proof.rs
+++ b/crates/common/validator/src/aggregate_and_proof.rs
@@ -24,11 +24,10 @@ pub fn get_aggregate_and_proof(
     aggregate: Attestation,
     private_key: PrivateKey,
 ) -> anyhow::Result<AggregateAndProof> {
-    let slot = aggregate.data.slot;
     Ok(AggregateAndProof {
+        selection_proof: get_slot_signature(state, aggregate.data.slot, private_key)?,
         aggregator_index,
         aggregate,
-        selection_proof: get_slot_signature(state, slot, private_key)?,
     })
 }
 


### PR DESCRIPTION
### What are you trying to achieve?

Fixes #413

### How was it implemented/fixed?

Implemented the get_aggregate_and_proof and get_aggregate_and_proof_signature functions as per the Phase0 Honest Validator Spec:
https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/validator.md#broadcast-aggregate

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
