### PR TITLE
feat: implement get_config_spec and get_sync_committee_duties in the Validator Beacon Client

### DIFF
--- a/crates/common/beacon_api_types/src/duties.rs
+++ b/crates/common/beacon_api_types/src/duties.rs
@@ -25,3 +25,11 @@ pub struct AttesterDuty {
     #[serde(with = "serde_utils::quoted_u64")]
     pub slot: u64,
 }
+
+#[derive(Debug, Deserialize, Serialize, Encode, Decode)]
+pub struct SyncCommitteeDuty {
+    pub pubkey: PubKey,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    pub validator_sync_committee_indices: Vec<u64>,
+}

--- a/crates/common/beacon_api_types/src/responses.rs
+++ b/crates/common/beacon_api_types/src/responses.rs
@@ -145,6 +145,30 @@ impl<T: Serialize + Encode + Decode> DutiesResponse<T> {
     }
 }
 
+/// A SyncCommitteeDutiesResponse data struct that can be used to wrap duty data
+/// for sync committee duties
+/// used for json rpc responses
+///
+/// # Example
+/// {
+///     "execution_optimistic": false,
+///     "data": [T]
+/// }
+#[derive(Debug, Deserialize, Serialize, Encode, Decode)]
+pub struct SyncCommitteeDutiesResponse<T: Encode + Decode> {
+    pub execution_optimistic: bool,
+    pub data: Vec<T>,
+}
+
+impl<T: Serialize + Encode + Decode> SyncCommitteeDutiesResponse<T> {
+    pub fn new(data: Vec<T>) -> Self {
+        Self {
+            execution_optimistic: EXECUTION_OPTIMISTIC,
+            data,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct BeaconHeadResponse {
     pub root: B256,

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -7,9 +7,9 @@ use eventsource_client::{Client, ClientBuilder, SSE};
 use futures::{Stream, StreamExt};
 use http_client::{ClientWithBaseUrl, ContentType};
 use ream_beacon_api_types::{
-    duties::{AttesterDuty, ProposerDuty},
+    duties::{AttesterDuty, ProposerDuty, SyncCommitteeDuty},
     error::ValidatorError,
-    responses::{DataResponse, DutiesResponse},
+    responses::{DataResponse, DutiesResponse, SyncCommitteeDutiesResponse},
     sync::SyncStatus,
 };
 use ream_network_spec::networks::NetworkSpec;
@@ -76,8 +76,6 @@ impl BeaconApiClient {
             })
             .boxed())
     }
-
-    
 
     pub async fn get_config_spec(
         &self,
@@ -153,6 +151,35 @@ impl BeaconApiClient {
             .execute(
                 self.http_client
                     .post(format!("/eth/v1/validator/duties/attester/{epoch}"))?
+                    .json(&json!(
+                        validator_indices
+                            .iter()
+                            .map(|i| i.to_string())
+                            .collect::<Vec<_>>()
+                    ))
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(response.json().await?)
+    }
+
+    pub async fn get_sync_committee_duties(
+        &self,
+        epoch: u64,
+        validator_indices: &[u64],
+    ) -> Result<SyncCommitteeDutiesResponse<SyncCommitteeDuty>, ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .post(format!("/eth/v1/validator/duties/sync/{epoch}"))?
                     .json(&json!(
                         validator_indices
                             .iter()

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -1,6 +1,6 @@
 pub mod event;
 pub mod http_client;
-use std::{any, pin::Pin, time::Duration};
+use std::{pin::Pin, time::Duration};
 
 use event::{BeaconEvent, EventTopic};
 use eventsource_client::{Client, ClientBuilder, SSE};

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -12,6 +12,7 @@ use ream_beacon_api_types::{
     responses::{DataResponse, DutiesResponse},
     sync::SyncStatus,
 };
+use ream_network_spec::networks::NetworkSpec;
 use reqwest::Url;
 use serde_json::json;
 use tracing::{error, info};
@@ -74,6 +75,29 @@ impl BeaconApiClient {
                 }
             })
             .boxed())
+    }
+
+    
+
+    pub async fn get_config_spec(
+        &self,
+    ) -> anyhow::Result<DataResponse<NetworkSpec>, ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .get("/eth/v1/config/spec".to_string())?
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(response.json().await?)
     }
 
     pub async fn get_node_syncing_status(

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -1,6 +1,6 @@
 pub mod event;
 pub mod http_client;
-use std::{pin::Pin, time::Duration};
+use std::{any, pin::Pin, time::Duration};
 
 use event::{BeaconEvent, EventTopic};
 use eventsource_client::{Client, ClientBuilder, SSE};
@@ -12,6 +12,7 @@ use ream_beacon_api_types::{
     responses::{DataResponse, DutiesResponse, SyncCommitteeDutiesResponse},
     sync::SyncStatus,
 };
+use ream_consensus::genesis::Genesis;
 use ream_network_spec::networks::NetworkSpec;
 use reqwest::Url;
 use serde_json::json;
@@ -75,6 +76,25 @@ impl BeaconApiClient {
                 }
             })
             .boxed())
+    }
+
+    pub async fn get_genesis(&self) -> anyhow::Result<DataResponse<Genesis>, ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .get("/eth/v1/beacon/genesis".to_string())?
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(response.json().await?)
     }
 
     pub async fn get_config_spec(


### PR DESCRIPTION
### What are you trying to achieve?

Fixes #515 
Fixes #514 
Fixes #431 

### How was it implemented/fixed?
We make a get request to the beacon node for the spec and parse the response in a NetworkSpec struct.
We make a post request for getting the sync committee duties and parse the response in the newly created SyncCommitteeDutiesResponse and SyncCommitteeDuty struct. 

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
