### PR TITLE
fix: force u64 on compute_proposer_index()'s random_bytes

### DIFF
--- a/crates/common/consensus/src/electra/beacon_state.rs
+++ b/crates/common/consensus/src/electra/beacon_state.rs
@@ -354,7 +354,7 @@ impl BeaconState {
         loop {
             let candidate_index = indices[compute_shuffled_index(i % total, total, seed)?];
 
-            let random_bytes = hash(&[seed.as_slice(), &(i / 16).to_le_bytes()].concat());
+            let random_bytes = hash(&[seed.as_slice(), &((i / 16) as u64).to_le_bytes()].concat());
             let offset = i % 16 * 2;
             let random_value = bytes_to_int64(&random_bytes[offset..offset + 2]);
 


### PR DESCRIPTION
### What are you trying to achieve?

This PR fixes the issue where `BeaconState::compute_proposer_index()` returns the incorrect proposer index on non-64-bit systems, which is crucial for zkvm work which mostly relies on 32-bit architectures.

### How was it implemented/fixed?

`compute_proposer_index()` relies on `to_le_bytes()` to compute the `random_bytes` and ultimately `random_value` which determines the block proposer index:

```rust
pub fn compute_proposer_index(&self, indices: &[u64], seed: B256) -> anyhow::Result<u64> {
    ...
    let random_bytes = hash(&[seed.as_slice(), &(i / 16).to_le_bytes()].concat()); // This is the problematic line
    ...
    let random_value = bytes_to_int64(&random_bytes[offset..offset + 2]);
    ...
    if (effective_balance * MAX_RANDOM_VALUE)
        >= (MAX_EFFECTIVE_BALANCE_ELECTRA * random_value as u64)
    {
        return Ok(candidate_index);
    }
}
```

And because `to_le_bytes()` yields different results on different CPU architectures. For example:

```rust
fn main() {
    println!("{:?}", 1u64.to_le_bytes()); // [1, 0, 0, 0, 0, 0, 0, 0]
    println!("{:?}", 1u32.to_le_bytes()); // [1, 0, 0, 0]
}
```

This causes `random_bytes` and `random_value` to arrive at different values for the proposer index, even though the inputs are for the same block.

This PR basically casts the value to `u64` before performing `to_le_bytes()` which is also expected by the [consensus-specs](https://ethereum.github.io/consensus-specs/specs/electra/beacon-chain/#modified-compute_proposer_index).

A more ideal approach would be to replace `usize` with `u64` everywhere as defined by the specs, but it will break many operations e.g. array indices that only work with `usize`. So this simpler and less intrusive change is proposed.

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
