### PR TITLE
validator liveness endpoint impl

### DIFF
--- a/crates/rpc/src/routes/beacon.rs
+++ b/crates/rpc/src/routes/beacon.rs
@@ -15,7 +15,7 @@ use crate::handlers::{
     validator::{
         get_validator_balances_from_state, get_validator_from_state, get_validators_from_state,
         post_validator_balances_from_state, post_validator_identities_from_state,
-        post_validators_from_state,
+        post_validators_from_state, post_validator_liveness,
     },
 };
 
@@ -41,7 +41,8 @@ pub fn register_beacon_routes(cfg: &mut ServiceConfig) {
         .service(post_validator_identities_from_state)
         .service(post_validators_from_state)
         .service(get_validator_balances_from_state)
-        .service(post_validator_balances_from_state);
+        .service(post_validator_balances_from_state)
+        .service(post_validator_liveness);
 }
 
 pub fn register_beacon_routes_v2(cfg: &mut ServiceConfig) {


### PR DESCRIPTION
### What are you trying to achieve?

Implement the `/eth/v1/validator/liveness/{epoch}` Beacon API endpoint as requested in issue #243.

### How was it implemented/fixed?

- Added `post_validator_liveness` handler 
- Added route registration in `beacon.rs`

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
