### PR TITLE
feat: add publish_block and publish_blinded_block

### DIFF
--- a/crates/common/beacon_api_types/src/block.rs
+++ b/crates/common/beacon_api_types/src/block.rs
@@ -7,6 +7,24 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BroadcastValidation {
+    /// Lightweight gossip checks only (default)
+    Gossip,
+    /// Full consensus checks, including validation of all signatures and block fields
+    /// except for the execution payload transactions
+    Consensus,
+    /// Same as consensus, with an extra equivocation check immediately before broadcast
+    ConsensusAndEquivocation,
+}
+
+impl Default for BroadcastValidation {
+    fn default() -> Self {
+        Self::Gossip
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProduceBlockResponse {
     pub version: String,
     pub execution_payload_blinded: bool,

--- a/crates/common/beacon_api_types/src/error.rs
+++ b/crates/common/beacon_api_types/src/error.rs
@@ -71,4 +71,7 @@ pub enum ValidatorError {
 
     #[error("Anyhow error: {0}")]
     Anyhow(#[from] anyhow::Error),
+
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
 }

--- a/crates/common/consensus/src/electra/blinded_beacon_block.rs
+++ b/crates/common/consensus/src/electra/blinded_beacon_block.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::B256;
+use ream_bls::BLSSignature;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash::TreeHash;
@@ -21,4 +22,10 @@ impl BlindedBeaconBlock {
     pub fn block_root(&self) -> B256 {
         self.tree_hash_root()
     }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+pub struct SignedBlindedBeaconBlock {
+    pub message: BlindedBeaconBlock,
+    pub signature: BLSSignature,
 }

--- a/crates/common/validator/src/beacon_api_client/http_client.rs
+++ b/crates/common/validator/src/beacon_api_client/http_client.rs
@@ -11,12 +11,6 @@ pub const JSON_ACCEPT_PRIORITY: &str = "application/json;q=1";
 pub const JSON_CONTENT_TYPE: &str = "application/json";
 pub const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
 
-#[derive(Debug, Clone, Copy)]
-pub enum ContentType {
-    Json,
-    Ssz,
-}
-
 #[derive(Debug, Clone)]
 pub struct ClientWithBaseUrl {
     client: Client,

--- a/crates/common/validator/src/beacon_api_client/http_client.rs
+++ b/crates/common/validator/src/beacon_api_client/http_client.rs
@@ -62,12 +62,20 @@ impl ClientWithBaseUrl {
 
     pub fn get<U: IntoUrl>(&self, url: U) -> anyhow::Result<RequestBuilder> {
         let url = self.base_url.join(url.as_str())?;
-        Ok(self.client.get(url))
+        Ok(self
+            .client
+            .get(url)
+            .header(CONTENT_TYPE, HeaderValue::from_static(SSZ_CONTENT_TYPE))
+            .header(ACCEPT, HeaderValue::from_static(ACCEPT_PRIORITY)))
     }
 
     pub fn post<U: IntoUrl>(&self, url: U) -> anyhow::Result<RequestBuilder> {
         let url = self.base_url.join(url.as_str())?;
-        Ok(self.client.post(url))
+        Ok(self
+            .client
+            .post(url)
+            .header(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE))
+            .header(ACCEPT, HeaderValue::from_static(ACCEPT_PRIORITY)))
     }
 
     pub async fn execute(&self, request: Request) -> Result<Response, reqwest::Error> {

--- a/crates/common/validator/src/beacon_api_client/http_client.rs
+++ b/crates/common/validator/src/beacon_api_client/http_client.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use anyhow::anyhow;
 use reqwest::{
     Client, IntoUrl, Request, RequestBuilder, Response, Url,
-    header::{ACCEPT, CONTENT_TYPE, HeaderMap, HeaderValue},
+    header::{ACCEPT, CONTENT_TYPE, HeaderValue},
 };
 
 pub const ACCEPT_PRIORITY: &str = "application/octet-stream;q=1.0,application/json;q=0.9";
@@ -24,24 +24,8 @@ pub struct ClientWithBaseUrl {
 }
 
 impl ClientWithBaseUrl {
-    pub fn new(
-        url: Url,
-        request_timeout: Duration,
-        content_type: ContentType,
-    ) -> anyhow::Result<Self> {
-        let mut headers = HeaderMap::new();
-        match content_type {
-            ContentType::Json => {
-                headers.insert(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE));
-            }
-            ContentType::Ssz => {
-                headers.insert(CONTENT_TYPE, HeaderValue::from_static(SSZ_CONTENT_TYPE));
-                headers.insert(ACCEPT, HeaderValue::from_static(ACCEPT_PRIORITY));
-            }
-        }
-
+    pub fn new(url: Url, request_timeout: Duration) -> anyhow::Result<Self> {
         let client = Client::builder()
-            .default_headers(headers)
             .timeout(request_timeout)
             .build()
             .map_err(|err| anyhow!("Failed to build HTTP client {err:?}"))?;

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -8,7 +8,7 @@ use anyhow::anyhow;
 use event::{BeaconEvent, EventTopic};
 use eventsource_client::{Client, ClientBuilder, SSE};
 use futures::{Stream, StreamExt};
-use http_client::{ClientWithBaseUrl, ContentType};
+use http_client::ClientWithBaseUrl;
 use ream_beacon_api_types::{
     block::{BroadcastValidation, FullBlockData, ProduceBlockData, ProduceBlockResponse},
     committee::BeaconCommitteeSubscription,
@@ -50,11 +50,7 @@ pub struct BeaconApiClient {
 impl BeaconApiClient {
     pub fn new(beacon_api_endpoint: Url, request_timeout: Duration) -> anyhow::Result<Self> {
         Ok(Self {
-            http_client: ClientWithBaseUrl::new(
-                beacon_api_endpoint,
-                request_timeout,
-                ContentType::Ssz,
-            )?,
+            http_client: ClientWithBaseUrl::new(beacon_api_endpoint, request_timeout)?,
         })
     }
 

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -37,7 +37,7 @@ use ream_consensus::{
 use ream_network_spec::networks::NetworkSpec;
 use reqwest::{Url, header::HeaderMap};
 use serde_json::json;
-use ssz::Decode;
+use ssz::{Decode, Encode};
 use tracing::{error, info};
 
 use crate::aggregate_and_proof::SignedAggregateAndProof;
@@ -501,7 +501,7 @@ impl BeaconApiClient {
                         serde_json::to_string(&broadcast_validation)?,
                     )])
                     .header(ETH_CONSENSUS_VERSION_HEADER, VERSION)
-                    .json(&signed_beacon_block)
+                    .body(signed_beacon_block.as_ssz_bytes())
                     .build()?,
             )
             .await?;
@@ -530,7 +530,7 @@ impl BeaconApiClient {
                         serde_json::to_string(&broadcast_validation)?,
                     )])
                     .header(ETH_CONSENSUS_VERSION_HEADER, VERSION)
-                    .json(&signed_blinded_beacon_block)
+                    .body(signed_blinded_beacon_block.as_ssz_bytes())
                     .build()?,
             )
             .await?;

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -501,6 +501,7 @@ impl BeaconApiClient {
                         serde_json::to_string(&broadcast_validation)?,
                     )])
                     .header(ETH_CONSENSUS_VERSION_HEADER, VERSION)
+                    .header("Content-Type", "application/octet-stream")
                     .body(signed_beacon_block.as_ssz_bytes())
                     .build()?,
             )
@@ -530,6 +531,7 @@ impl BeaconApiClient {
                         serde_json::to_string(&broadcast_validation)?,
                     )])
                     .header(ETH_CONSENSUS_VERSION_HEADER, VERSION)
+                    .header("Content-Type", "application/octet-stream")
                     .body(signed_blinded_beacon_block.as_ssz_bytes())
                     .build()?,
             )


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: #483 
Fixes: #543  

### How was it implemented/fixed?
I created POST requests in the beacon_api_client to publish a block and to publish a blinded beacon block as per the Beacon API specs:
https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/publishBlockV2
https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/publishBlindedBlockV2

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
