### PR TITLE
feat: added the method for sync committees for non-aggregators

### DIFF
--- a/crates/common/validator/src/contribution_and_proof.rs
+++ b/crates/common/validator/src/contribution_and_proof.rs
@@ -2,8 +2,9 @@ use alloy_primitives::B256;
 use ream_bls::{BLSSignature, PrivateKey, traits::Signable};
 use ream_consensus::{
     electra::beacon_state::BeaconState,
-    misc::{compute_epoch_at_slot, compute_signing_root},
+    misc::{compute_domain, compute_epoch_at_slot, compute_signing_root},
 };
+use ream_network_spec::networks::network_spec;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{BitVector, typenum::U128};
@@ -38,18 +39,12 @@ pub struct SignedContributionAndProof {
     pub signature: BLSSignature,
 }
 
-pub fn get_contribution_and_proof(
-    state: &BeaconState,
-    aggregator_index: u64,
-    contribution: SyncCommitteeContribution,
-    private_key: PrivateKey,
-) -> anyhow::Result<ContributionAndProof> {
+pub fn get_contribution_and_proof(contribution: SyncCommitteeContribution, aggregator_index: u64, privkey: &PrivateKey) -> anyhow::Result<ContributionAndProof> {
     Ok(ContributionAndProof {
         selection_proof: get_sync_committee_selection_proof(
-            state,
             contribution.slot,
             contribution.subcommittee_index,
-            private_key,
+            privkey,
         )?,
         aggregator_index,
         contribution,
@@ -57,15 +52,13 @@ pub fn get_contribution_and_proof(
 }
 
 pub fn get_contribution_and_proof_signature(
-    state: &BeaconState,
     contribution_and_proof: ContributionAndProof,
     private_key: PrivateKey,
 ) -> anyhow::Result<BLSSignature> {
-    let domain = state.get_domain(
+    let domain = compute_domain(
         DOMAIN_CONTRIBUTION_AND_PROOF,
-        Some(compute_epoch_at_slot(
-            contribution_and_proof.contribution.slot,
-        )),
+        Some(network_spec().electra_fork_version),
+        None,
     );
     let signing_root = compute_signing_root(contribution_and_proof, domain);
     Ok(private_key.sign(signing_root.as_ref())?)

--- a/crates/common/validator/src/validator.rs
+++ b/crates/common/validator/src/validator.rs
@@ -12,7 +12,7 @@ use ream_beacon_api_types::{
     id::{ID, ValidatorID},
     request::SyncCommitteeRequestItem,
 };
-use ream_bls::{PubKey, traits::Signable};
+use ream_bls::{traits::Signable, BLSSignature, PrivateKey, PubKey};
 use ream_consensus::{
     constants::DOMAIN_SYNC_COMMITTEE,
     electra::beacon_state::BeaconState,
@@ -28,7 +28,7 @@ use tracing::{error, info, warn};
 use crate::{
     beacon_api_client::BeaconApiClient,
     block::{sign_beacon_block, sign_blinded_beacon_block},
-    randao::sign_randao_reveal,
+    randao::sign_randao_reveal, sync_committee::SyncAggregatorSelectionData,
 };
 
 pub fn check_if_validator_active(


### PR DESCRIPTION
### What are you trying to achieve?

fixes https://github.com/ReamLabs/ream/issues/563

### How was it implemented/fixed?

I modified some of the current code to instead use just the block root instead of the entire beacon block, which would lower the response sizes.

Additionally, the sync committees are submitted with a single request for all the validators to lower the number of requests we need.

### To-Do

The next step is to deal with aggregators, and then hook it up to the duties.

I'll also see if there's any consensus tests specifically for validators so we can validate our validation.
