### PR TITLE
feat: Initial implementation of ream's account manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,13 +1168,26 @@ dependencies = [
 
 [[package]]
 name = "bls12_381"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
+dependencies = [
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pairing 0.22.0",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "bls12_381"
 version = "0.8.0"
 source = "git+https://github.com/zkcrypto/bls12_381?rev=9ea427c0eb1a7e2ac16902a322aea156c496ddb0#9ea427c0eb1a7e2ac16902a322aea156c496ddb0"
 dependencies = [
  "digest 0.10.7",
- "ff",
- "group",
- "pairing",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "pairing 0.23.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1459,6 +1483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1569,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -2003,9 +2043,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2183,6 +2223,17 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2481,11 +2532,23 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "memuse",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2529,6 +2592,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "halo2"
+version = "0.1.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
+dependencies = [
+ "halo2_proofs",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pasta_curves 0.4.1",
+ "rand_core 0.6.4",
+ "rayon",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2648,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashsig"
+version = "0.1.0"
+source = "git+https://github.com/b-wagn/hash-sig#489054d66635d09a56f01be66efc296e8019a876"
+dependencies = [
+ "num-bigint",
+ "rand 0.8.5",
+ "rayon",
+ "sha3",
+ "zkhash",
 ]
 
 [[package]]
@@ -3269,6 +3367,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jubjub"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
+dependencies = [
+ "bitvec",
+ "bls12_381 0.7.1",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,6 +3435,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -3955,6 +4070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memuse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,11 +4477,20 @@ dependencies = [
 
 [[package]]
 name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group 0.12.1",
+]
+
+[[package]]
+name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -4418,6 +4548,36 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "lazy_static",
+ "rand 0.8.5",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "lazy_static",
+ "rand 0.8.5",
+ "static_assertions",
+ "subtle",
 ]
 
 [[package]]
@@ -4848,6 +5008,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4893,6 +5073,8 @@ dependencies = [
 name = "ream-account-manager"
 version = "0.1.0"
 dependencies = [
+ "hashsig",
+ "rand 0.8.5",
  "tracing",
 ]
 
@@ -4933,11 +5115,11 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
- "bls12_381",
+ "bls12_381 0.8.0",
  "blst",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "group",
+ "group 0.13.0",
  "serde",
  "sha2 0.10.8",
  "ssz_types",
@@ -6165,6 +6347,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -7646,6 +7834,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "zkhash"
+version = "0.2.0"
+source = "git+https://github.com/HorizenLabs/poseidon2?branch=main#055bde3f4782731ba5f5ce5888a440a94327eaf3"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+ "bitvec",
+ "blake2",
+ "bls12_381 0.7.1",
+ "byteorder",
+ "cfg-if",
+ "group 0.12.1",
+ "group 0.13.0",
+ "halo2",
+ "hex",
+ "jubjub",
+ "lazy_static",
+ "pasta_curves 0.5.1",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.8",
+ "sha3",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4869,6 +4869,7 @@ dependencies = [
  "clap",
  "discv5",
  "hashbrown 0.15.3",
+ "ream-account-manager",
  "ream-checkpoint-sync",
  "ream-consensus",
  "ream-discv5",
@@ -4886,6 +4887,13 @@ dependencies = [
  "tracing-subscriber",
  "unicode-normalization",
  "url",
+]
+
+[[package]]
+name = "ream-account-manager"
+version = "0.1.0"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 default-members = ["bin/ream"]
 members = [
     "bin/ream",
+    "crates/account_manager",
     "crates/common/beacon_api_types",
     "crates/common/beacon_chain",
     "crates/common/checkpoint_sync",
@@ -99,6 +100,7 @@ unicode-normalization = "0.1.24"
 url = "2.5"
 
 # ream dependencies
+ream-account-manager = { path = "crates/account_manager" }
 ream-beacon-api-types = { path = "crates/common/beacon_api_types" }
 ream-beacon-chain = { path = "crates/common/beacon_chain" }
 ream-bls = { path = "crates/crypto/bls", features = ["zkcrypto"] } # Default feature is zkcrypto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ ethereum_ssz_derive = "0.9"
 eventsource-client = "0.15.0"
 futures = "0.3"
 hashbrown = "0.15.3"
+hashsig = { git = "https://github.com/b-wagn/hash-sig" }
+rand = "0.8"
 itertools = "0.14"
 jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -27,6 +27,7 @@ unicode-normalization.workspace = true
 url.workspace = true
 
 # ream dependencies
+ream-account-manager.workspace = true
 ream-checkpoint-sync.workspace = true
 ream-consensus.workspace = true
 ream-discv5.workspace = true

--- a/bin/ream/src/cli/account_manager.rs
+++ b/bin/ream/src/cli/account_manager.rs
@@ -1,0 +1,46 @@
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct AccountManagerConfig {
+    /// Verbosity level
+    #[arg(short, long, default_value_t = 3)]
+    pub verbosity: u8,
+
+    /// Account lifetime in 2 ** lifetime slots
+    #[arg(short, long, default_value_t = 28)]
+    pub lifetime: u64,
+
+    /// Chunk size for messages
+    #[arg(short, long, default_value_t = 5)]
+    pub chunk_size: u64,
+}
+
+impl Default for AccountManagerConfig {
+    fn default() -> Self {
+        Self {
+            verbosity: 3,
+            lifetime: 28,
+            chunk_size: 5,
+        }
+    }
+}
+
+impl AccountManagerConfig {
+    pub fn new() -> Self {
+        Self::parse()
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        // Validate chunk size
+        if self.chunk_size < 4 {
+            anyhow::bail!("Chunk size must be at least 4");
+        }
+
+        // Validate lifetime
+        if self.lifetime < 18 {
+            anyhow::bail!("Lifetime must be at least 18");
+        }
+
+        Ok(())
+    }
+}

--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod account_manager;
 pub mod beacon_node;
 pub mod constants;
 pub mod import_keystores;
@@ -6,7 +7,10 @@ pub mod validator_node;
 use clap::{Parser, Subcommand};
 use ream_node::version::FULL_VERSION;
 
-use crate::cli::{beacon_node::BeaconNodeConfig, validator_node::ValidatorNodeConfig};
+use crate::cli::{
+    account_manager::AccountManagerConfig, beacon_node::BeaconNodeConfig,
+    validator_node::ValidatorNodeConfig,
+};
 
 #[derive(Debug, Parser)]
 #[command(author, version = FULL_VERSION, about, long_about = None)]
@@ -17,11 +21,17 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
-    /// Start the node
+    /// Start the beacon node
     #[command(name = "beacon_node")]
     BeaconNode(Box<BeaconNodeConfig>),
+
+    /// Start the validator node
     #[command(name = "validator_node")]
     ValidatorNode(Box<ValidatorNodeConfig>),
+
+    /// Manage validator accounts
+    #[command(name = "account_manager")]
+    AccountManager(Box<AccountManagerConfig>),
 }
 
 #[cfg(test)]
@@ -96,6 +106,29 @@ mod tests {
                 assert_eq!(config.request_timeout, Duration::from_secs(3));
             }
             _ => unreachable!("This test should only validate the validator node cli"),
+        }
+    }
+
+    #[test]
+    fn test_cli_account_manager_command() {
+        let cli = Cli::parse_from([
+            "program",
+            "account_manager",
+            "--verbosity",
+            "2",
+            "--lifetime",
+            "30",
+            "--chunk-size",
+            "10",
+        ]);
+
+        match cli.command {
+            Commands::AccountManager(config) => {
+                assert_eq!(config.verbosity, 2);
+                assert_eq!(config.lifetime, 30);
+                assert_eq!(config.chunk_size, 10);
+            }
+            _ => unreachable!("This test should only validate the account manager cli"),
         }
     }
 }

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::process;
+use std::{env, process};
 
 use clap::Parser;
 use ream::cli::{

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -1,8 +1,10 @@
 use std::env;
+use std::process;
 
 use clap::Parser;
 use ream::cli::{
     Cli, Commands,
+    account_manager::AccountManagerConfig,
     beacon_node::BeaconNodeConfig,
     import_keystores::{load_keystore_directory, load_password_file, process_password},
     validator_node::ValidatorNodeConfig,
@@ -45,6 +47,7 @@ async fn main() {
             run_beacon_node(*config, async_executor, main_executor).await
         }
         Commands::ValidatorNode(config) => run_validator_node(*config, async_executor).await,
+        Commands::AccountManager(config) => run_account_manager(*config).await,
     }
 }
 
@@ -151,4 +154,23 @@ pub async fn run_validator_node(config: ValidatorNodeConfig, async_executor: Rea
     .expect("Failed to create validator service");
 
     validator_service.start().await;
+}
+
+pub async fn run_account_manager(config: AccountManagerConfig) {
+    info!("starting up account manager...");
+
+    // Validate the configuration
+    config
+        .validate()
+        .expect("Invalid account manager configuration");
+
+    info!(
+        "Account manager configuration: lifetime={}, chunk_size={}",
+        config.lifetime, config.chunk_size
+    );
+
+    ream_account_manager::generate_keys();
+
+    info!("Account manager completed successfully");
+    process::exit(0);
 }

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -6,5 +6,6 @@
   - [`ream`](./cli/ream.md)
     - [`ream beacon_node`](./cli/ream/beacon_node.md)
     - [`ream validator_node`](./cli/ream/validator_node.md)
+    - [`ream account_manager`](./cli/ream/account_manager.md)
 - [Changelog](./Changelog.md) <!-- CLI_REFERENCE END -->
 

--- a/book/cli/SUMMARY.md
+++ b/book/cli/SUMMARY.md
@@ -1,4 +1,5 @@
 - [`ream`](./ream.md)
   - [`ream beacon_node`](./ream/beacon_node.md)
   - [`ream validator_node`](./ream/validator_node.md)
+  - [`ream account_manager`](./ream/account_manager.md)
 

--- a/book/cli/ream.md
+++ b/book/cli/ream.md
@@ -9,9 +9,10 @@ $ ream --help
 Usage: ream <COMMAND>
 
 Commands:
-  beacon_node     Start the node
-  validator_node
-  help            Print this message or the help of the given subcommand(s)
+  beacon_node      Start the beacon node
+  validator_node   Start the validator node
+  account_manager  Manage validator accounts
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help

--- a/book/cli/ream/account_manager.md
+++ b/book/cli/ream/account_manager.md
@@ -1,0 +1,16 @@
+# ream account_manager
+
+Manage validator accounts
+
+```bash
+$ ream account_manager --help
+```
+```txt
+Usage: ream account_manager [OPTIONS]
+
+Options:
+  -v, --verbosity <VERBOSITY>    Verbosity level [default: 3]
+  -l, --lifetime <LIFETIME>      Account lifetime in 2 ** lifetime slots [default: 28]
+  -c, --chunk-size <CHUNK_SIZE>  Chunk size for messages [default: 5]
+  -h, --help                     Print help
+```

--- a/book/cli/ream/beacon_node.md
+++ b/book/cli/ream/beacon_node.md
@@ -1,6 +1,6 @@
 # ream beacon_node
 
-Start the node
+Start the beacon node
 
 ```bash
 $ ream beacon_node --help

--- a/book/cli/ream/validator_node.md
+++ b/book/cli/ream/validator_node.md
@@ -1,6 +1,6 @@
 # ream validator_node
 
-
+Start the validator node
 
 ```bash
 $ ream validator_node --help

--- a/crates/account_manager/Cargo.toml
+++ b/crates/account_manager/Cargo.toml
@@ -10,4 +10,6 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+hashsig.workspace = true
+rand.workspace = true
 tracing.workspace = true

--- a/crates/account_manager/Cargo.toml
+++ b/crates/account_manager/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ream-account-manager"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+tracing.workspace = true

--- a/crates/account_manager/Readme.md
+++ b/crates/account_manager/Readme.md
@@ -1,0 +1,25 @@
+# Ream Account Manager
+
+**Ream Chain Account Manager** is a CLI tool written in **Rust** for generating **Winternitz One-Time Signature (WOTS)** validator keys for use on the **Beam Chain**.
+
+> ⚡ Secure, deterministic, and purpose-built for lightweight cryptographic identity management.
+
+---
+
+## 🚀 Features
+
+- 🔐 Generate Winternitz OTS (WOTS) key pairs
+- 🧾 Export public/private keys to files or standard output
+- 🏷️ Tag key generation with metadata or labels
+- 🛡️ Designed with validator node integration in mind
+
+---
+
+## 📦 Installation
+
+### Prerequisites
+- Rust & Cargo: [Install Rust](https://www.rust-lang.org/tools/install)
+
+### Clone and Build
+
+TODO

--- a/crates/account_manager/src/lib.rs
+++ b/crates/account_manager/src/lib.rs
@@ -1,5 +1,23 @@
+use std::time::Instant;
+
+use hashsig::signature::{
+    SignatureScheme,
+    generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::winternitz::SIGWinternitzLifetime20W4,
+};
+use hashsig::signature::SignatureScheme;
+use rand::{Rng, thread_rng};
 use tracing::info;
 
 pub fn generate_keys() {
     info!("Generating beam chain validator keys.....");
+    let mut rng = thread_rng();
+    // measure_time::<SIGWinternitzLifetime20W4, _>("Poseidon - L 20 - Winternitz - w 4", &mut rng);
+    info!("Key generation complete");
+}
+
+fn measure_time<T: SignatureScheme, R: Rng>(description: &str, rng: &mut R) {
+    let start = Instant::now();
+    // let (_pk, _sk) = T::gen(rng);
+    let duration = start.elapsed();
+    info!("{} - Gen: {:?}", description, duration);
 }

--- a/crates/account_manager/src/lib.rs
+++ b/crates/account_manager/src/lib.rs
@@ -1,0 +1,5 @@
+use tracing::info;
+
+pub fn generate_keys() {
+    info!("Generating beam chain validator keys.....");
+}


### PR DESCRIPTION
### What are you trying to achieve?

Initial implementation of ream's `account_manager` tool. This tool will replace the existing account_manager tool used to generate validator keys for the beacon chain.

### How was it implemented/fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
