### PR TITLE
feat: implement get_attester_duties in the beacon node

### DIFF
--- a/crates/common/validator/src/validator.rs
+++ b/crates/common/validator/src/validator.rs
@@ -1,8 +1,5 @@
-use anyhow::{anyhow, ensure};
-use ream_consensus::{
-    constants::SLOTS_PER_EPOCH, electra::beacon_state::BeaconState,
-    misc::compute_start_slot_at_epoch,
-};
+use anyhow::anyhow;
+use ream_consensus::electra::beacon_state::BeaconState;
 
 pub fn check_if_validator_active(
     state: &BeaconState,
@@ -17,33 +14,4 @@ pub fn check_if_validator_active(
 
 pub fn is_proposer(state: &BeaconState, validator_index: u64) -> anyhow::Result<bool> {
     Ok(state.get_beacon_proposer_index(None)? == validator_index)
-}
-
-/// Return the committee assignment in the ``epoch`` for ``validator_index``.
-/// ``assignment`` returned is a tuple of the following form:
-///     * ``assignment[0]`` is the list of validators in the committee
-///     * ``assignment[1]`` is the index to which the committee is assigned
-///     * ``assignment[2]`` is the slot at which the committee is assigned
-/// Return None if no assignment.
-pub fn get_committee_assignment(
-    state: &BeaconState,
-    epoch: u64,
-    validator_index: u64,
-) -> anyhow::Result<Option<(Vec<u64>, u64, u64)>> {
-    let next_epoch = state.get_current_epoch() + 1;
-    ensure!(
-        epoch <= next_epoch,
-        "Requested epoch {epoch} is beyond the allowed maximum (next epoch: {next_epoch})",
-    );
-    let start_slot = compute_start_slot_at_epoch(epoch);
-    let committee_count_per_slot = state.get_committee_count_per_slot(epoch);
-    for slot in start_slot..start_slot + SLOTS_PER_EPOCH {
-        for index in 0..committee_count_per_slot {
-            let committee = state.get_beacon_committee(slot, index)?;
-            if committee.contains(&validator_index) {
-                return Ok(Some((committee, index, slot)));
-            }
-        }
-    }
-    Ok(None)
 }

--- a/crates/rpc/src/handlers/duties.rs
+++ b/crates/rpc/src/handlers/duties.rs
@@ -66,7 +66,7 @@ pub async fn get_proposer_duties(
     Ok(HttpResponse::Ok().json(DutiesResponse::new(dependent_root, duties)))
 }
 
-#[post("/validator/duties/proposer/{epoch}")]
+#[post("/validator/duties/attester/{epoch}")]
 pub async fn get_attester_duties(
     db: Data<ReamDB>,
     epoch: Path<u64>,

--- a/crates/rpc/src/handlers/duties.rs
+++ b/crates/rpc/src/handlers/duties.rs
@@ -1,6 +1,6 @@
 use actix_web::{
-    HttpResponse, Responder, get,
-    web::{Data, Path},
+    HttpResponse, Responder, get, post,
+    web::{Data, Json, Path},
 };
 use ream_bls::PubKey;
 use ream_consensus::{constants::SLOTS_PER_EPOCH, misc::compute_start_slot_at_epoch};
@@ -17,6 +17,21 @@ pub struct ProposerDuty {
     pub pubkey: PubKey,
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub slot: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AttesterDuty {
+    pub pubkey: PubKey,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub committee_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub committees_at_slot: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_committee_index: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     pub slot: u64,
 }
@@ -47,6 +62,51 @@ pub async fn get_proposer_duties(
             validator_index,
             slot,
         });
+    }
+    Ok(HttpResponse::Ok().json(DutiesResponse::new(dependent_root, duties)))
+}
+
+#[post("/validator/duties/proposer/{epoch}")]
+pub async fn get_attester_duties(
+    db: Data<ReamDB>,
+    epoch: Path<u64>,
+    validator_indices: Json<Vec<u64>>,
+) -> Result<impl Responder, ApiError> {
+    let epoch = epoch.into_inner();
+    let state = get_state_from_id(ID::Slot(compute_start_slot_at_epoch(epoch)), &db).await?;
+    let dependent_root = state
+        .get_block_root_at_slot(compute_start_slot_at_epoch(epoch) - 1)
+        .map_err(|err| ApiError::BadRequest(err.to_string()))?;
+
+    let validator_indices = validator_indices.into_inner();
+    let committees_at_slot = state.get_committee_count_per_slot(epoch);
+    let mut duties = vec![];
+
+    for validator_index in validator_indices {
+        let Some(validator) = state.validators.get(validator_index as usize) else {
+            return Err(ApiError::ValidatorNotFound(format!("{validator_index}")));
+        };
+
+        if let Some((committee, committee_index, slot)) = state
+            .get_committee_assignment(epoch, validator_index)
+            .map_err(|err| ApiError::BadRequest(err.to_string()))?
+        {
+            let validator_committee_index = committee
+                .iter()
+                .position(|&v| v == validator_index)
+                .ok_or_else(|| {
+                    ApiError::BadRequest("Validator not found in assigned committee".to_string())
+                })?;
+
+            duties.push(AttesterDuty {
+                pubkey: validator.pubkey.clone(),
+                validator_index,
+                committee_index,
+                committees_at_slot,
+                validator_committee_index: validator_committee_index as u64,
+                slot,
+            });
+        }
     }
     Ok(HttpResponse::Ok().json(DutiesResponse::new(dependent_root, duties)))
 }

--- a/crates/rpc/src/routes/validator.rs
+++ b/crates/rpc/src/routes/validator.rs
@@ -1,7 +1,8 @@
 use actix_web::web::ServiceConfig;
 
-use crate::handlers::duties::get_proposer_duties;
+use crate::handlers::duties::{get_attester_duties, get_proposer_duties};
 
 pub fn register_validator_routes(config: &mut ServiceConfig) {
     config.service(get_proposer_duties);
+    config.service(get_attester_duties);
 }


### PR DESCRIPTION
### What are you trying to achieve?

Implement the Beacon API endpoint POST /eth/v1/validator/duties/attester/{epoch}  to allow validator clients to retrieve attester duties for a specified epoch and a given set of validator indices. 

Fixes: #228 
https://ethereum.github.io/beacon-APIs/#/Validator/getAttesterDuties

### How was it implemented/fixed?
We moved the function get_committee_assignment(epoch, validator_index) into BeaconState as it will be used in multiple places across the codebase.
For every validator in the list requested, we get the validator's public key and then get the committee assignment for it. 
 
I have tested this by running the ream binary. Results of my test can be found here: 
https://pastebin.com/RzSvRWLG

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
