### PR TITLE
feat: Connect p2p gossip messages to network manager and add respective on_*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,6 +4925,7 @@ dependencies = [
  "ream-execution-engine",
  "ream-fork-choice",
  "ream-storage",
+ "tokio",
 ]
 
 [[package]]
@@ -5100,12 +5101,14 @@ dependencies = [
  "ream-discv5",
  "ream-execution-engine",
  "ream-executor",
+ "ream-fork-choice",
  "ream-network-spec",
  "ream-p2p",
  "ream-storage",
  "ream-syncer",
  "tokio",
  "tracing",
+ "tree_hash",
  "url",
 ]
 

--- a/crates/common/beacon_chain/Cargo.toml
+++ b/crates/common/beacon_chain/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+tokio.workspace = true
 
 # ream dependencies
 ream-consensus.workspace = true

--- a/crates/common/beacon_chain/src/beacon_chain.rs
+++ b/crates/common/beacon_chain/src/beacon_chain.rs
@@ -1,11 +1,18 @@
-use ream_consensus::electra::beacon_block::SignedBeaconBlock;
+use ream_consensus::{
+    attestation::Attestation, attester_slashing::AttesterSlashing,
+    electra::beacon_block::SignedBeaconBlock,
+};
 use ream_execution_engine::ExecutionEngine;
-use ream_fork_choice::{handlers::on_block, store::Store};
+use ream_fork_choice::{
+    handlers::{on_attestation, on_attester_slashing, on_block, on_tick},
+    store::Store,
+};
 use ream_storage::db::ReamDB;
+use tokio::sync::Mutex;
 
 /// BeaconChain is the main struct which manages the nodes local beacon chain.
 pub struct BeaconChain {
-    pub store: Store,
+    pub store: Mutex<Store>,
     pub execution_engine: Option<ExecutionEngine>,
 }
 
