### PR TITLE
feat: implement get block proposer duties in the beacon node

### DIFF
--- a/crates/common/consensus/src/electra/beacon_state.rs
+++ b/crates/common/consensus/src/electra/beacon_state.rs
@@ -383,6 +383,20 @@ impl BeaconState {
         self.compute_proposer_index(&indices, seed)
     }
 
+    /// Return the beacon proposer index at the given slot.
+    pub fn get_beacon_proposer_index_at_slot(&self, slot: u64) -> anyhow::Result<u64> {
+        let epoch = compute_epoch_at_slot(slot);
+        let seed = B256::from(hash_fixed(
+            &[
+                self.get_seed(epoch, DOMAIN_BEACON_PROPOSER).as_slice(),
+                &slot.to_le_bytes(),
+            ]
+            .concat(),
+        ));
+        let indices = self.get_active_validator_indices(epoch);
+        self.compute_proposer_index(&indices, seed)
+    }
+
     /// Return the combined effective balance of the ``indices``.
     /// ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
     /// Math safe up to ~10B ETH, after which this overflows uint64.

--- a/crates/common/validator/src/validator.rs
+++ b/crates/common/validator/src/validator.rs
@@ -16,7 +16,7 @@ pub fn check_if_validator_active(
 }
 
 pub fn is_proposer(state: &BeaconState, validator_index: u64) -> anyhow::Result<bool> {
-    Ok(state.get_beacon_proposer_index()? == validator_index)
+    Ok(state.get_beacon_proposer_index(None)? == validator_index)
 }
 
 /// Return the committee assignment in the ``epoch`` for ``validator_index``.

