### PR TITLE
feat: remove excess Runtimes from 3 to 1 + properly shutdown runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5261,6 +5261,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/common/executor/Cargo.toml
+++ b/crates/common/executor/Cargo.toml
@@ -12,3 +12,4 @@ version.workspace = true
 [dependencies]
 futures.workspace = true
 tokio.workspace = true
+tracing.workspace = true


### PR DESCRIPTION
### What are you trying to achieve?

- We are currently spawning 3 tokio async runtimes, we should only be spawning 1 runtime

### How was it implemented/fixed?

- Only spawn 1 runtime
- shutdown the tokio threads
- shutdown the runtime
