### PR TITLE
feat: added /eth/v1/beacon/pool/sync_committees

### DIFF
--- a/crates/common/beacon_api_types/src/request.rs
+++ b/crates/common/beacon_api_types/src/request.rs
@@ -11,9 +11,6 @@ pub struct ValidatorsPostRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct SyncCommitteePostRequest(Vec<SyncCommitteeRequestItem>);
-
-#[derive(Debug, Deserialize, Serialize)]
 pub struct SyncCommitteeRequestItem {
     #[serde(with = "serde_utils::quoted_u64")]
     pub slot: u64,

--- a/crates/common/beacon_api_types/src/request.rs
+++ b/crates/common/beacon_api_types/src/request.rs
@@ -1,3 +1,5 @@
+use alloy_primitives::B256;
+use ream_bls::BLSSignature;
 use serde::{Deserialize, Serialize};
 
 use crate::{id::ValidatorID, validator::ValidatorStatus};
@@ -6,4 +8,17 @@ use crate::{id::ValidatorID, validator::ValidatorStatus};
 pub struct ValidatorsPostRequest {
     pub ids: Option<Vec<ValidatorID>>,
     pub statuses: Option<Vec<ValidatorStatus>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SyncCommitteePostRequest(Vec<SyncCommitteeRequestItem>);
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SyncCommitteeRequestItem {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub slot: u64,
+    pub beacon_block_root: B256,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    pub signature: BLSSignature,
 }

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -194,7 +194,10 @@ impl BeaconApiClient {
             .http_client
             .execute(
                 self.http_client
-                    .post("/eth/v1/beacon/pool/sync_committees".to_string())?
+                    .post(
+                        "/eth/v1/beacon/pool/sync_committees".to_string(),
+                        ContentType::Json,
+                    )?
                     .json(&sync_committee_request)
                     .build()?,
             )

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -15,7 +15,7 @@ use ream_beacon_api_types::{
     duties::{AttesterDuty, ProposerDuty, SyncCommitteeDuty},
     error::ValidatorError,
     id::{ID, ValidatorID},
-    request::{SyncCommitteePostRequest, ValidatorsPostRequest},
+    request::{SyncCommitteeRequestItem, ValidatorsPostRequest},
     responses::{
         BeaconResponse, DataResponse, DutiesResponse, ETH_CONSENSUS_VERSION_HEADER, RootResponse,
         SyncCommitteeDutiesResponse, VERSION,
@@ -188,7 +188,7 @@ impl BeaconApiClient {
 
     pub async fn publish_sync_committee_signature(
         &self,
-        sync_committee_request: SyncCommitteePostRequest,
+        sync_committee_request: Vec<SyncCommitteeRequestItem>,
     ) -> anyhow::Result<(), ValidatorError> {
         let response = self
             .http_client

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -195,6 +195,7 @@ impl BeaconApiClient {
             .execute(
                 self.http_client
                     .post("/eth/v1/beacon/pool/sync_committees")?
+                    .header(ETH_CONSENSUS_VERSION_HEADER, VERSION)
                     .json(&sync_committee_request)
                     .build()?,
             )

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -15,7 +15,7 @@ use ream_beacon_api_types::{
     duties::{AttesterDuty, ProposerDuty, SyncCommitteeDuty},
     error::ValidatorError,
     id::{ID, ValidatorID},
-    request::ValidatorsPostRequest,
+    request::{SyncCommitteePostRequest, ValidatorsPostRequest},
     responses::{
         BeaconResponse, DataResponse, DutiesResponse, ETH_CONSENSUS_VERSION_HEADER, RootResponse,
         SyncCommitteeDutiesResponse, VERSION,
@@ -184,6 +184,29 @@ impl BeaconApiClient {
         }
 
         Ok(response.json().await?)
+    }
+
+    pub async fn publish_sync_committee_signature(
+        &self,
+        sync_committee_request: SyncCommitteePostRequest,
+    ) -> anyhow::Result<(), ValidatorError> {
+        let response = self
+            .http_client
+            .execute(
+                self.http_client
+                    .post("/eth/v1/beacon/pool/sync_committees")?
+                    .json(&sync_committee_request)
+                    .build()?,
+            )
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(ValidatorError::RequestFailed {
+                status_code: response.status(),
+            });
+        }
+
+        Ok(())
     }
 
     pub async fn get_state_validator_list(

--- a/crates/common/validator/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/src/beacon_api_client/mod.rs
@@ -194,8 +194,7 @@ impl BeaconApiClient {
             .http_client
             .execute(
                 self.http_client
-                    .post("/eth/v1/beacon/pool/sync_committees")?
-                    .header(ETH_CONSENSUS_VERSION_HEADER, VERSION)
+                    .post("/eth/v1/beacon/pool/sync_committees".to_string())?
                     .json(&sync_committee_request)
                     .build()?,
             )


### PR DESCRIPTION
### What are you trying to achieve?

fixes https://github.com/ReamLabs/ream/issues/554

### How was it implemented/fixed?

Essentially follows the same format as the subscription endpoint.

### To-Do

With this and the other PR, the goal is to fetch the fork and root, use it to produce a committee message, and then publish that committee message. Aggregators also have to be dealt with later.