--- a/crates/rpc/src/handlers/duties.rs
+++ b/crates/rpc/src/handlers/duties.rs
@@ -34,20 +34,17 @@ pub async fn get_proposer_duties(
 
     let start_slot = compute_start_slot_at_epoch(epoch);
     let end_slot = start_slot + SLOTS_PER_EPOCH;
-
-    let mut duties = Vec::new();
-
+    let mut duties = vec![];
     for slot in start_slot..end_slot {
-        let proposer_index = state
-            .get_beacon_proposer_index_at_slot(slot)
-            .map_err(|e| ApiError::BadRequest(e.to_string()))?;
-        let Some(validator) = state.validators.get(proposer_index as usize) else {
-            return Err(ApiError::ValidatorNotFound(format!("{proposer_index}")));
+        let validator_index = state
+            .get_beacon_proposer_index(Some(slot))
+            .map_err(|err| ApiError::BadRequest(err.to_string()))?;
+        let Some(validator) = state.validators.get(validator_index as usize) else {
+            return Err(ApiError::ValidatorNotFound(format!("{validator_index}")));
         };
-
         duties.push(ProposerDuty {
             pubkey: validator.pubkey.clone(),
-            validator_index: proposer_index,
+            validator_index,
             slot,
         });
     }

--- a/crates/rpc/src/handlers/duties.rs
+++ b/crates/rpc/src/handlers/duties.rs
@@ -1,0 +1,55 @@
+use actix_web::{
+    HttpResponse, Responder, get,
+    web::{Data, Path},
+};
+use ream_bls::PubKey;
+use ream_consensus::{constants::SLOTS_PER_EPOCH, misc::compute_start_slot_at_epoch};
+use ream_storage::db::ReamDB;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    handlers::state::get_state_from_id,
+    types::{errors::ApiError, id::ID, response::DutiesResponse},
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProposerDuty {
+    pub pubkey: PubKey,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub slot: u64,
+}
+
+#[get("/validator/duties/proposer/{epoch}")]
+pub async fn get_proposer_duties(
+    db: Data<ReamDB>,
+    epoch: Path<u64>,
+) -> Result<impl Responder, ApiError> {
+    let epoch = epoch.into_inner();
+    let state = get_state_from_id(ID::Slot(compute_start_slot_at_epoch(epoch)), &db).await?;
+    let dependent_root = state
+        .get_block_root_at_slot(compute_start_slot_at_epoch(epoch) - 1)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    let start_slot = compute_start_slot_at_epoch(epoch);
+    let end_slot = start_slot + SLOTS_PER_EPOCH;
+
+    let mut duties = Vec::new();
+
+    for slot in start_slot..end_slot {
+        let proposer_index = state
+            .get_beacon_proposer_index_at_slot(slot)
+            .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+        let Some(validator) = state.validators.get(proposer_index as usize) else {
+            return Err(ApiError::ValidatorNotFound(format!("{proposer_index}")));
+        };
+
+        duties.push(ProposerDuty {
+            pubkey: validator.pubkey.clone(),
+            validator_index: proposer_index,
+            slot,
+        });
+    }
+    Ok(HttpResponse::Ok().json(DutiesResponse::new(dependent_root, duties)))
+}

--- a/crates/rpc/src/handlers/mod.rs
+++ b/crates/rpc/src/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod blob_sidecar;
 pub mod block;
 pub mod committee;
 pub mod config;
+pub mod duties;
 pub mod header;
 pub mod light_client;
 pub mod state;

--- a/crates/rpc/src/routes/mod.rs
+++ b/crates/rpc/src/routes/mod.rs
@@ -4,6 +4,7 @@ pub mod beacon;
 pub mod config;
 pub mod debug;
 pub mod node;
+pub mod validator;
 
 pub fn get_v1_routes(config: &mut ServiceConfig) {
     config.service(
@@ -11,7 +12,8 @@ pub fn get_v1_routes(config: &mut ServiceConfig) {
             .configure(beacon::register_beacon_routes)
             .configure(debug::register_debug_routes)
             .configure(node::register_node_routes)
-            .configure(config::register_config_routes),
+            .configure(config::register_config_routes)
+            .configure(validator::register_validator_routes),
     );
 }
 

--- a/crates/rpc/src/routes/validator.rs
+++ b/crates/rpc/src/routes/validator.rs
@@ -1,0 +1,7 @@
+use actix_web::web::ServiceConfig;
+
+use crate::handlers::duties::get_proposer_duties;
+
+pub fn register_validator_routes(config: &mut ServiceConfig) {
+    config.service(get_proposer_duties);
+}

--- a/crates/rpc/src/types/response.rs
+++ b/crates/rpc/src/types/response.rs
@@ -117,6 +117,32 @@ impl<T: Serialize> DataVersionedResponse<T> {
     }
 }
 
+/// A DutiesResponse data struct that can be used to wrap duty data
+/// used for json rpc responses
+///
+/// # Example
+/// {
+///     "dependent_root": "0x...",
+///     "execution_optimistic": false,
+///     "data": [T]
+/// }
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DutiesResponse<T> {
+    pub dependent_root: B256,
+    pub execution_optimistic: bool,
+    pub data: Vec<T>,
+}
+
+impl<T: Serialize> DutiesResponse<T> {
+    pub fn new(dependent_root: B256, data: Vec<T>) -> Self {
+        Self {
+            dependent_root,
+            execution_optimistic: EXECUTION_OPTIMISTIC,
+            data,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct BeaconHeadResponse {
     pub root: B256,


### PR DESCRIPTION
### What are you trying to achieve?

Implement the Beacon API endpoint GET /eth/v1/validator/duties/proposer/{epoch} to allow validator clients to retrieve proposer duty assignments for a specified epoch. 

This endpoint enables validators to query which validator index is assigned to propose blocks for each slot in the given epoch. This is the first endpoint called by a validator in the validator flow.

Fixes #230 
https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/getProposerDuties

### How was it implemented/fixed?

The logic implemented:
For each slot in the epoch, find the proposer index of that slot, find it's pubkey, make the ProposerDuty for struct for that slot and send it in the response.

I created the DutiesResponse struct in the beacon response as it has a different response structure than other BeaconAPIs.

I then tested it on sepolia on the highest epoch available. My test result can be accessed here:
https://pastebin.com/AxJ3cbn6

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
