### PR TITLE
feat: implement get_contribution_and_proof and get_contribution_and_proof_signature

### DIFF
--- a/crates/common/validator/src/constants.rs
+++ b/crates/common/validator/src/constants.rs
@@ -1,6 +1,8 @@
 use alloy_primitives::{aliases::B32, fixed_bytes};
 
 pub const ATTESTATION_SUBNET_COUNT: u64 = 64;
+pub const DOMAIN_CONTRIBUTION_AND_PROOF: B32 = fixed_bytes!("0x09000000");
 pub const DOMAIN_SELECTION_PROOF: B32 = fixed_bytes!("0x05000000");
+pub const DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF: B32 = fixed_bytes!("0x08000000");
 pub const SYNC_COMMITTEE_SUBNET_COUNT: u64 = 4;
 pub const TARGET_AGGREGATORS_PER_COMMITTEE: u64 = 16;

--- a/crates/common/validator/src/contribution_and_proof.rs
+++ b/crates/common/validator/src/contribution_and_proof.rs
@@ -44,16 +44,15 @@ pub fn get_contribution_and_proof(
     contribution: SyncCommitteeContribution,
     private_key: PrivateKey,
 ) -> anyhow::Result<ContributionAndProof> {
-    let selection_proof = get_sync_committee_selection_proof(
-        state,
-        contribution.slot,
-        contribution.subcommittee_index,
-        private_key,
-    )?;
     Ok(ContributionAndProof {
+        selection_proof: get_sync_committee_selection_proof(
+            state,
+            contribution.slot,
+            contribution.subcommittee_index,
+            private_key,
+        )?,
         aggregator_index,
         contribution,
-        selection_proof,
     })
 }
 

--- a/crates/common/validator/src/contribution_and_proof.rs
+++ b/crates/common/validator/src/contribution_and_proof.rs
@@ -1,9 +1,17 @@
 use alloy_primitives::B256;
-use ream_bls::BLSSignature;
+use ream_bls::{BLSSignature, PrivateKey, traits::Signable};
+use ream_consensus::{
+    electra::beacon_state::BeaconState,
+    misc::{compute_epoch_at_slot, compute_signing_root},
+};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{BitVector, typenum::U128};
 use tree_hash_derive::TreeHash;
+
+use crate::{
+    constants::DOMAIN_CONTRIBUTION_AND_PROOF, sync_committee::get_sync_committee_selection_proof,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct SyncCommitteeContribution {
@@ -28,4 +36,39 @@ pub struct ContributionAndProof {
 pub struct SignedContributionAndProof {
     pub message: ContributionAndProof,
     pub signature: BLSSignature,
+}
+
+pub fn get_contribution_and_proof(
+    state: &BeaconState,
+    aggregator_index: u64,
+    contribution: SyncCommitteeContribution,
+    private_key: PrivateKey,
+) -> anyhow::Result<ContributionAndProof> {
+    let slot = contribution.slot;
+    let subcommittee_index = contribution.slot;
+    Ok(ContributionAndProof {
+        aggregator_index,
+        contribution,
+        selection_proof: get_sync_committee_selection_proof(
+            state,
+            slot,
+            subcommittee_index,
+            private_key,
+        )?,
+    })
+}
+
+pub fn get_contribution_proof_and_signature(
+    state: &BeaconState,
+    contribution_and_proof: ContributionAndProof,
+    private_key: PrivateKey,
+) -> anyhow::Result<BLSSignature> {
+    let domain = state.get_domain(
+        DOMAIN_CONTRIBUTION_AND_PROOF,
+        Some(compute_epoch_at_slot(
+            contribution_and_proof.contribution.slot,
+        )),
+    );
+    let signing_root = compute_signing_root(contribution_and_proof, domain);
+    Ok(private_key.sign(signing_root.as_ref())?)
 }

--- a/crates/common/validator/src/contribution_and_proof.rs
+++ b/crates/common/validator/src/contribution_and_proof.rs
@@ -44,17 +44,16 @@ pub fn get_contribution_and_proof(
     contribution: SyncCommitteeContribution,
     private_key: PrivateKey,
 ) -> anyhow::Result<ContributionAndProof> {
-    let slot = contribution.slot;
-    let subcommittee_index = contribution.slot;
+    let selection_proof = get_sync_committee_selection_proof(
+        state,
+        contribution.slot,
+        contribution.subcommittee_index,
+        private_key,
+    )?;
     Ok(ContributionAndProof {
         aggregator_index,
         contribution,
-        selection_proof: get_sync_committee_selection_proof(
-            state,
-            slot,
-            subcommittee_index,
-            private_key,
-        )?,
+        selection_proof,
     })
 }
 


### PR DESCRIPTION
…roof_signature

### What are you trying to achieve?

Fixes #412

### How was it implemented/fixed?

Implement get_contribution_and_proof and get_contribution_and_proof_signature based on the Altair Honest Validator Spec:
https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#broadcast-sync-committee-contribution

This also required the get_sync_committee_selection_proof method and has been implemented as per the Altair Honest Validator Spec:
https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#aggregation-selection

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
