### PR TITLE
feat: implement get_state_fork and get_state_validator in the validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,6 +4909,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "ream-bls",
+ "ream-consensus",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/common/beacon_api_types/Cargo.toml
+++ b/crates/common/beacon_api_types/Cargo.toml
@@ -24,3 +24,4 @@ url.workspace = true
 
 # ream dependencies
 ream-bls.workspace = true
+ream-consensus.workspace = true

--- a/crates/common/beacon_api_types/src/lib.rs
+++ b/crates/common/beacon_api_types/src/lib.rs
@@ -5,3 +5,4 @@ pub mod query;
 pub mod request;
 pub mod responses;
 pub mod sync;
+pub mod validator;

--- a/crates/common/beacon_api_types/src/validator.rs
+++ b/crates/common/beacon_api_types/src/validator.rs
@@ -1,0 +1,31 @@
+use ream_consensus::validator::Validator;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ValidatorData {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub balance: u64,
+    pub status: String,
+    pub validator: Validator,
+}
+
+impl ValidatorData {
+    pub fn new(index: u64, balance: u64, status: String, validator: Validator) -> Self {
+        Self {
+            index,
+            balance,
+            status,
+            validator,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ValidatorBalance {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub balance: u64,
+}

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -14,7 +14,8 @@ use ream_beacon_api_types::{
     sync::SyncStatus,
     validator::ValidatorData,
 };
-use ream_consensus::fork::Fork;
+use ream_consensus::{fork::Fork, genesis::Genesis};
+use ream_network_spec::networks::NetworkSpec;
 use reqwest::Url;
 use serde_json::json;
 use tracing::{error, info};
@@ -77,6 +78,46 @@ impl BeaconApiClient {
                 }
             })
             .boxed())
+    }
+
+    pub async fn get_genesis(&self) -> anyhow::Result<DataResponse<Genesis>, ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .get("/eth/v1/beacon/genesis".to_string())?
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(response.json().await?)
+    }
+
+    pub async fn get_config_spec(
+        &self,
+    ) -> anyhow::Result<DataResponse<NetworkSpec>, ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .get("/eth/v1/config/spec".to_string())?
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(response.json().await?)
     }
 
     pub async fn get_state_fork(

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -7,10 +7,10 @@ use eventsource_client::{Client, ClientBuilder, SSE};
 use futures::{Stream, StreamExt};
 use http_client::{ClientWithBaseUrl, ContentType};
 use ream_beacon_api_types::{
-    duties::{AttesterDuty, ProposerDuty},
+    duties::{AttesterDuty, ProposerDuty, SyncCommitteeDuty},
     error::ValidatorError,
     id::{ID, ValidatorID},
-    responses::{BeaconResponse, DataResponse, DutiesResponse},
+    responses::{BeaconResponse, DataResponse, DutiesResponse, SyncCommitteeDutiesResponse},
     sync::SyncStatus,
     validator::ValidatorData,
 };
@@ -179,6 +179,35 @@ impl BeaconApiClient {
             .execute(
                 self.http_client
                     .post(format!("/eth/v1/validator/duties/attester/{epoch}"))?
+                    .json(&json!(
+                        validator_indices
+                            .iter()
+                            .map(|i| i.to_string())
+                            .collect::<Vec<_>>()
+                    ))
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(response.json().await?)
+    }
+
+    pub async fn get_sync_committee_duties(
+        &self,
+        epoch: u64,
+        validator_indices: &[u64],
+    ) -> Result<SyncCommitteeDutiesResponse<SyncCommitteeDuty>, ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .post(format!("/eth/v1/validator/duties/sync/{epoch}"))?
                     .json(&json!(
                         validator_indices
                             .iter()

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -10,45 +10,17 @@ use ream_beacon_api_types::{
     query::{IdQuery, StatusQuery},
     request::ValidatorsPostRequest,
     responses::BeaconResponse,
+    validator::{ValidatorBalance, ValidatorData},
 };
 use ream_bls::PubKey;
 use ream_consensus::validator::Validator;
 use ream_storage::db::ReamDB;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tracing::error;
 
 use super::state::get_state_from_id;
 
 const MAX_VALIDATOR_COUNT: usize = 100;
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ValidatorData {
-    #[serde(with = "serde_utils::quoted_u64")]
-    index: u64,
-    #[serde(with = "serde_utils::quoted_u64")]
-    balance: u64,
-    status: String,
-    validator: Validator,
-}
-
-impl ValidatorData {
-    pub fn new(index: u64, balance: u64, status: String, validator: Validator) -> Self {
-        Self {
-            index,
-            balance,
-            status,
-            validator,
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-struct ValidatorBalance {
-    #[serde(with = "serde_utils::quoted_u64")]
-    index: u64,
-    #[serde(with = "serde_utils::quoted_u64")]
-    balance: u64,
-}
 
 fn build_validator_balances(
     validators: &[(Validator, u64)],


### PR DESCRIPTION
### What are you trying to achieve?

Fixes #524 
Fixes #525

### How was it implemented/fixed?
We moved the structs for ValidatorData and ValidatorBalance from the rpc crate to the beacon_api_types crate as it is used across rpc and validator.
We then made GET requests as per the Beacon API spec to the below endpoints and parsed their JSON response to the appropriate structs. 
/eth/v1/beacon/states/{state_id}/fork
/eth/v1/beacon/states/{state_id}/validators/{validator_id} 
  

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
