### PR TITLE
fix: ReqResp handler crashing when handling outbound connection

### DIFF
--- a/crates/networking/p2p/src/gossipsub/error.rs
+++ b/crates/networking/p2p/src/gossipsub/error.rs
@@ -1,8 +1,8 @@
 #[derive(thiserror::Error, Debug)]
 pub enum GossipsubError {
-    #[error("Invalid data {0}")]
+    #[error("Gossipsub invalid data {0}")]
     InvalidData(String),
-    #[error("Invalid topic {0}")]
+    #[error("Gossipsub invalid topic {0}")]
     InvalidTopic(String),
 }
 

--- a/crates/networking/p2p/src/req_resp/error.rs
+++ b/crates/networking/p2p/src/req_resp/error.rs
@@ -35,6 +35,6 @@ impl From<ssz::DecodeError> for ReqRespError {
 impl From<VariableList<u8, U256>> for ReqRespError {
     fn from(err: VariableList<u8, U256>) -> Self {
         let err = String::from_utf8(Vec::from(err)).unwrap_or("Invalid UTF-8".to_string());
-        ReqRespError::InvalidData(format!("Failed to decode variable list: {err:?}"))
+        ReqRespError::InvalidData(format!("ReqResp error message from peer: {err:?}"))
     }
 }

--- a/crates/networking/p2p/src/req_resp/outbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/outbound_protocol.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use alloy_primitives::aliases::B32;
+use anyhow::anyhow;
 use asynchronous_codec::BytesMut;
 use futures::{
     FutureExt, SinkExt,
@@ -217,13 +218,7 @@ impl Decoder for OutboundSSZSnappyCodec {
                     }
                 } else {
                     Ok(Some(RespMessage::Error(
-                        VariableList::<u8, U256>::from_ssz_bytes(&buf)
-                            .map(ReqRespError::from)
-                            .unwrap_or_else(|err| {
-                                ReqRespError::InvalidData(format!(
-                                    "Failed to decode variable list: {err:?}"
-                                ))
-                            }),
+                        VariableList::<u8, U256>::from_ssz_bytes(&buf).map(ReqRespError::from).map_err(|err| anyhow!("OutboundSSZSnappyCodec::decode: protocol: {:?}, response_code: {response_code:?}, err: {err:?}", self.protocol.protocol))?,
                     )))
                 }
             }


### PR DESCRIPTION
### What are you trying to achieve?

When I tried to send outbound ReqResp messages, the handler would panic with 

```OutboundStreamState should always be present, poll() should not be in parallel```

### How was it implemented/fixed?

We were returning before removing the dead outbound streams, update the code to remove the dead stream before returning
