### PR TITLE
feat: implement get unsigned block from beacon node

### DIFF
--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -1,12 +1,16 @@
 pub mod event;
 pub mod http_client;
+pub mod produce_block;
 
 use std::{pin::Pin, time::Duration};
 
+use alloy_primitives::{B256, hex};
 use event::{BeaconEvent, EventTopic};
 use eventsource_client::{Client, ClientBuilder, SSE};
 use futures::{Stream, StreamExt};
 use http_client::{ClientWithBaseUrl, ContentType};
+use produce_block::ProduceBlock;
+use ream_bls::BLSSignature;
 use reqwest::Url;
 use tracing::{error, info};
 
@@ -68,5 +72,38 @@ impl BeaconApiClient {
                 }
             })
             .boxed())
+    }
+
+    pub async fn produce_block(
+        &self,
+        slot: u64,
+        randao_reveal: BLSSignature,
+        graffiti: B256,
+        skip_randao_verification: Option<bool>,
+        builder_boost_factor: Option<u64>,
+    ) -> anyhow::Result<ProduceBlock> {
+        let mut request_builder = self
+            .http_client
+            .get(format!("/eth/v3/validator/blocks/{slot}"))?
+            .query(&[("randao_reveal", format!("{:?}", randao_reveal))])
+            .query(&[("graffiti", format!("0x{}", hex::encode(graffiti)))]);
+
+        if let Some(skip_randao) = skip_randao_verification {
+            request_builder =
+                request_builder.query(&[("skip_randao_verification", skip_randao.to_string())]);
+        }
+
+        if let Some(boost_factor) = builder_boost_factor {
+            request_builder =
+                request_builder.query(&[("builder_boost_factor", boost_factor.to_string())]);
+        }
+
+        let response = self.http_client.execute(request_builder.build()?).await?;
+
+        if response.status().is_success() {
+            Ok(response.json().await?)
+        } else {
+            anyhow::bail!("Failed to produce block: {}", response.status())
+        }
     }
 }

--- a/crates/common/validator/src/beacon_api_client/produce_block.rs
+++ b/crates/common/validator/src/beacon_api_client/produce_block.rs
@@ -1,0 +1,23 @@
+use ream_consensus::{
+    electra::beacon_block::BeaconBlock, execution_engine::rpc_types::get_blobs::Blob,
+    polynomial_commitments::kzg_proof::KZGProof,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProduceBlock {
+    pub version: String,
+    pub execution_payload_blinded: bool,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub execution_payload_value: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub consensus_block_value: u64,
+    pub data: ProduceBlockData,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProduceBlockData {
+    pub block: BeaconBlock,
+    pub kzg_proofs: Vec<KZGProof>,
+    pub blobs: Vec<Blob>,
+}


### PR DESCRIPTION
### What are you trying to achieve?

Implementing the GET /eth/v3/validator/blocks/{slot} request in the Validator client and parsing the response from a beacon node into a ProduceBlock struct.

### How was it implemented/fixed?

I read the Beacon API documentation for the endpoint and created the request as defined.
I then created the struct to parse the response on based on the Electra Spec as seen in of the response schema of the endpoint.

I am looking for feedback on my approach as I am also implementing some other requests in a similar manner. 

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
