### PR TITLE
feat: handle ReqResp P2P messages in NetworkManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5074,6 +5074,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "discv5",
+ "libp2p",
  "ream-beacon-chain",
  "ream-consensus",
  "ream-discv5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
     "testing/ef-tests",
 ]
 resolver = "2"
-exclude = ["book/cli", "book/sources"]
+exclude = ["book/cli"]
 
 [workspace.package]
 authors = ["https://github.com/ReamLabs/ream/graphs/contributors"]

--- a/crates/crypto/keystore/src/encrypted_keystore.rs
+++ b/crates/crypto/keystore/src/encrypted_keystore.rs
@@ -123,7 +123,6 @@ mod tests {
         let keystore_as_string = r#"{"crypto":{"kdf":{"function":"scrypt","params":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"12345678"},"message":"90abcdef"},"checksum":{"function":"sha256","params":{},"message":"01020304"},"cipher":{"function":"aes-128-ctr","params":{"iv":"aabbccdd"},"message":"11223344"}},"description":"Test Keystore","pubkey":"0x121212121212121212121212121212121212121212121212121212121212121212121212121212121212121212121212","path":"m/44'/60'/0'/0/0","uuid":"123e4567-e89b-12d3-a456-426614174000","version":4}"#;
 
         let serialized = serde_json::to_string(&keystore).expect("Failed to serialize keystore");
-        println!("{}", serialized);
         assert_eq!(serialized, keystore_as_string);
     }
 

--- a/crates/networking/manager/Cargo.toml
+++ b/crates/networking/manager/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 discv5.workspace = true
+libp2p.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -1,7 +1,10 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
+use anyhow::anyhow;
+use discv5::multiaddr::PeerId;
+use libp2p::swarm::ConnectionId;
 use ream_beacon_chain::beacon_chain::BeaconChain;
