### PR TITLE
fix: failing to BlockBlock requests over p2p

### DIFF
--- a/crates/networking/p2p/src/req_resp/mod.rs
+++ b/crates/networking/p2p/src/req_resp/mod.rs
@@ -146,10 +146,6 @@ impl NetworkBehaviour for ReqResp {
         connection_id: ConnectionId,
         event: <Self::ConnectionHandler as ConnectionHandler>::ToBehaviour,
     ) {
-        info!(
-            "REQRESP: Handling connection handler event {:?} {:?} {:?}",
-            peer_id, connection_id, event
-        );
         match event {
             HandlerEvent::Ok(message) => self.events.push(ToSwarm::GenerateEvent(ReqRespMessage {
                 peer_id,


### PR DESCRIPTION
### What are you trying to achieve?

When I was trying to request blocks by range I was getting errors, due to the full payload not being ready and we would keep trying to decode the length every time we would check if we got enough data. This was leading to cases where we would either
- decode the current or next payload improperly


Also we were erroring if we got a `ErrorKind::UnexpectedEof`, but this is fine it just means we didn't get enough data yet

### How was it implemented/fixed?

Only decode the length once per a piece of content

Don't error if we haven't gotten enough content yet