### PR TITLE
feat: implement submit_aggregate_and_proof

### DIFF
--- a/crates/common/validator/src/aggregate_and_proof.rs
+++ b/crates/common/validator/src/aggregate_and_proof.rs
@@ -3,8 +3,9 @@ use ream_consensus::{
     attestation::Attestation,
     constants::DOMAIN_AGGREGATE_AND_PROOF,
     electra::beacon_state::BeaconState,
-    misc::{compute_epoch_at_slot, compute_signing_root},
+    misc::{compute_domain, compute_epoch_at_slot, compute_signing_root},
 };
+use ream_network_spec::networks::network_spec;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
@@ -47,6 +48,19 @@ pub fn get_aggregate_and_proof_signature(
         Some(compute_epoch_at_slot(
             aggregate_and_proof.aggregate.data.slot,
         )),
+    );
+    let signing_root = compute_signing_root(aggregate_and_proof, domain);
+    Ok(private_key.sign(signing_root.as_ref())?)
+}
+
+pub fn sign_aggregate_and_proof(
+    aggregate_and_proof: &AggregateAndProof,
+    private_key: &PrivateKey,
+) -> anyhow::Result<BLSSignature> {
+    let domain = compute_domain(
+        DOMAIN_AGGREGATE_AND_PROOF,
+        Some(network_spec().electra_fork_version),
+        None,
     );
     let signing_root = compute_signing_root(aggregate_and_proof, domain);
     Ok(private_key.sign(signing_root.as_ref())?)

--- a/crates/common/validator/src/attestation.rs
+++ b/crates/common/validator/src/attestation.rs
@@ -138,3 +138,13 @@ pub fn sign_attestation_data(
     let signing_root = compute_signing_root(attestation_data, domain);
     Ok(private_key.sign(signing_root.as_ref())?)
 }
+
+pub fn get_selection_proof(slot: u64, private_key: &PrivateKey) -> anyhow::Result<BLSSignature> {
+    let domain = compute_domain(
+        DOMAIN_SELECTION_PROOF,
+        Some(network_spec().electra_fork_version),
+        None,
+    );
+    let signing_root = compute_signing_root(slot, domain);
+    Ok(private_key.sign(signing_root.as_ref())?)
+}

--- a/crates/common/validator/src/validator.rs
+++ b/crates/common/validator/src/validator.rs
@@ -331,15 +331,15 @@ impl ValidatorService {
             .get_attestation_data(slot, committee_index)
             .await?
             .data;
-        Ok(self.beacon_api_client.submit_attestation(
-            vec![SingleAttestation {
+        Ok(self
+            .beacon_api_client
+            .submit_attestation(vec![SingleAttestation {
                 attester_index: validator_index,
                 committee_index,
                 signature: sign_attestation_data(&attestation_data, &keystore.private_key)?,
                 data: attestation_data,
-            }]
-            .await?,
-        ))
+            }])
+            .await?)
     }
 
     pub async fn submit_aggregate_and_proof(


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: #562 
We implement the following portion of the [Validator Flow](https://ethereum.github.io/beacon-APIs/validator-flow.md):
>5. If aggregator:
    - Wait for `SECONDS_PER_SLOT * 2 / 3` seconds into the assigned slot
    - [Fetch aggregated Attestation](#/ValidatorRequiredApi/getAggregatedAttestation) from Beacon Node you've subscribed to your subnet
    - [Publish SignedAggregateAndProofs](#/ValidatorRequiredApi/publishAggregateAndProofs)

### How was it implemented/fixed?
I check for the keystore for the provided validator index (aggregator_index)
I fetch the aggregated attestation from the beacon node.
I then create an AggregateAndProof object using the aggregate and the selection_proof (I believe this is a slot signature)
I sign this aggregate and proof and publish it using the Beacon API endpoint.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