-use ream_consensus::constants::genesis_validators_root;
+use ream_consensus::{blob_sidecar::BlobIdentifier, constants::genesis_validators_root};
 use ream_discv5::{
     config::DiscoveryConfig,
     subnet::{AttestationSubnets, SyncCommitteeSubnets},
@@ -10,27 +13,43 @@ use ream_execution_engine::ExecutionEngine;
 use ream_executor::ReamExecutor;
 use ream_network_spec::networks::network_spec;
 use ream_p2p::{
-    channel::P2PMessages,
+    channel::{P2PMessage, P2PResponse},
     config::NetworkConfig,
     gossipsub::{
         configurations::GossipsubConfig,
         topics::{GossipTopic, GossipTopicKind},
     },
-    network::{Network, PeerTable, ReamNetworkEvent},
+    network::{Network, ReamNetworkEvent},
+    network_state::NetworkState,
+    req_resp::{
+        error::ReqRespError,
+        handler::RespMessage,
+        messages::{
+            RequestMessage, ResponseMessage,
+            beacon_blocks::{BeaconBlocksByRangeV2Request, BeaconBlocksByRootV2Request},
+            blob_sidecars::{BlobSidecarsByRangeV1Request, BlobSidecarsByRootV1Request},
+            status::Status,
+        },
+    },
 };
-use ream_storage::db::ReamDB;
+use ream_storage::{
+    db::ReamDB,
+    tables::{Field, Table},
+};
 use ream_syncer::block_range::BlockRangeSyncer;
 use tokio::{sync::mpsc, task::JoinHandle};
-use tracing::info;
+use tracing::{info, trace, warn};
 
 use crate::config::ManagerConfig;
 
 pub struct ManagerService {
+    pub beacon_chain: Arc<BeaconChain>,
     pub manager_receiver: mpsc::UnboundedReceiver<ReamNetworkEvent>,
-    pub p2p_sender: mpsc::UnboundedSender<P2PMessages>,
+    p2p_sender: P2PSender,
     pub network_handle: JoinHandle<()>,
-    pub peer_table: PeerTable,
+    pub network_state: Arc<NetworkState>,
     pub block_range_syncer: BlockRangeSyncer,
+    pub ream_db: ReamDB,
 }
 
 impl ManagerService {
@@ -38,6 +57,7 @@ impl ManagerService {
         async_executor: ReamExecutor,
         config: ManagerConfig,
         ream_db: ReamDB,
+        ream_dir: PathBuf,
     ) -> anyhow::Result<Self> {
         let discv5_config = discv5::ConfigBuilder::new(discv5::ListenConfig::from_ip(
             config.socket_address,
@@ -68,13 +88,14 @@ impl ManagerService {
             socket_port: config.socket_port,
             discv5_config,
             gossipsub_config,
+            data_dir: ream_dir,
         };
 
         let (manager_sender, manager_receiver) = mpsc::unbounded_channel();
         let (p2p_sender, p2p_receiver) = mpsc::unbounded_channel();
 
         let network = Network::init(async_executor, &network_config).await?;
-        let peer_table = network.peer_table().clone();
+        let network_state = network.network_state();
         let network_handle = tokio::spawn(async move {
             network.start(manager_sender, p2p_receiver).await;
         });
@@ -86,15 +107,17 @@ impl ManagerService {
         } else {
             None
         };
-        let beacon_chain = Arc::new(BeaconChain::new(ream_db, execution_engine));
-        let block_range_syncer = BlockRangeSyncer::new(beacon_chain, p2p_sender.clone());
+        let beacon_chain = Arc::new(BeaconChain::new(ream_db.clone(), execution_engine));
+        let block_range_syncer = BlockRangeSyncer::new(beacon_chain.clone(), p2p_sender.clone());
 
         Ok(Self {
+            beacon_chain,
             manager_receiver,
-            p2p_sender,
+            p2p_sender: P2PSender(p2p_sender),
             network_handle,
-            peer_table,
+            network_state,
             block_range_syncer,
+            ream_db,
         })
     }
 
@@ -103,13 +126,292 @@ impl ManagerService {
         loop {
             tokio::select! {
                 Some(event) = manager_receiver.recv() => {
-                     info!("Received event: {:?}", event);
+                     match event {
+                        ReamNetworkEvent::RequestMessage { peer_id, stream_id, connection_id, message } => {
+                            match message {
+                                RequestMessage::Status(status) => {
+                                    trace!(?peer_id, ?stream_id, ?connection_id, ?status, "Received Status request");
+                                    let Ok(finalized_checkpoint) = self.ream_db.finalized_checkpoint_provider().get() else {
+                                        trace!("Failed to get finalized checkpoint");
+                                        self.p2p_sender.send_error_response(
+                                            peer_id,
+                                            connection_id,
+                                            stream_id,
+                                            "Failed to get finalized checkpoint",
+                                        );
+                                        continue;
+                                    };
+
+                                    let head_root = match self.beacon_chain.store.get_head() {
+                                        Ok(head) => head,
+                                        Err(err) => {
+                                            info!("Failed to get head root: {err}");
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("Failed to get head root: {err}"),
+                                            );
+                                            continue;
+                                        }
+                                    };
+
+                                    let head_slot = match self.ream_db.beacon_block_provider().get(head_root) {
+                                        Ok(Some(block)) => block.message.slot,
+                                        err => {
+                                            info!("Failed to get block for head root {head_root}: {err:?}");
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("Failed to get block for head root {head_root}: {err:?}"),
+                                            );
+                                            continue;
+                                        }
+                                    };
+
+                                    self.p2p_sender.send_response(
+                                        peer_id,
+                                        connection_id,
+                                        stream_id,
+                                        ResponseMessage::Status(Status {
+                                            fork_digest: network_spec().fork_digest(genesis_validators_root()),
+                                            finalized_root: finalized_checkpoint.root,
+                                            finalized_epoch: finalized_checkpoint.epoch,
+                                            head_root,
+                                            head_slot
+                                         }),
+                                    );
+
+                                    self.p2p_sender.send_end_of_stream_response(peer_id, connection_id, stream_id);
+                                },
+                                RequestMessage::BeaconBlocksByRange(BeaconBlocksByRangeV2Request { start_slot, count, .. }) => {
+                                    for slot in start_slot..start_slot + count {
+                                        let Ok(Some(block_root)) = self.ream_db.slot_index_provider().get(slot) else {
+                                            trace!("No block root found for slot {slot}");
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("No block root found for slot {slot}"),
+                                            );
+                                            continue;
+                                        };
+                                        let Ok(Some(block)) = self.ream_db.beacon_block_provider().get(block_root) else {
+                                            trace!("No block found for root {block_root}");
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("No block found for root {block_root}"),
+                                            );
+                                            continue;
+                                        };
+
+                                        self.p2p_sender.send_response(
+                                            peer_id,
+                                            connection_id,
+                                            stream_id,
+                                            ResponseMessage::BeaconBlocksByRange(block),
+                                        );
+                                    }
+
+                                    self.p2p_sender.send_end_of_stream_response(peer_id, connection_id, stream_id);
+                                },
+                                RequestMessage::BeaconBlocksByRoot(BeaconBlocksByRootV2Request { inner }) =>
+                                {
+                                    for block_root in inner {
+                                        let Ok(Some(block)) = self.ream_db.beacon_block_provider().get(block_root) else {
+                                            trace!("No block found for root {block_root}");
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("No block found for root {block_root}"),
+                                            );
+                                            continue;
+                                        };
+
+                                        self.p2p_sender.send_response(
+                                            peer_id,
+                                            connection_id,
+                                            stream_id,
+                                            ResponseMessage::BeaconBlocksByRoot(block),
+                                        );
+                                    }
+
+                                    self.p2p_sender.send_end_of_stream_response(peer_id, connection_id, stream_id);
+                                },
+                                RequestMessage::BlobSidecarsByRange(BlobSidecarsByRangeV1Request { start_slot, count }) => {
+                                    for slot in start_slot..start_slot + count {
+                                        let Ok(Some(block_root)) = self.ream_db.slot_index_provider().get(slot) else {
+                                            trace!("No block root found for slot {slot}");
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("No block root found for slot {slot}"),
+                                            );
+                                            continue;
+                                        };
+                                        let Ok(Some(block)) = self.ream_db.beacon_block_provider().get(block_root) else {
+                                            trace!("No block found for root {block_root}");
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("No block found for root {block_root}"),
+                                            );
+                                            continue;
+                                        };
+
+                                        for index in 0..block.message.body.blob_kzg_commitments.len() {
+                                            let Ok(Some(blob_and_proof)) = self.ream_db.blobs_and_proofs_provider().get(BlobIdentifier::new(block_root, index as u64)) else {
+                                                trace!("No blob and proof found for block root {block_root} and index {index}");
+                                                self.p2p_sender.send_error_response(
+                                                    peer_id,
+                                                    connection_id,
+                                                    stream_id,
+                                                    &format!("No blob and proof found for block root {block_root} and index {index}"),
+                                                );
+                                                continue;
+                                            };
+
+                                            let blob_sidecar = match block.blob_sidecar(blob_and_proof, index as u64) {
+                                                Ok(blob_sidecar) => blob_sidecar,
+                                                Err(err) => {
+                                                    info!("Failed to create blob sidecar for block root {block_root} and index {index}: {err}");
+                                                    self.p2p_sender.send_error_response(
+                                                        peer_id,
+                                                        connection_id,
+                                                        stream_id,
+                                                        &format!("Failed to create blob sidecar: {err}"),
+                                                    );
+                                                    continue;
+                                                }
+                                            };
+
+                                            self.p2p_sender.send_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                ResponseMessage::BlobSidecarsByRange(blob_sidecar),
+                                            );
+                                        }
+                                    }
+
+                                    self.p2p_sender.send_end_of_stream_response(peer_id, connection_id, stream_id);
+                                },
+                                RequestMessage::BlobSidecarsByRoot(BlobSidecarsByRootV1Request { inner }) => {
+                                    for blob_identifier in inner {
+                                        let Ok(Some(blob_and_proof)) = self.ream_db.blobs_and_proofs_provider().get(blob_identifier.clone()) else {
+                                            trace!("No blob and proof found for identifier {blob_identifier:?}");
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("No blob and proof found for identifier {blob_identifier:?}"),
+                                            );
+                                            continue;
+                                        };
+
+                                        let Ok(Some(block)) = self.ream_db.beacon_block_provider().get(blob_identifier.block_root) else {
+                                            trace!("No block found for root {}", blob_identifier.block_root);
+                                            self.p2p_sender.send_error_response(
+                                                peer_id,
+                                                connection_id,
+                                                stream_id,
+                                                &format!("No block found for root {}", blob_identifier.block_root),
+                                            );
+                                            continue;
+                                        };
+
+                                        let blob_sidecar = match block.blob_sidecar(blob_and_proof, blob_identifier.index) {
+                                            Ok(blob_sidecar) => blob_sidecar,
+                                            Err(err) => {
+                                                info!("Failed to create blob sidecar for identifier {blob_identifier:?}: {err}");
+                                                self.p2p_sender.send_error_response(
+                                                    peer_id,
+                                                    connection_id,
+                                                    stream_id,
+                                                    &format!("Failed to create blob sidecar: {err}"),
+                                                );
+                                                continue;
+                                            }
+                                        };
+
+                                        self.p2p_sender.send_response(
+                                            peer_id,
+                                            connection_id,
+                                            stream_id,
+                                            ResponseMessage::BlobSidecarsByRoot(blob_sidecar),
+                                        );
+                                    }
+                                    self.p2p_sender.send_end_of_stream_response(peer_id, connection_id, stream_id);
+                                },
+                                _ => warn!("This message shouldn't be handled in the network manager: {message:?}"),
+                            }
+                        },
+                        unhandled_request => {
+                            info!("Unhandled request: {unhandled_request:?}");
+                        }
+                    }
                 }
             }
         }
     }
