### PR TITLE
feat: add get_aggregated_attestation to the Validator

### DIFF
--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -374,7 +374,6 @@ impl BeaconApiClient {
 
         Ok(())
     }
-
     pub async fn get_attestation_data(
         &self,
         slot: u64,
@@ -384,7 +383,11 @@ impl BeaconApiClient {
             .http_client
             .execute(
                 self.http_client
-                    .get(format!("/eth/v1/validator/attestation_data?slot={slot}&committee_index={committee_index}"))?
+                    .get("/eth/v1/validator/attestation_data".to_string())?
+                    .query(&[
+                        ("slot", slot.to_string()),
+                        ("committee_index", committee_index.to_string()),
+                    ])
                     .build()?,
             )
             .await?;
@@ -450,6 +453,35 @@ impl BeaconApiClient {
         }
 
         Ok(())
+    }
+
+    pub async fn get_aggregated_attestation(
+        &self,
+        attestation_data_root: B256,
+        slot: u64,
+        committee_index: u64,
+    ) -> anyhow::Result<DataVersionedResponse<Attestation>, ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .get("/eth/v2/validator/aggregate_attestation".to_string())?
+                    .query(&[
+                        ("attestation_data_root", attestation_data_root.to_string()),
+                        ("slot", slot.to_string()),
+                        ("committee_index", committee_index.to_string()),
+                    ])
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(response.json().await?)
     }
 
     pub async fn produce_block(

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -17,14 +17,15 @@ use ream_beacon_api_types::{
     id::{ID, ValidatorID},
     request::ValidatorsPostRequest,
     responses::{
-        BeaconResponse, DataResponse, DutiesResponse, ETH_CONSENSUS_VERSION_HEADER, RootResponse,
-        SyncCommitteeDutiesResponse, VERSION,
+        BeaconResponse, DataResponse, DataVersionedResponse, DutiesResponse,
+        ETH_CONSENSUS_VERSION_HEADER, RootResponse, SyncCommitteeDutiesResponse, VERSION,
     },
     sync::SyncStatus,
     validator::{ValidatorData, ValidatorStatus},
 };
 use ream_bls::BLSSignature;
 use ream_consensus::{
+    attestation::Attestation,
     attestation_data::AttestationData,
     electra::{
         beacon_block::SignedBeaconBlock,


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: #536 

### How was it implemented/fixed?

I  implemented a GET request the Beacon node as Beacon API spec:
https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/getAggregatedAttestationV2

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
