### PR TITLE
feat: implement make attestation

### DIFF
--- a/crates/common/validator/src/validator.rs
+++ b/crates/common/validator/src/validator.rs
@@ -325,21 +325,20 @@ impl ValidatorService {
                 .await?
                 .data;
 
-            let signature = sign_attestation_data(&attestation_data, &keystore.private_key)?;
-
-            let single_attestation = SingleAttestation {
-                attester_index: validator_index,
-                committee_index,
-                data: attestation_data,
-                signature,
-            };
-
-            self.beacon_api_client
-                .submit_attestation(vec![single_attestation])
-                .await?;
+            Ok(self
+                .beacon_api_client
+                .submit_attestation(vec![SingleAttestation {
+                    attester_index: validator_index,
+                    committee_index,
+                    signature: sign_attestation_data(&attestation_data, &keystore.private_key)?,
+                    data: attestation_data,
+                }])
+                .await?)
+        } else {
+            Err(anyhow!(
+                "Keystore not found for validator: {validator_index}"
+            ))
         }
-
-        Ok(())
     }
 
     pub async fn on_epoch(&mut self, epoch: u64) {


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: #561 

Implements the following portion of the [validator flow](https://ethereum.github.io/beacon-APIs/validator-flow.md): 
> 3. [Fetch AttestationData](#/ValidatorRequiredApi/produceAttestationData)
> 4. [Submit Attestation](#/ValidatorRequiredApi/submitPoolAttestations) (AttestationData + aggregation bits)
    - Aggregation bits are `Bitlist` with length of committee (received in AttesterDuty)
    with bit on position `validator_committee_index` (see AttesterDuty) set to true


### How was it implemented/fixed?
I fetch an attestation data from the beacon node.
I then sign the attestation data and create a single attestation object that we use to submit an attestation.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
