### PR TITLE
feat: add get_block_root and fix a small spelling mistake

### DIFF
--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -17,7 +17,7 @@ use ream_beacon_api_types::{
     id::{ID, ValidatorID},
     request::ValidatorsPostRequest,
     responses::{
-        BeaconResponse, DataResponse, DutiesResponse, ETH_CONSENSUS_VERSION_HEADER,
+        BeaconResponse, DataResponse, DutiesResponse, ETH_CONSENSUS_VERSION_HEADER, RootResponse,
         SyncCommitteeDutiesResponse, VERSION,
     },
     sync::SyncStatus,
@@ -102,6 +102,28 @@ impl BeaconApiClient {
             .execute(
                 self.http_client
                     .get("/eth/v1/beacon/genesis".to_string())?
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(response.json().await?)
+    }
+
+    pub async fn get_block_root(
+        &self,
+        state_id: ID,
+    ) -> anyhow::Result<BeaconResponse<RootResponse>, ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .get(format!("/eth/v1/beacon/states/{state_id}/root"))?
                     .build()?,
             )
             .await?;
@@ -312,7 +334,7 @@ impl BeaconApiClient {
         Ok(response.json().await?)
     }
 
-    pub async fn prepare_committe_subnet(
+    pub async fn prepare_committee_subnet(
         &self,
         subscriptions: Vec<BeaconCommitteeSubscription>,
     ) -> anyhow::Result<(), ValidatorError> {


### PR DESCRIPTION
### What are you trying to achieve?

fixes https://github.com/ReamLabs/ream/issues/552

### How was it implemented/fixed?

Similar to the other items inside the BeaconApiClient for the Validator. I also noticed a small spelling mistake, so I ended up fixing that.

### To-Do

Implement the logic for creating the sync committee message using the block root.
