### PR TITLE
feat: hmac for pbkdf2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,6 +3311,7 @@ dependencies = [
  "ream-bls",
  "serde",
  "serde_json",
+ "sha2 0.10.8",
  "ssz_types",
 ]
 

--- a/crates/crypto/keystore/Cargo.toml
+++ b/crates/crypto/keystore/Cargo.toml
@@ -14,6 +14,7 @@ alloy-primitives.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 ssz_types.workspace = true
 
 # ream dependencies

--- a/crates/crypto/keystore/src/hmac.rs
+++ b/crates/crypto/keystore/src/hmac.rs
@@ -1,0 +1,98 @@
+use sha2::{Digest, digest::crypto_common::BlockSizeUser};
+use ssz_types::FixedVector;
+
+// Going off of this
+// https://en.wikipedia.org/wiki/HMAC#:~:text=In%20cryptography%2C%20an%20HMAC%20(sometimes,and%20a%20secret%20cryptographic%20key.
+pub fn hmac<T: Digest + BlockSizeUser>(
+    key: &[u8],
+    message: &[u8],
+) -> FixedVector<u8, T::OutputSize> {
+    let block_sized_key = compute_block_sized_key::<T>(key);
+
+    let o_key_pad = block_sized_key
+        .iter()
+        .map(|&b| b ^ 0x5c)
+        .collect::<Vec<_>>();
+    let i_key_pad = block_sized_key
+        .iter()
+        .map(|&b| b ^ 0x36)
+        .collect::<Vec<_>>();
+
+    // Compute inner hash
+    let mut inner_hasher = T::new();
+    inner_hasher.update(&i_key_pad);
+    inner_hasher.update(message);
+    let inner_hash = inner_hasher.finalize();
+
+    // Compute outer hash
+    let mut outer_hasher = T::new();
+    outer_hasher.update(&o_key_pad);
+    outer_hasher.update(&inner_hash);
+
+    FixedVector::<u8, T::OutputSize>::from(outer_hasher.finalize().to_vec())
+}
+
+pub fn compute_block_sized_key<T: Digest + BlockSizeUser>(
+    key: &[u8],
+) -> FixedVector<u8, T::BlockSize> {
+    let block_size = T::block_size();
+    if key.len() > block_size {
+        let mut hasher = T::new();
+        hasher.update(key);
+        return FixedVector::<u8, T::BlockSize>::from(hasher.finalize().to_vec());
+    }
+    FixedVector::<u8, T::BlockSize>::from(key.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::hex;
+    use sha2::{Sha256, Sha512, Sha512_224, Sha512_256};
+
+    use crate::hmac::hmac;
+
+    #[test]
+    fn test_hmac_sha256() {
+        let key = b"key";
+        let message = b"The quick brown fox jumps over the lazy dog";
+        let expected_hmac =
+            hex::decode("f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8")
+                .unwrap();
+
+        let result = hmac::<Sha256>(key, message);
+        assert_eq!(result, expected_hmac.into());
+    }
+
+    #[test]
+    fn test_hmac_sha512() {
+        let key = b"key";
+        let message = b"The quick brown fox jumps over the lazy dog";
+        let expected_hmac = hex::decode("b42af09057bac1e2d41708e48a902e09b5ff7f12ab428a4fe86653c73dd248fb82f948a549f7b791a5b41915ee4d1ec3935357e4e2317250d0372afa2ebeeb3a").unwrap();
+
+        let result = hmac::<Sha512>(key, message);
+        assert_eq!(result, expected_hmac.into());
+    }
+
+    #[test]
+    fn test_hmac_sha512_224() {
+        let key = b"key";
+        let message = b"The quick brown fox jumps over the lazy dog";
+        let expected_hmac =
+            hex::decode("a1afb4f708cb63570639195121785ada3dc615989cc3c73f38e306a3").unwrap();
+
+        let result = hmac::<Sha512_224>(key, message);
+        assert_eq!(result, expected_hmac.into());
+    }
+
+    #[test]
+    fn test_hmac_sha512_256() {
+        let key = b"a very loooooooooooooooooooooooooooooong keyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
+        let message = b"The quick brown fox jumps over the lazy dog";
+        let expected_hmac =
+            hex::decode("52ebe97c6bc6cf28493d0ac9304af47482eda1345f9c80be311949ccc1726b6b")
+                .unwrap();
+
+        let result = hmac::<Sha512_256>(key, message);
+        assert_eq!(result, expected_hmac.into());
+    }
+}

--- a/crates/crypto/keystore/src/hmac.rs
+++ b/crates/crypto/keystore/src/hmac.rs
@@ -1,98 +1,91 @@
-use sha2::{Digest, digest::crypto_common::BlockSizeUser};
-use ssz_types::FixedVector;
+use alloy_primitives::{B256, B512};
+use sha2::{Digest, Sha256, digest::crypto_common::BlockSizeUser};
 
 // Going off of this
 // https://en.wikipedia.org/wiki/HMAC#:~:text=In%20cryptography%2C%20an%20HMAC%20(sometimes,and%20a%20secret%20cryptographic%20key.
-pub fn hmac<T: Digest + BlockSizeUser>(
-    key: &[u8],
-    message: &[u8],
-) -> FixedVector<u8, T::OutputSize> {
-    let block_sized_key = compute_block_sized_key::<T>(key);
+pub fn hmac_sha_256(key: &[u8], message: &[u8]) -> B256 {
+    let block_sized_key = compute_block_sized_key_sha_256(key);
 
-    let o_key_pad = block_sized_key
+    let outer_padded_key = block_sized_key
         .iter()
         .map(|&b| b ^ 0x5c)
         .collect::<Vec<_>>();
-    let i_key_pad = block_sized_key
+    let inner_padded_key = block_sized_key
         .iter()
         .map(|&b| b ^ 0x36)
         .collect::<Vec<_>>();
 
     // Compute inner hash
-    let mut inner_hasher = T::new();
-    inner_hasher.update(&i_key_pad);
+    let mut inner_hasher = Sha256::new();
+    inner_hasher.update(&inner_padded_key);
     inner_hasher.update(message);
     let inner_hash = inner_hasher.finalize();
 
     // Compute outer hash
-    let mut outer_hasher = T::new();
-    outer_hasher.update(&o_key_pad);
-    outer_hasher.update(&inner_hash);
+    let mut outer_hasher = Sha256::new();
+    outer_hasher.update(&outer_padded_key);
+    outer_hasher.update(inner_hash);
 
-    FixedVector::<u8, T::OutputSize>::from(outer_hasher.finalize().to_vec())
+    B256::from_slice(&outer_hasher.finalize())
 }
 
-pub fn compute_block_sized_key<T: Digest + BlockSizeUser>(
-    key: &[u8],
-) -> FixedVector<u8, T::BlockSize> {
-    let block_size = T::block_size();
+fn compute_block_sized_key_sha_256(key: &[u8]) -> B512 {
+    let block_size = Sha256::block_size();
     if key.len() > block_size {
-        let mut hasher = T::new();
+        let mut hasher = Sha256::new();
         hasher.update(key);
-        return FixedVector::<u8, T::BlockSize>::from(hasher.finalize().to_vec());
+        return B512::from_slice(&hasher.finalize());
     }
-    FixedVector::<u8, T::BlockSize>::from(key.to_vec())
+    let mut padded_key = vec![0u8; block_size];
+    padded_key[..key.len()].copy_from_slice(key);
+    B512::from_slice(&padded_key)
 }
 
 #[cfg(test)]
 mod tests {
     use alloy_primitives::hex;
-    use sha2::{Sha256, Sha512, Sha512_224, Sha512_256};
 
-    use crate::hmac::hmac;
+    use crate::hmac::hmac_sha_256;
 
     #[test]
     fn test_hmac_sha256() {
         let key = b"key";
         let message = b"The quick brown fox jumps over the lazy dog";
-        let expected_hmac =
+        let expected_hmac: [u8; 32] =
             hex::decode("f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8")
-                .unwrap();
+                .unwrap()
+                .try_into()
+                .expect("Expected HMAC must be 32 bytes");
 
-        let result = hmac::<Sha256>(key, message);
-        assert_eq!(result, expected_hmac.into());
+        let result = hmac_sha_256(key, message);
+        assert_eq!(result.as_slice(), expected_hmac.as_slice());
     }
 
     #[test]
-    fn test_hmac_sha512() {
-        let key = b"key";
+    fn test_hmac_sha256_long() {
+        let key = b"a veryyyyyyyyyyyyyy loooooooooooooong keeeeeeeeeeeeeey";
         let message = b"The quick brown fox jumps over the lazy dog";
-        let expected_hmac = hex::decode("b42af09057bac1e2d41708e48a902e09b5ff7f12ab428a4fe86653c73dd248fb82f948a549f7b791a5b41915ee4d1ec3935357e4e2317250d0372afa2ebeeb3a").unwrap();
+        let expected_hmac: [u8; 32] =
+            hex::decode("21ceea730aaa96810456eda3ec6ea3dbec121fe232fa103c711fe53db365de88")
+                .unwrap()
+                .try_into()
+                .expect("Expected HMAC must be 32 bytes");
 
-        let result = hmac::<Sha512>(key, message);
-        assert_eq!(result, expected_hmac.into());
+        let result = hmac_sha_256(key, message);
+        assert_eq!(result.as_slice(), expected_hmac.as_slice());
     }
 
     #[test]
-    fn test_hmac_sha512_224() {
-        let key = b"key";
+    fn test_hmac_sha256_exact() {
+        let key = b"quinquagintaquadringentilliardth";
         let message = b"The quick brown fox jumps over the lazy dog";
-        let expected_hmac =
-            hex::decode("a1afb4f708cb63570639195121785ada3dc615989cc3c73f38e306a3").unwrap();
+        let expected_hmac: [u8; 32] =
+            hex::decode("f32363682e10c5cd1966701fffb18addaba376aa307c1742019a3d9e01d01608")
+                .unwrap()
+                .try_into()
+                .expect("Expected HMAC must be 32 bytes");
 
-        let result = hmac::<Sha512_224>(key, message);
-        assert_eq!(result, expected_hmac.into());
-    }
-
-    #[test]
-    fn test_hmac_sha512_256() {
-        let key = b"a very loooooooooooooooooooooooooooooong keyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy";
-        let message = b"The quick brown fox jumps over the lazy dog";
-        let expected_hmac =
-            hex::decode("52ebe97c6bc6cf28493d0ac9304af47482eda1345f9c80be311949ccc1726b6b")
-                .unwrap();
-
-        let result = hmac::<Sha512_256>(key, message);
-        assert_eq!(result, expected_hmac.into());
+        let result = hmac_sha_256(key, message);
+        assert_eq!(result.as_slice(), expected_hmac.as_slice());
     }
 }

--- a/crates/crypto/keystore/src/lib.rs
+++ b/crates/crypto/keystore/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod encrypted_keystore;
 pub mod hex_serde;
+pub mod hmac;


### PR DESCRIPTION
### What are you trying to achieve?

Creating the HMAC helper function in order to read off the encrypted keystore files normally generated by any of the staking CLI.

### How was it implemented/fixed?

Originally I intended to just do it for sha256, but I noticed it apparently would work for any hash function. I instead generalized it to work with most of the hash functions we already use in the odd case we may need it for something else.

### To-Do

This is meant as a part of the PBKDF2 implementation, so this would be next. Additionally, scrypt requires PBKDF2-HMAC-SHA256, so it's a mandatory function for keystore decryption.
