### PR TITLE
feat: implement compute_signed_block_header and get_sync_committee_message

### DIFF
--- a/crates/common/validator/src/block.rs
+++ b/crates/common/validator/src/block.rs
@@ -1,9 +1,14 @@
 use ream_bls::{BLSSignature, PrivateKey, traits::Signable};
 use ream_consensus::{
+    beacon_block_header::{BeaconBlockHeader, SignedBeaconBlockHeader},
     constants::DOMAIN_BEACON_PROPOSER,
-    electra::{beacon_block::BeaconBlock, beacon_state::BeaconState},
+    electra::{
+        beacon_block::{BeaconBlock, SignedBeaconBlock},
+        beacon_state::BeaconState,
+    },
     misc::{compute_epoch_at_slot, compute_signing_root},
 };
+use tree_hash::TreeHash;
 
 pub fn get_block_signature(
     state: &BeaconState,
@@ -16,4 +21,19 @@ pub fn get_block_signature(
     );
     let signing_root = compute_signing_root(block, domain);
     Ok(private_key.sign(signing_root.as_ref())?)
+}
+
+pub fn compute_signed_block_header(signed_block: &SignedBeaconBlock) -> SignedBeaconBlockHeader {
+    let block = &signed_block.message;
+    let block_header = BeaconBlockHeader {
+        slot: block.slot,
+        proposer_index: block.proposer_index,
+        parent_root: block.parent_root,
+        state_root: block.state_root,
+        body_root: block.body.tree_hash_root(),
+    };
+    SignedBeaconBlockHeader {
+        message: block_header,
+        signature: signed_block.signature.clone(),
+    }
 }

--- a/crates/common/validator/src/contribution_and_proof.rs
+++ b/crates/common/validator/src/contribution_and_proof.rs
@@ -56,7 +56,7 @@ pub fn get_contribution_and_proof(
     })
 }
 
-pub fn get_contribution_proof_and_signature(
+pub fn get_contribution_and_proof_signature(
     state: &BeaconState,
     contribution_and_proof: ContributionAndProof,
     private_key: PrivateKey,


### PR DESCRIPTION
### What are you trying to achieve?

Fixes #502 

### How was it implemented/fixed?

I implemented the compute_signed_block_header and get_sync_committee_message based on the Honest Validator Specs:

https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#sync-committee-messages
https://github.com/ethereum/consensus-specs/blob/74a077e83c08bddf369f8d5f3b3955cd57f201d8/specs/deneb/validator.md#modified-getpayloadresponse

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
