### PR TITLE
feat: add keystore decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,6 +3306,7 @@ dependencies = [
 name = "keystore"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "alloy-primitives",
  "anyhow",
  "ream-bls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ version = "0.1.0"
 [workspace.dependencies]
 actix-web = "4.10.2"
 actix-web-lab = "0.24.1"
+aes = "0.8.4"
 alloy-consensus = { version = "1.0", default-features = false }
 alloy-primitives = { version = "1.1", features = ['serde'] }
 alloy-rlp = { version = "0.3.8", default-features = false, features = ["derive"] }

--- a/crates/crypto/keystore/Cargo.toml
+++ b/crates/crypto/keystore/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+aes.workspace = true
 alloy-primitives.workspace = true
 anyhow.workspace = true
 serde.workspace = true

--- a/crates/crypto/keystore/src/decrypt.rs
+++ b/crates/crypto/keystore/src/decrypt.rs
@@ -1,0 +1,18 @@
+use aes::{
+    cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray},
+    Aes128,
+};
+
+pub fn aes128_ctr(buf: &mut [u8], key: [u8; 16], iv: &[u8; 16]) {
+    let cipher = Aes128::new(&key.into());
+    let mut ctr = u128::from_be_bytes(*iv);
+
+    for chunk in buf.chunks_mut(16) {
+        let mut block = GenericArray::from(ctr.to_be_bytes());
+        cipher.encrypt_block(&mut block);
+        for (b, k) in chunk.iter_mut().zip(block.iter()) {
+            *b ^= k;
+        }
+        ctr = ctr.wrapping_add(1);
+    }
+}

--- a/crates/crypto/keystore/src/decrypt.rs
+++ b/crates/crypto/keystore/src/decrypt.rs
@@ -3,16 +3,16 @@ use aes::{
     cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray},
 };
 
-pub fn aes128_ctr(buf: &mut [u8], key: [u8; 16], iv: &[u8; 16]) {
+pub fn aes128_ctr(buffer: &mut [u8], key: [u8; 16], initial_vector: &[u8; 16]) {
     let cipher = Aes128::new(&key.into());
-    let mut ctr = u128::from_be_bytes(*iv);
+    let mut counter = u128::from_be_bytes(*initial_vector);
 
-    for chunk in buf.chunks_mut(16) {
-        let mut block = GenericArray::from(ctr.to_be_bytes());
+    for chunk in buffer.chunks_mut(16) {
+        let mut block = GenericArray::from(counter.to_be_bytes());
         cipher.encrypt_block(&mut block);
-        for (b, k) in chunk.iter_mut().zip(block.iter()) {
-            *b ^= k;
+        for (chunk_byte, block_byte) in chunk.iter_mut().zip(block.iter()) {
+            *chunk_byte ^= block_byte;
         }
-        ctr = ctr.wrapping_add(1);
+        counter = counter.wrapping_add(1);
     }
 }

--- a/crates/crypto/keystore/src/decrypt.rs
+++ b/crates/crypto/keystore/src/decrypt.rs
@@ -1,6 +1,6 @@
 use aes::{
-    cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray},
     Aes128,
+    cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray},
 };
 
 pub fn aes128_ctr(buf: &mut [u8], key: [u8; 16], iv: &[u8; 16]) {

--- a/crates/crypto/keystore/src/keystore.rs
+++ b/crates/crypto/keystore/src/keystore.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::Path};
 
 use alloy_primitives::B256;
-use anyhow::{Result, ensure, anyhow};
+use anyhow::{Result, anyhow, ensure};
 use ream_bls::{PrivateKey, PubKey as PublicKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/crates/crypto/keystore/src/keystore.rs
+++ b/crates/crypto/keystore/src/keystore.rs
@@ -1,8 +1,8 @@
 use std::{fs, path::Path};
 
 use alloy_primitives::B256;
-use anyhow::{Result, ensure};
-use ream_bls::{PrivateKey, PubKey};
+use anyhow::{Result, ensure, anyhow};
+use ream_bls::{PrivateKey, PubKey as PublicKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -12,14 +12,14 @@ use crate::{decrypt::aes128_ctr, hex_serde, pbkdf2::pbkdf2, scrypt::scrypt};
 pub struct EncryptedKeystore {
     pub crypto: Crypto,
     pub description: String,
-    pub pubkey: PubKey,
+    pub pubkey: PublicKey,
     pub path: String,
     pub uuid: String,
     pub version: u64,
 }
 
 pub struct Keystore {
-    pub public_key: PubKey,
+    pub public_key: PublicKey,
     pub private_key: PrivateKey,
 }
 
@@ -86,12 +86,12 @@ impl EncryptedKeystore {
         match &self.crypto.cipher.params {
             CipherParams::Aes128Ctr { iv } => {
                 let key_param: [u8; 16] = derived_key[0..16].try_into().map_err(|err| {
-                    anyhow::anyhow!(format!(
+                    anyhow!(format!(
                         "Failed to convert derived key into 16 byte array: {err:?}"
                     ))
                 })?;
                 let iv_param: &[u8; 16] = iv.as_slice().try_into().map_err(|err| {
-                    anyhow::anyhow!(format!(
+                    anyhow!(format!(
                         "Failed to convert derived key into 16 byte array: {err:?}"
                     ))
                 })?;
@@ -196,7 +196,7 @@ mod tests {
                 },
             },
             description: "Test Keystore".to_string(),
-            pubkey: PubKey {
+            pubkey: PublicKey {
                 inner: FixedVector::from(vec![0x12; 48]),
             },
             path: "m/44'/60'/0'/0/0".to_string(),
@@ -243,7 +243,7 @@ mod tests {
                         },
                     },
                     description: "".to_string(),
-                    pubkey: PubKey {
+                    pubkey: PublicKey {
                         inner: FixedVector::from(
                             hex::decode(
                                 "b69dfa082ca75d4e50ed4da8fa07d550ba9ec4019815409f42a98b79861d7ad96633a2476594b94c8a6e3048e1b2623e",

--- a/crates/crypto/keystore/src/lib.rs
+++ b/crates/crypto/keystore/src/lib.rs
@@ -1,7 +1,7 @@
-pub mod keystore;
 pub mod decrypt;
 pub mod hex_serde;
 pub mod hmac;
+pub mod keystore;
 pub mod pbkdf2;
 pub mod salsa;
 pub mod scrypt;

--- a/crates/crypto/keystore/src/lib.rs
+++ b/crates/crypto/keystore/src/lib.rs
@@ -1,4 +1,5 @@
-pub mod encrypted_keystore;
+pub mod keystore;
+pub mod decrypt;
 pub mod hex_serde;
 pub mod hmac;
 pub mod pbkdf2;


### PR DESCRIPTION
### What are you trying to achieve?

 fixes https://github.com/ReamLabs/ream/issues/510

### How was it implemented/fixed?

Adds a method to get actual key pairs from an encrypted keystore, such as those generated with the staking CLI.

### To-Do

The next logical step is to use these key pairs for our validator client.
