### PR TITLE
feat: send status requests when dialing peers to properly connect with peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4916,9 +4916,12 @@ dependencies = [
  "ream-consensus",
  "ream-execution-engine",
  "ream-fork-choice",
+ "ream-network-spec",
  "ream-operation-pool",
+ "ream-p2p",
  "ream-storage",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/common/beacon_chain/Cargo.toml
+++ b/crates/common/beacon_chain/Cargo.toml
@@ -12,10 +12,13 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 # ream dependencies
 ream-consensus.workspace = true
 ream-execution-engine.workspace = true
 ream-fork-choice.workspace = true
+ream-network-spec.workspace = true
 ream-operation-pool.workspace = true
+ream-p2p.workspace = true
 ream-storage.workspace = true

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -33,7 +33,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-io-timeout = "1"
 tokio-util.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["log"] }
 tree_hash.workspace = true
 unsigned-varint = { version = "0.8", features = ["codec"] }
 

--- a/crates/networking/p2p/src/channel.rs
+++ b/crates/networking/p2p/src/channel.rs
@@ -1,7 +1,10 @@
 use libp2p::{PeerId, swarm::ConnectionId};
 use tokio::sync::mpsc;
 
-use crate::req_resp::{handler::RespMessage, messages::ResponseMessage};
+use crate::req_resp::{
+    handler::RespMessage,
+    messages::{ResponseMessage, status::Status},
+};
 
 pub enum P2PCallbackResponse {
     ResponseMessage(Box<ResponseMessage>),
@@ -14,6 +17,10 @@ pub enum P2PMessage {
 }
 
 pub enum P2PRequest {
+    Status {
+        peer_id: PeerId,
+        status: Status,
+    },
     BlockRange {
         peer_id: PeerId,
         start: u64,

--- a/crates/networking/p2p/src/network_state.rs
+++ b/crates/networking/p2p/src/network_state.rs
@@ -8,13 +8,14 @@ use ssz::Encode;
 
 use crate::{
     peer::{CachedPeer, ConnectionState, Direction},
-    req_resp::messages::meta_data::GetMetaDataV2,
+    req_resp::messages::{meta_data::GetMetaDataV2, status::Status},
     utils::META_DATA_FILE_NAME,
 };
 
 pub struct NetworkState {
     pub peer_table: RwLock<HashMap<PeerId, CachedPeer>>,
     pub meta_data: RwLock<GetMetaDataV2>,
+    pub status: RwLock<Status>,
     pub data_dir: PathBuf,
 }
 
@@ -40,14 +41,7 @@ impl NetworkState {
                     cached_peer.enr = Some(enr_ref.clone());
                 }
             })
-            .or_insert(CachedPeer {
-                peer_id,
-                last_seen_p2p_address: address,
-                state,
-                direction,
-                enr,
-                meta_data: None,
-            });
+            .or_insert(CachedPeer::new(peer_id, address, state, direction, enr));
     }
 
     pub fn write_meta_data_to_disk(&self) -> anyhow::Result<()> {

--- a/crates/networking/p2p/src/peer.rs
+++ b/crates/networking/p2p/src/peer.rs
@@ -1,10 +1,12 @@
+use std::time::Instant;
+
 use discv5::Enr;
 use libp2p::{Multiaddr, PeerId};
 use serde::Serialize;
 
-use crate::req_resp::messages::meta_data::GetMetaDataV2;
+use crate::req_resp::messages::{meta_data::GetMetaDataV2, status::Status};
 
-#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum ConnectionState {
     Connected,
@@ -35,8 +37,39 @@ pub struct CachedPeer {
     /// Direction of the most recent connection (inbound/outbound)
     pub direction: Direction,
 
+    /// Last time we received a message from this peer
+    pub last_seen: Instant,
+
     /// Ethereum Node Record (ENR), if known
     pub enr: Option<Enr>,
 
+    pub status: Option<Status>,
+
     pub meta_data: Option<GetMetaDataV2>,
+}
+
+impl CachedPeer {
+    pub fn new(
+        peer_id: PeerId,
+        address: Option<Multiaddr>,
+        state: ConnectionState,
+        direction: Direction,
+        enr: Option<Enr>,
+    ) -> Self {
+        CachedPeer {
+            peer_id,
+            last_seen_p2p_address: address,
+            state,
+            direction,
+            last_seen: Instant::now(),
+            enr,
+            status: None,
+            meta_data: None,
+        }
+    }
+
+    /// Update the last seen timestamp
+    pub fn update_last_seen(&mut self) {
+        self.last_seen = Instant::now();
+    }
 }

--- a/crates/networking/p2p/src/req_resp/handler.rs
+++ b/crates/networking/p2p/src/req_resp/handler.rs
@@ -17,7 +17,7 @@ use libp2p::{
         },
     },
 };
