### PR TITLE
feat: implement prepare_committee_subnet and publish_aggregate_and_proofs

### DIFF
--- a/crates/common/beacon_api_types/src/committee.rs
+++ b/crates/common/beacon_api_types/src/committee.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BeaconCommitteeSubscription {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub committee_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub committees_at_slot: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub slot: u64,
+    pub is_aggregator: bool,
+}

--- a/crates/common/beacon_api_types/src/lib.rs
+++ b/crates/common/beacon_api_types/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod committee;
 pub mod duties;
 pub mod error;
 pub mod id;

--- a/crates/common/validator/src/aggregate_and_proof.rs
+++ b/crates/common/validator/src/aggregate_and_proof.rs
@@ -18,6 +18,12 @@ pub struct AggregateAndProof {
     pub selection_proof: BLSSignature,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct SignedAggregateAndProof {
+    pub message: AggregateAndProof,
+    pub signature: BLSSignature,
+}
+
 pub fn get_aggregate_and_proof(
     state: &BeaconState,
     aggregator_index: u64,

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -7,6 +7,7 @@ use eventsource_client::{Client, ClientBuilder, SSE};
 use futures::{Stream, StreamExt};
 use http_client::{ClientWithBaseUrl, ContentType};
 use ream_beacon_api_types::{
+    committee::BeaconCommitteeSubscription,
     duties::{AttesterDuty, ProposerDuty, SyncCommitteeDuty},
     error::ValidatorError,
     id::{ID, ValidatorID},
@@ -301,6 +302,29 @@ impl BeaconApiClient {
         }
 
         Ok(response.json().await?)
+    }
+
+    pub async fn prepare_committe_subnet(
+        &self,
+        subscriptions: Vec<BeaconCommitteeSubscription>,
+    ) -> anyhow::Result<(), ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .post("/eth/v1/validator/beacon_committee_subscriptions".to_string())?
+                    .json(&subscriptions)
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(())
     }
 
     pub async fn get_attestation_data(


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: #517 
Fixes: #537 

Small PR implementing some of the Beacon API callers required for attesting validators. I aim to finish all the proposer and attester endpoints in an upcoming PR.

### How was it implemented/fixed?

Both functions were implemented as per their Beacon API specs:
https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/publishAggregateAndProofsV2 
https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/prepareBeaconCommitteeSubnet

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