@@ -13,13 +20,39 @@ impl BeaconChain {
     /// Creates a new instance of `BeaconChain`.
     pub fn new(db: ReamDB, execution_engine: Option<ExecutionEngine>) -> Self {
         Self {
-            store: Store::new(db),
+            store: Mutex::new(Store::new(db)),
             execution_engine,
         }
     }
 
-    pub async fn process_block(&mut self, signed_block: SignedBeaconBlock) -> anyhow::Result<()> {
-        on_block(&mut self.store, &signed_block, &self.execution_engine).await?;
+    pub async fn process_block(&self, signed_block: SignedBeaconBlock) -> anyhow::Result<()> {
+        let mut store = self.store.lock().await;
+        on_block(&mut store, &signed_block, &self.execution_engine).await?;
+        Ok(())
+    }
+
+    pub async fn process_attester_slashing(
+        &self,
+        attester_slashing: AttesterSlashing,
+    ) -> anyhow::Result<()> {
+        let mut store = self.store.lock().await;
+        on_attester_slashing(&mut store, attester_slashing)?;
+        Ok(())
+    }
+
+    pub async fn process_attestation(
+        &self,
+        attestation: Attestation,
+        is_from_block: bool,
+    ) -> anyhow::Result<()> {
+        let mut store = self.store.lock().await;
+        on_attestation(&mut store, attestation, is_from_block)?;
+        Ok(())
+    }
+
+    pub async fn process_tick(&self, time: u64) -> anyhow::Result<()> {
+        let mut store = self.store.lock().await;
+        on_tick(&mut store, time)?;
         Ok(())
     }
 }

--- a/crates/networking/manager/Cargo.toml
+++ b/crates/networking/manager/Cargo.toml
@@ -15,6 +15,7 @@ discv5.workspace = true
 libp2p.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tree_hash.workspace = true
 url.workspace = true
 
 # ream dependencies
@@ -23,6 +24,7 @@ ream-consensus.workspace = true
 ream-discv5.workspace = true
 ream-execution-engine.workspace = true
 ream-executor.workspace = true
+ream-fork-choice.workspace = true
 ream-network-spec.workspace = true
 ream-p2p.workspace = true
 ream-storage.workspace = true

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -1,4 +1,8 @@
-use std::{path::PathBuf, sync::Arc, time::{Duration, UNIX_EPOCH}};
+use std::{
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use anyhow::anyhow;
 use discv5::multiaddr::PeerId;
@@ -174,8 +178,13 @@ impl ManagerService {
         let mut interval = interval(Duration::from_secs(12));
         loop {
             tokio::select! {
-                time = interval.tick() => {
-                    if let Err(err) = self.beacon_chain.process_tick(time.duration_since(UNIX_EPOCH)).await {
+                _ = interval.tick() => {
+                    let time = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .expect("correct time")
+                        .as_secs();
+
+                    if let Err(err) = self.beacon_chain.process_tick(time).await {
                         error!("Failed to process gossipsub tick: {}", err);
                     }
                 }

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc, time::{Duration, UNIX_EPOCH}};
 
 use anyhow::anyhow;
 use discv5::multiaddr::PeerId;
@@ -17,6 +17,7 @@ use ream_p2p::{
     config::NetworkConfig,
     gossipsub::{
         configurations::GossipsubConfig,
+        message::GossipsubMessage,
         topics::{GossipTopic, GossipTopicKind},
     },
     network::{Network, ReamNetworkEvent},
@@ -37,8 +38,9 @@ use ream_storage::{
     tables::{Field, Table},
 };
 use ream_syncer::block_range::BlockRangeSyncer;
-use tokio::{sync::mpsc, task::JoinHandle};
-use tracing::{info, trace, warn};
+use tokio::{sync::mpsc, task::JoinHandle, time::interval};
+use tracing::{error, info, trace, warn};
+use tree_hash::TreeHash;
 
 use crate::config::ManagerConfig;
 
@@ -78,10 +80,56 @@ impl ManagerService {
         };
 
         let mut gossipsub_config = GossipsubConfig::default();
-        gossipsub_config.set_topics(vec![GossipTopic {
-            fork: network_spec().fork_digest(genesis_validators_root()),
-            kind: GossipTopicKind::BeaconBlock,
-        }]);
+        gossipsub_config.set_topics(vec![
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::BeaconBlock,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::AggregateAndProof,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::VoluntaryExit,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::ProposerSlashing,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::AttesterSlashing,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::BeaconAttestation(0),
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::SyncCommittee(0),
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::SyncCommitteeContributionAndProof,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::BlsToExecutionChange,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::LightClientFinalityUpdate,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::LightClientOptimisticUpdate,
+            },
+            GossipTopic {
+                fork: network_spec().fork_digest(genesis_validators_root()),
+                kind: GossipTopicKind::BlobSidecar(0),
+            },
+        ]);
 
         let network_config = NetworkConfig {
             socket_address: config.socket_address,
@@ -123,10 +171,110 @@ impl ManagerService {
 
     pub async fn start(self) {
         let mut manager_receiver = self.manager_receiver;
+        let mut interval = interval(Duration::from_secs(12));
         loop {
             tokio::select! {
+                time = interval.tick() => {
+                    if let Err(err) = self.beacon_chain.process_tick(time.duration_since(UNIX_EPOCH)).await {
+                        error!("Failed to process gossipsub tick: {}", err);
+                    }
+                }
                 Some(event) = manager_receiver.recv() => {
-                     match event {
+                    match event {
+                        ReamNetworkEvent::GossipsubMessage { message } => {
+                            match GossipsubMessage::decode(&message.topic, &message.data) {
+                                Ok(gossip_message) => match gossip_message {
+                                    GossipsubMessage::BeaconBlock(signed_block) => {
+                                        info!(
+                                            "Beacon block received over gossipsub: slot: {}, root: {}",
+                                            signed_block.message.slot,
+                                            signed_block.message.block_root()
+                                        );
+
+                                        if let Err(err) = self.beacon_chain.process_block(*signed_block).await {
+                                            error!("Failed to process gossipsub beacon block: {}", err);
+                                        }
+                                    }
+                                    GossipsubMessage::BeaconAttestation(attestation) => {
+                                        info!(
+                                            "Beacon Attestation received over gossipsub: root: {}",
+                                            attestation.tree_hash_root()
+                                        );
+
+                                        let is_from_block = false;
+
+                                        if let Err(err) = self.beacon_chain.process_attestation(*attestation, is_from_block).await {
+                                            error!("Failed to process gossipsub attestation: {}", err);
+                                        }
+                                    }
+                                    GossipsubMessage::BlsToExecutionChange(bls_to_execution_change) => {
+                                        info!(
+                                            "Bls To Execution Change received over gossipsub: root: {}",
+                                            bls_to_execution_change.tree_hash_root()
+                                        );
+                                    }
+                                    GossipsubMessage::AggregateAndProof(aggregate_and_proof) => {
+                                        info!(
+                                            "Aggregate And Proof received over gossipsub: root: {}",
+                                            aggregate_and_proof.tree_hash_root()
+                                        );
+                                    }
+                                    GossipsubMessage::SyncCommittee(sync_committee) => {
+                                        info!(
+                                            "Sync Committee received over gossipsub: root: {}",
+                                            sync_committee.tree_hash_root()
+                                        );
+                                    }
+                                    GossipsubMessage::SyncCommitteeContributionAndProof(
+                                        sync_committee_contribution_and_proof,
+                                    ) => {
+                                        info!(
+                                            "Sync Committee Contribution And Proof received over gossipsub: root: {}",
+                                            sync_committee_contribution_and_proof.tree_hash_root()
+                                        );
+                                    }
+                                    GossipsubMessage::AttesterSlashing(attester_slashing) => {
+                                        info!(
+                                            "Attester Slashing received over gossipsub: root: {}",
+                                            attester_slashing.tree_hash_root()
+                                        );
+
+                                        if let Err(err) = self.beacon_chain.process_attester_slashing(*attester_slashing).await {
+                                            error!("Failed to process gossipsub attester slashing: {}", err);
+                                        }
+                                    }
+                                    GossipsubMessage::ProposerSlashing(proposer_slashing) => {
+                                        info!(
+                                            "Proposer Slashing received over gossipsub: root: {}",
+                                            proposer_slashing.tree_hash_root()
+                                        );
+                                    }
+                                    GossipsubMessage::BlobSidecar(blob_sidecar) => {
+                                        info!(
+                                            "Blob Sidecar received over gossipsub: root: {}",
+                                            blob_sidecar.tree_hash_root()
+                                        );
+                                    }
+                                    GossipsubMessage::LightClientFinalityUpdate(light_client_finality_update) => {
+                                        info!(
+                                            "Light Client Finality Update received over gossipsub: root: {}",
+                                            light_client_finality_update.tree_hash_root()
+                                        );
+                                    }
+                                    GossipsubMessage::LightClientOptimisticUpdate(
+                                        light_client_optimistic_update,
+                                    ) => {
+                                        info!(
+                                            "Light Client Optimistic Update received over gossipsub: root: {}",
+                                            light_client_optimistic_update.tree_hash_root()
+                                        );
+                                    }
+                                },
+                                Err(err) => {
+                                    trace!("Failed to decode gossip message: {err:?}");
+                                }
+                            }
+                        },
                         ReamNetworkEvent::RequestMessage { peer_id, stream_id, connection_id, message } => {
                             match message {
                                 RequestMessage::Status(status) => {
@@ -142,13 +290,15 @@ impl ManagerService {
                                         continue;
                                     };
 
-                                    let head_root = match self.beacon_chain.store.get_head() {
+                                    let store = self.beacon_chain.store.lock().await;
+                                    let head_root = match store.get_head() {
                                         Ok(head) => head,
                                         Err(err) => {
                                             warn!("Failed to get head root: {err}, falling back to finalized root");
                                             finalized_checkpoint.root
                                         }
                                     };
+
 
                                     let head_slot = match self.ream_db.beacon_block_provider().get(head_root) {
                                         Ok(Some(block)) => block.message.slot,

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -175,7 +175,7 @@ impl ManagerService {
 
     pub async fn start(self) {
         let mut manager_receiver = self.manager_receiver;
-        let mut interval = interval(Duration::from_secs(12));
+        let mut interval = interval(Duration::from_secs(network_spec().seconds_per_slot));
         loop {
             tokio::select! {
                 _ = interval.tick() => {
@@ -185,7 +185,7 @@ impl ManagerService {
                         .as_secs();
 
                     if let Err(err) = self.beacon_chain.process_tick(time).await {
-                        error!("Failed to process gossipsub tick: {}", err);
+                        error!("Failed to process gossipsub tick: {err}");
                     }
                 }
                 Some(event) = manager_receiver.recv() => {
@@ -201,7 +201,7 @@ impl ManagerService {
                                         );
 
                                         if let Err(err) = self.beacon_chain.process_block(*signed_block).await {
-                                            error!("Failed to process gossipsub beacon block: {}", err);
+                                            error!("Failed to process gossipsub beacon block: {err}");
                                         }
                                     }
                                     GossipsubMessage::BeaconAttestation(attestation) => {
@@ -213,7 +213,7 @@ impl ManagerService {
                                         let is_from_block = false;
 
                                         if let Err(err) = self.beacon_chain.process_attestation(*attestation, is_from_block).await {
-                                            error!("Failed to process gossipsub attestation: {}", err);
+                                            error!("Failed to process gossipsub attestation: {err}");
                                         }
                                     }
                                     GossipsubMessage::BlsToExecutionChange(bls_to_execution_change) => {
@@ -249,7 +249,7 @@ impl ManagerService {
                                         );
 
                                         if let Err(err) = self.beacon_chain.process_attester_slashing(*attester_slashing).await {
-                                            error!("Failed to process gossipsub attester slashing: {}", err);
+                                            error!("Failed to process gossipsub attester slashing: {err}");
                                         }
                                     }
                                     GossipsubMessage::ProposerSlashing(proposer_slashing) => {

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -210,9 +210,7 @@ impl ManagerService {
                                             attestation.tree_hash_root()
                                         );
 
-                                        let is_from_block = false;
-
-                                        if let Err(err) = self.beacon_chain.process_attestation(*attestation, is_from_block).await {
+                                        if let Err(err) = self.beacon_chain.process_attestation(*attestation, true).await {
                                             error!("Failed to process gossipsub attestation: {err}");
                                         }
                                     }
@@ -299,8 +297,7 @@ impl ManagerService {
                                         continue;
                                     };
 
-                                    let store = self.beacon_chain.store.lock().await;
-                                    let head_root = match store.get_head() {
+                                    let head_root = match self.beacon_chain.store.lock().await.get_head() {
                                         Ok(head) => head,
                                         Err(err) => {
                                             warn!("Failed to get head root: {err}, falling back to finalized root");


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: https://github.com/ReamLabs/ream/issues/451

### How was it implemented/fixed?

Connected p2p gossip messages to network manager and added respective on_