-use tracing::{debug, error};
+use tracing::{error, info};
 
 use super::{
     error::ReqRespError,
@@ -107,6 +107,7 @@ pub struct OutboundOpenInfo {
     pub message: RequestMessage,
 }
 
+#[derive(Debug)]
 enum ConnectionState {
     Live,
     ShuttingDown,
@@ -464,6 +465,7 @@ impl ConnectionHandler for ReqRespConnectionHandler {
     }
 
     fn on_behaviour_event(&mut self, event: ConnectionRequest) {
+        info!("REQRESP: On behaviour event: {event:?}");
         match event {
             ConnectionRequest::Request {
                 request_id,
@@ -485,7 +487,7 @@ impl ConnectionHandler for ReqRespConnectionHandler {
             Self::OutboundOpenInfo,
         >,
     ) {
-        debug!("REQRESP: On connection event: {event:?}");
+        info!("REQRESP: On connection event: {event:?}");
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound { protocol, info }) => {
                 self.on_fully_negotiated_inbound(protocol, info)

--- a/crates/networking/p2p/src/req_resp/messages/mod.rs
+++ b/crates/networking/p2p/src/req_resp/messages/mod.rs
@@ -16,6 +16,8 @@ use ream_consensus::{blob_sidecar::BlobSidecar, electra::beacon_block::SignedBea
 use ssz_derive::{Decode, Encode};
 use status::Status;
 
+use super::protocol_id::{ProtocolId, SupportedProtocol};
+
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 #[ssz(enum_behaviour = "transparent")]
 pub enum RequestMessage {
@@ -27,6 +29,29 @@ pub enum RequestMessage {
     BeaconBlocksByRoot(BeaconBlocksByRootV2Request),
     BlobSidecarsByRange(BlobSidecarsByRangeV1Request),
     BlobSidecarsByRoot(BlobSidecarsByRootV1Request),
+}
+
+impl RequestMessage {
+    pub fn supported_protocols(&self) -> Vec<ProtocolId> {
+        match self {
+            RequestMessage::MetaData(_) => vec![ProtocolId::new(SupportedProtocol::GetMetaDataV2)],
+            RequestMessage::Goodbye(_) => vec![ProtocolId::new(SupportedProtocol::GoodbyeV1)],
+            RequestMessage::Status(_) => vec![ProtocolId::new(SupportedProtocol::StatusV1)],
+            RequestMessage::Ping(_) => vec![ProtocolId::new(SupportedProtocol::PingV1)],
+            RequestMessage::BeaconBlocksByRange(_) => {
+                vec![ProtocolId::new(SupportedProtocol::BeaconBlocksByRangeV2)]
+            }
+            RequestMessage::BeaconBlocksByRoot(_) => {
+                vec![ProtocolId::new(SupportedProtocol::BeaconBlocksByRootV2)]
+            }
+            RequestMessage::BlobSidecarsByRange(_) => {
+                vec![ProtocolId::new(SupportedProtocol::BlobSidecarsByRangeV1)]
+            }
+            RequestMessage::BlobSidecarsByRoot(_) => {
+                vec![ProtocolId::new(SupportedProtocol::BlobSidecarsByRootV1)]
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]

--- a/crates/networking/p2p/src/req_resp/outbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/outbound_protocol.rs
@@ -78,7 +78,7 @@ impl UpgradeInfo for OutboundReqRespProtocol {
     type InfoIter = Vec<Self::Info>;
 
     fn protocol_info(&self) -> Self::InfoIter {
-        SupportedProtocol::supported_protocols()
+        self.request.supported_protocols()
     }
 }
 


### PR DESCRIPTION
### What are you trying to achieve?

When dialing a peer, the spec says we must follow up with sending a status message

this serves 2 purposes
- find out if the peer is on the same network or not
- see what block the peer is on so we know what range we can download blocks from them for syncing

### How was it implemented/fixed?

Send a status message when dialing a peer, once we get a response we consider a peer connected
