### PR TITLE
feat: implement /eth/v1/node/syncing in the validator

### DIFF
--- a/crates/common/beacon_api_types/src/lib.rs
+++ b/crates/common/beacon_api_types/src/lib.rs
@@ -4,3 +4,4 @@ pub mod id;
 pub mod query;
 pub mod request;
 pub mod responses;
+pub mod sync;

--- a/crates/common/beacon_api_types/src/sync.rs
+++ b/crates/common/beacon_api_types/src/sync.rs
@@ -5,7 +5,8 @@ use ssz_derive::{Decode, Encode};
 pub struct SyncStatus {
     #[serde(with = "serde_utils::quoted_u64")]
     pub head_slot: u64,
-    pub sync_distance: usize,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub sync_distance: u64,
     pub is_syncing: bool,
     pub is_optimistic: bool,
     pub el_offline: bool,

--- a/crates/common/beacon_api_types/src/sync.rs
+++ b/crates/common/beacon_api_types/src/sync.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+
+#[derive(Debug, Deserialize, Serialize, Encode, Decode)]
+pub struct SyncStatus {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub head_slot: u64,
+    pub sync_distance: usize,
+    pub is_syncing: bool,
+    pub is_optimistic: bool,
+    pub el_offline: bool,
+}

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -2,7 +2,6 @@ pub mod event;
 pub mod http_client;
 use std::{pin::Pin, time::Duration};
 
-use alloy_rpc_types_beacon::node::SyncStatus;
 use event::{BeaconEvent, EventTopic};
 use eventsource_client::{Client, ClientBuilder, SSE};
 use futures::{Stream, StreamExt};
@@ -11,6 +10,7 @@ use ream_beacon_api_types::{
     duties::ProposerDuty,
     error::ValidatorError,
     responses::{DataResponse, DutiesResponse},
+    sync::SyncStatus,
 };
 use reqwest::Url;
 use tracing::{error, info};

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -93,10 +93,7 @@ impl BeaconApiClient {
             });
         }
 
-        response
-            .json()
-            .await
-            .map_err(|err| ValidatorError::JsonDecodeError(err.to_string()))
+        Ok(response.json().await?)
     }
 
     pub async fn get_proposer_duties(
@@ -118,9 +115,6 @@ impl BeaconApiClient {
             });
         }
 
-        response
-            .json()
-            .await
-            .map_err(|err| ValidatorError::JsonDecodeError(err.to_string()))
+        Ok(response.json().await?)
     }
 }


### PR DESCRIPTION
### What are you trying to achieve?

Fixes #504 

### How was it implemented/fixed?
I created the expected response struct `SyncStatus` in the beacon_api_crate.
I then created a function called `get_node_syncing_status` in the beacon_api_client to make the request to a beacon node and parse the json response. 

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