+}
 
-    pub fn peer_table(&self) -> &PeerTable {
-        &self.peer_table
+struct P2PSender(pub mpsc::UnboundedSender<P2PMessage>);
+
+impl P2PSender {
+    pub fn send_response(
+        &self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        stream_id: u64,
+        message: ResponseMessage,
+    ) {
+        if let Err(err) = self.0.send(P2PMessage::Response(P2PResponse {
+            peer_id,
+            connection_id,
+            stream_id,
+            message: RespMessage::Response(Box::new(message)),
+        })) {
+            warn!("Failed to send P2P response: {err}");
+        }
+    }
+
+    pub fn send_end_of_stream_response(
+        &self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        stream_id: u64,
+    ) {
+        if let Err(err) = self.0.send(P2PMessage::Response(P2PResponse {
+            peer_id,
+            connection_id,
+            stream_id,
+            message: RespMessage::EndOfStream,
+        })) {
+            warn!("Failed to send end of stream response: {err}");
+        }
+    }
+
+    pub fn send_error_response(
+        &self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        stream_id: u64,
+        error: &str,
+    ) {
+        if let Err(err) = self.0.send(P2PMessage::Response(P2PResponse {
+            peer_id,
+            connection_id,
+            stream_id,
+            message: RespMessage::Error(ReqRespError::Anyhow(anyhow!(error.to_string()))),
+        })) {
+            warn!("Failed to send error response: {err}");
+        }
     }
 }

--- a/crates/networking/p2p/src/channel.rs
+++ b/crates/networking/p2p/src/channel.rs
@@ -1,18 +1,30 @@
-use libp2p::PeerId;
+use libp2p::{PeerId, swarm::ConnectionId};
 use tokio::sync::mpsc;
 
-use crate::req_resp::messages::ResponseMessage;
+use crate::req_resp::{handler::RespMessage, messages::ResponseMessage};
 
-pub enum P2PResponse {
-    ResponseMessage(ResponseMessage),
+pub enum P2PCallbackResponse {
+    ResponseMessage(Box<ResponseMessage>),
     EndOfStream,
 }
 
-pub enum P2PMessages {
-    RequestBlockRange {
+pub enum P2PMessage {
+    Request(P2PRequest),
+    Response(P2PResponse),
+}
+
+pub enum P2PRequest {
+    BlockRange {
         peer_id: PeerId,
         start: u64,
         count: u64,
-        callback: mpsc::Sender<anyhow::Result<P2PResponse>>,
+        callback: mpsc::Sender<anyhow::Result<P2PCallbackResponse>>,
     },
+}
+
+pub struct P2PResponse {
+    pub peer_id: PeerId,
+    pub connection_id: ConnectionId,
+    pub stream_id: u64,
+    pub message: RespMessage,
 }

--- a/crates/networking/p2p/src/config.rs
+++ b/crates/networking/p2p/src/config.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::{net::IpAddr, path::PathBuf};
 
 use ream_discv5::config::DiscoveryConfig;
 
@@ -12,4 +12,6 @@ pub struct NetworkConfig {
     pub discv5_config: DiscoveryConfig,
 
     pub gossipsub_config: GossipsubConfig,
+
+    pub data_dir: PathBuf,
 }

--- a/crates/networking/p2p/src/lib.rs
+++ b/crates/networking/p2p/src/lib.rs
@@ -4,5 +4,7 @@ pub mod config;
 pub mod constants;
 pub mod gossipsub;
 pub mod network;
+pub mod network_state;
+pub mod peer;
 pub mod req_resp;
 pub mod utils;

--- a/crates/networking/p2p/src/network_state.rs
+++ b/crates/networking/p2p/src/network_state.rs
@@ -1,0 +1,58 @@
+use std::{collections::HashMap, fs, path::PathBuf};
+
+use anyhow::anyhow;
+use discv5::Enr;
+use libp2p::{Multiaddr, PeerId};
+use parking_lot::RwLock;
+use ssz::Encode;
+
+use crate::{
+    peer::{CachedPeer, ConnectionState, Direction},
+    req_resp::messages::meta_data::GetMetaDataV2,
+    utils::META_DATA_FILE_NAME,
+};
+
+pub struct NetworkState {
+    pub peer_table: RwLock<HashMap<PeerId, CachedPeer>>,
+    pub meta_data: RwLock<GetMetaDataV2>,
+    pub data_dir: PathBuf,
+}
+
+impl NetworkState {
+    pub fn upsert_peer(
+        &self,
+        peer_id: PeerId,
+        address: Option<Multiaddr>,
+        state: ConnectionState,
+        direction: Direction,
+        enr: Option<Enr>,
+    ) {
+        let mut peer_table = self.peer_table.write();
+        peer_table
+            .entry(peer_id)
+            .and_modify(|cached_peer| {
+                if let Some(address_ref) = &address {
+                    cached_peer.last_seen_p2p_address = Some(address_ref.clone());
+                }
+                cached_peer.state = state;
+                cached_peer.direction = direction;
+                if let Some(enr_ref) = &enr {
+                    cached_peer.enr = Some(enr_ref.clone());
+                }
+            })
+            .or_insert(CachedPeer {
+                peer_id,
+                last_seen_p2p_address: address,
+                state,
+                direction,
+                enr,
+            });
+    }
+
+    pub fn write_meta_data_to_disk(&self) -> anyhow::Result<()> {
+        let meta_data_path = self.data_dir.join(META_DATA_FILE_NAME);
+        fs::write(meta_data_path, self.meta_data.read().as_ssz_bytes())
+            .map_err(|err| anyhow!("Failed to write meta data to disk: {err:?}"))?;
+        Ok(())
+    }
+}

--- a/crates/networking/p2p/src/peer.rs
+++ b/crates/networking/p2p/src/peer.rs
@@ -1,0 +1,40 @@
+use discv5::Enr;
+use libp2p::{Multiaddr, PeerId};
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ConnectionState {
+    Connected,
+    Connecting,
+    Disconnected,
+    Disconnecting,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Direction {
+    Inbound,
+    Outbound,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CachedPeer {
+    /// libp2p peer ID
+    pub peer_id: PeerId,
+
+    /// Last known multiaddress observed for the peer
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_seen_p2p_address: Option<Multiaddr>,
+
+    /// Current known connection state
+    pub state: ConnectionState,
+
+    /// Direction of the most recent connection (inbound/outbound)
+    pub direction: Direction,
+
+    /// Ethereum Node Record (ENR), if known
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enr: Option<Enr>,
+}

--- a/crates/networking/p2p/src/req_resp/messages/beacon_blocks.rs
+++ b/crates/networking/p2p/src/req_resp/messages/beacon_blocks.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::B256;
-use ream_consensus::electra::beacon_block::SignedBeaconBlock;
 use ssz_derive::{Decode, Encode};
 use ssz_types::{VariableList, typenum::U1024};
 
@@ -25,10 +24,4 @@ impl BeaconBlocksByRangeV2Request {
 #[ssz(struct_behaviour = "transparent")]
 pub struct BeaconBlocksByRootV2Request {
     pub inner: VariableList<B256, U1024>,
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Encode, Decode)]
-#[ssz(struct_behaviour = "transparent")]
-pub struct BeaconBlocksResponse {
-    pub inner: VariableList<SignedBeaconBlock, U1024>,
 }

--- a/crates/networking/p2p/src/req_resp/messages/blob_sidecars.rs
+++ b/crates/networking/p2p/src/req_resp/messages/blob_sidecars.rs
@@ -1,4 +1,4 @@
-use ream_consensus::blob_sidecar::{BlobIdentifier, BlobSidecar};
+use ream_consensus::blob_sidecar::BlobIdentifier;
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
     VariableList,
@@ -26,10 +26,4 @@ pub struct BlobSidecarsByRangeV1Request {
 #[ssz(struct_behaviour = "transparent")]
 pub struct BlobSidecarsByRootV1Request {
     pub inner: VariableList<BlobIdentifier, MaxRequestBlobSidecarsElectra>,
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Encode, Decode)]
-#[ssz(struct_behaviour = "transparent")]
-pub struct BlobSidecarsResponse {
-    pub inner: VariableList<BlobSidecar, MaxRequestBlobSidecarsElectra>,
 }

--- a/crates/networking/p2p/src/req_resp/messages/mod.rs
+++ b/crates/networking/p2p/src/req_resp/messages/mod.rs
@@ -7,15 +7,12 @@ pub mod status;
 
 use std::sync::Arc;
 
-use beacon_blocks::{
-    BeaconBlocksByRangeV2Request, BeaconBlocksByRootV2Request, BeaconBlocksResponse,
-};
-use blob_sidecars::{
-    BlobSidecarsByRangeV1Request, BlobSidecarsByRootV1Request, BlobSidecarsResponse,
-};
+use beacon_blocks::{BeaconBlocksByRangeV2Request, BeaconBlocksByRootV2Request};
+use blob_sidecars::{BlobSidecarsByRangeV1Request, BlobSidecarsByRootV1Request};
 use goodbye::Goodbye;
 use meta_data::GetMetaDataV2;
 use ping::Ping;
+use ream_consensus::{blob_sidecar::BlobSidecar, electra::beacon_block::SignedBeaconBlock};
 use ssz_derive::{Decode, Encode};
 use status::Status;
 
@@ -39,8 +36,8 @@ pub enum ResponseMessage {
     Goodbye(Goodbye),
     Status(Status),
     Ping(Ping),
-    BeaconBlocksByRange(BeaconBlocksResponse),
-    BeaconBlocksByRoot(BeaconBlocksResponse),
-    BlobSidecarsByRange(BlobSidecarsResponse),
-    BlobSidecarsByRoot(BlobSidecarsResponse),
+    BeaconBlocksByRange(SignedBeaconBlock),
+    BeaconBlocksByRoot(SignedBeaconBlock),
+    BlobSidecarsByRange(BlobSidecar),
+    BlobSidecarsByRoot(BlobSidecar),
 }

--- a/crates/networking/p2p/src/req_resp/messages/ping.rs
+++ b/crates/networking/p2p/src/req_resp/messages/ping.rs
@@ -6,6 +6,12 @@ pub struct Ping {
     pub sequence_number: u64,
 }
 
+impl Ping {
+    pub fn new(sequence_number: u64) -> Self {
+        Self { sequence_number }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ssz::{Decode, Encode};

--- a/crates/networking/p2p/src/req_resp/messages/status.rs
+++ b/crates/networking/p2p/src/req_resp/messages/status.rs
@@ -7,5 +7,5 @@ pub struct Status {
     pub finalized_root: B256,
     pub finalized_epoch: u64,
     pub head_root: B256,
-    pub head_epoch: u64,
+    pub head_slot: u64,
 }

--- a/crates/networking/p2p/src/req_resp/mod.rs
+++ b/crates/networking/p2p/src/req_resp/mod.rs
@@ -40,7 +40,7 @@ pub enum ConnectionRequest {
     },
     Response {
         stream_id: u64,
-        message: RespMessage,
+        message: Box<RespMessage>,
     },
     Shutdown,
 }
@@ -75,7 +75,10 @@ impl ReqResp {
         self.events.push(ToSwarm::NotifyHandler {
             peer_id,
             handler: NotifyHandler::One(connection_id),
-            event: ConnectionRequest::Response { stream_id, message },
+            event: ConnectionRequest::Response {
+                stream_id,
+                message: Box::new(message),
+            },
         });
     }
 }
@@ -140,7 +143,7 @@ impl NetworkBehaviour for ReqResp {
             HandlerEvent::Ok(message) => self.events.push(ToSwarm::GenerateEvent(ReqRespMessage {
                 peer_id,
                 connection_id,
-                message: Ok(message),
+                message: Ok(*message),
             })),
             HandlerEvent::Err(err) => self.events.push(ToSwarm::GenerateEvent(ReqRespMessage {
                 peer_id,

--- a/crates/networking/p2p/src/utils.rs
+++ b/crates/networking/p2p/src/utils.rs
@@ -1,6 +1,11 @@
-use std::cmp::max;
+use std::{cmp::max, fs, path::PathBuf};
 
-use crate::constants::MAX_PAYLOAD_SIZE;
+use anyhow::anyhow;
+use ssz::Decode;
+
+use crate::{constants::MAX_PAYLOAD_SIZE, req_resp::messages::meta_data::GetMetaDataV2};
+
+pub const META_DATA_FILE_NAME: &str = "meta_data.ssz";
 
 /// Worst-case compressed length for a given payload of size n when using snappy:
 /// https://github.com/google/snappy/blob/32ded457c0b1fe78ceb8397632c416568d6714a0/snappy.cc#L218C1-L218C47
@@ -12,4 +17,14 @@ pub fn max_compressed_len(n: u64) -> u64 {
 /// small.
 pub fn max_message_size() -> u64 {
     max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1024 * 1024)
+}
+
+pub fn read_meta_data_from_disk(path: PathBuf) -> anyhow::Result<GetMetaDataV2> {
+    let meta_data_path = path.join(META_DATA_FILE_NAME);
+    if !meta_data_path.exists() {
+        return Ok(GetMetaDataV2::default());
+    }
+
+    GetMetaDataV2::from_ssz_bytes(&fs::read(meta_data_path)?)
+        .map_err(|err| anyhow!("Failed to decode meta data: {err:?}"))
 }

--- a/crates/networking/syncer/src/block_range/mod.rs
+++ b/crates/networking/syncer/src/block_range/mod.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
 use ream_beacon_chain::beacon_chain::BeaconChain;
-use ream_p2p::channel::P2PMessages;
+use ream_p2p::channel::P2PMessage;
 use tokio::sync::mpsc::UnboundedSender;
 
 pub struct BlockRangeSyncer {
     pub beacon_chain: Arc<BeaconChain>,
-    pub p2p_sender: UnboundedSender<P2PMessages>,
+    pub p2p_sender: UnboundedSender<P2PMessage>,
 }
 
 impl BlockRangeSyncer {
-    pub fn new(beacon_chain: Arc<BeaconChain>, p2p_sender: UnboundedSender<P2PMessages>) -> Self {
+    pub fn new(beacon_chain: Arc<BeaconChain>, p2p_sender: UnboundedSender<P2PMessage>) -> Self {
         Self {
             beacon_chain,
             p2p_sender,

--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -1,18 +1,18 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
 use actix_web::{
     HttpResponse, Responder, get,
     web::{Data, Path},
 };
 use libp2p::PeerId;
-use ream_p2p::network::PeerTable;
+use ream_p2p::network_state::NetworkState;
 
 use crate::types::{errors::ApiError, response::DataResponse};
 
 /// GET /eth/v1/node/peers/{peer_id}
 #[get("/node/peers/{peer_id}")]
 pub async fn get_peer(
-    peer_table: Data<PeerTable>,
+    network_state: Data<Arc<NetworkState>>,
     peer_id: Path<String>,
 ) -> Result<impl Responder, ApiError> {
     let peer_id = peer_id.into_inner();
@@ -20,7 +20,8 @@ pub async fn get_peer(
         ApiError::BadRequest(format!("Invalid PeerId format: {peer_id}, {err:?}"))
     })?;
 
-    let cached_peer = peer_table
+    let cached_peer = network_state
+        .peer_table
         .read()
         .get(&peer_id)
         .cloned()

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use actix_web::{App, HttpServer, dev::ServerHandle, middleware, web::Data};
 use config::RpcServerConfig;
-use ream_p2p::network::PeerTable;
+use ream_p2p::network_state::NetworkState;
 use ream_storage::db::ReamDB;
 use tracing::info;
 
@@ -15,7 +17,7 @@ pub mod types;
 pub async fn start_server(
     server_config: RpcServerConfig,
     db: ReamDB,
-    peer_table: PeerTable,
+    network_state: Arc<NetworkState>,
 ) -> std::io::Result<()> {
     info!(
         "starting HTTP server on {:?}",
@@ -30,7 +32,7 @@ pub async fn start_server(
             .wrap(middleware::Logger::default())
             .app_data(stop_handle)
             .app_data(Data::new(db.clone()))
-            .app_data(Data::new(peer_table.clone()))
+            .app_data(Data::new(network_state.clone()))
             .configure(register_routers)
     })
     .bind(server_config.http_socket_address)?


### PR DESCRIPTION
### What are you trying to achieve?

We want to handle to requests we are sent over the Req Response P2P domain

### How was it implemented/fixed?

Implementing handling the responses some in the network service itself, and others which require access to the database in NetworkManager