### PR TITLE
feat: add `peer_count` endpoint

### DIFF
--- a/crates/rpc/src/handlers/peers.rs
+++ b/crates/rpc/src/handlers/peers.rs
@@ -11,7 +11,7 @@ use ream_p2p::{
     network_state::NetworkState,
     peer::{ConnectionState, Direction},
 };
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 
 /// GET /eth/v1/node/peers/{peer_id}
 #[get("/node/peers/{peer_id}")]

--- a/crates/rpc/src/routes/node.rs
+++ b/crates/rpc/src/routes/node.rs
@@ -1,7 +1,12 @@
 use actix_web::web::ServiceConfig;
 
-use crate::handlers::{peers::get_peer, peers::get_peer_count, version::get_version};
+use crate::handlers::{
+    peers::{get_peer, get_peer_count},
+    version::get_version,
+};
 
 pub fn register_node_routes(cfg: &mut ServiceConfig) {
-    cfg.service(get_version).service(get_peer).service(get_peer_count);
+    cfg.service(get_version)
+        .service(get_peer)
+        .service(get_peer_count);
 }

--- a/crates/rpc/src/routes/node.rs
+++ b/crates/rpc/src/routes/node.rs
@@ -1,7 +1,7 @@
 use actix_web::web::ServiceConfig;
 
-use crate::handlers::{peers::get_peer, version::get_version};
+use crate::handlers::{peers::get_peer, peers::get_peer_count, version::get_version};
 
 pub fn register_node_routes(cfg: &mut ServiceConfig) {
-    cfg.service(get_version).service(get_peer);
+    cfg.service(get_version).service(get_peer).service(get_peer_count);
 }


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: [#223](https://github.com/ReamLabs/ream/issues/223)

### How was it implemented/fixed?

Implemented the get REST endpoint for [getPeerCount](https://ethereum.github.io/beacon-APIs/#/Node/getPeerCount)

### To-Do

- [ x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
