### PR TITLE
refactor: rename PubKey to PublicKey

### DIFF
--- a/crates/common/beacon_api_types/src/duties.rs
+++ b/crates/common/beacon_api_types/src/duties.rs
@@ -1,10 +1,11 @@
-use ream_bls::PubKey;
+use ream_bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 
 #[derive(Debug, Deserialize, Serialize, Encode, Decode)]
 pub struct ProposerDuty {
-    pub pubkey: PubKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
     #[serde(with = "serde_utils::quoted_u64")]
@@ -13,7 +14,8 @@ pub struct ProposerDuty {
 
 #[derive(Debug, Deserialize, Serialize, Encode, Decode)]
 pub struct AttesterDuty {
-    pub pubkey: PubKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
     #[serde(with = "serde_utils::quoted_u64")]
@@ -28,7 +30,8 @@ pub struct AttesterDuty {
 
 #[derive(Debug, Deserialize, Serialize, Encode, Decode)]
 pub struct SyncCommitteeDuty {
-    pub pubkey: PubKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
     pub validator_sync_committee_indices: Vec<u64>,

--- a/crates/common/beacon_api_types/src/id.rs
+++ b/crates/common/beacon_api_types/src/id.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::{fmt::Display, str::FromStr};
 
 use alloy_primitives::{B256, hex};
-use ream_bls::PubKey;
+use ream_bls::PublicKey;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,7 +70,7 @@ impl fmt::Display for ID {
 pub enum ValidatorID {
     Index(u64),
     /// expected to be a 0x-prefixed hex string.
-    Address(PubKey),
+    Address(PublicKey),
 }
 
 impl Serialize for ValidatorID {
@@ -89,7 +89,7 @@ impl<'de> Deserialize<'de> for ValidatorID {
     {
         let s = String::deserialize(deserializer)?;
         if s.starts_with("0x") {
-            PubKey::from_str(&s)
+            PublicKey::from_str(&s)
                 .map(ValidatorID::Address)
                 .map_err(|_| serde::de::Error::custom(format!("Invalid hex address: {s}")))
         } else if s.chars().all(|c| c.is_ascii_digit()) {

--- a/crates/common/consensus/src/bls_to_execution_change.rs
+++ b/crates/common/consensus/src/bls_to_execution_change.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use ream_bls::{BLSSignature, PubKey};
+use ream_bls::{BLSSignature, PublicKey};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
@@ -16,7 +16,8 @@ pub struct SignedBLSToExecutionChange {
 pub struct BLSToExecutionChange {
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
-    pub from_bls_pubkey: PubKey,
+    #[serde(rename = "from_bls_pubkey")]
+    pub from_bls_public_key: PublicKey,
     #[serde(with = "checksummed_address")]
     pub to_execution_address: Address,
 }

--- a/crates/common/consensus/src/consolidation_request.rs
+++ b/crates/common/consensus/src/consolidation_request.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use ream_bls::PubKey;
+use ream_bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
@@ -10,6 +10,8 @@ use crate::misc::checksummed_address;
 pub struct ConsolidationRequest {
     #[serde(with = "checksummed_address")]
     pub source_address: Address,
-    pub source_pubkey: PubKey,
-    pub target_pubkey: PubKey,
+    #[serde(rename = "source_pubkey")]
+    pub source_public_key: PublicKey,
+    #[serde(rename = "target_pubkey")]
+    pub target_public_key: PublicKey,
 }

--- a/crates/common/consensus/src/deposit_data.rs
+++ b/crates/common/consensus/src/deposit_data.rs
@@ -1,12 +1,13 @@
 use alloy_primitives::B256;
-use ream_bls::{BLSSignature, PubKey};
+use ream_bls::{BLSSignature, PublicKey};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct DepositData {
-    pub pubkey: PubKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
     pub withdrawal_credentials: B256,
     #[serde(with = "serde_utils::quoted_u64")]
     pub amount: u64,

--- a/crates/common/consensus/src/deposit_message.rs
+++ b/crates/common/consensus/src/deposit_message.rs
@@ -1,12 +1,13 @@
 use alloy_primitives::B256;
-use ream_bls::PubKey;
+use ream_bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct DepositMessage {
-    pub pubkey: PubKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
     pub withdrawal_credentials: B256,
     pub amount: u64,
 }

--- a/crates/common/consensus/src/deposit_request.rs
+++ b/crates/common/consensus/src/deposit_request.rs
@@ -1,12 +1,13 @@
 use alloy_primitives::B256;
-use ream_bls::{BLSSignature, PubKey};
+use ream_bls::{BLSSignature, PublicKey};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct DepositRequest {
-    pub pubkey: PubKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
     pub withdrawal_credentials: B256,
     #[serde(with = "serde_utils::quoted_u64")]
     pub amount: u64,

--- a/crates/common/consensus/src/pending_deposit.rs
+++ b/crates/common/consensus/src/pending_deposit.rs
@@ -1,12 +1,13 @@
 use alloy_primitives::B256;
-use ream_bls::{BLSSignature, PubKey};
+use ream_bls::{BLSSignature, PublicKey};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct PendingDeposit {
-    pub pubkey: PubKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
     pub withdrawal_credentials: B256,
     #[serde(with = "serde_utils::quoted_u64")]
     pub amount: u64,

--- a/crates/common/consensus/src/sync_committee.rs
+++ b/crates/common/consensus/src/sync_committee.rs
@@ -1,4 +1,4 @@
-use ream_bls::PubKey;
+use ream_bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, typenum::U512};
@@ -6,6 +6,8 @@ use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct SyncCommittee {
-    pub pubkeys: FixedVector<PubKey, U512>,
-    pub aggregate_pubkey: PubKey,
+    #[serde(rename = "pubkeys")]
+    pub public_keys: FixedVector<PublicKey, U512>,
+    #[serde(rename = "aggregate_pubkey")]
+    pub aggregate_public_key: PublicKey,
 }

--- a/crates/common/consensus/src/validator.rs
+++ b/crates/common/consensus/src/validator.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::B256;
-use ream_bls::PubKey;
+use ream_bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
@@ -14,7 +14,8 @@ use crate::{
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct Validator {
-    pub pubkey: PubKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
 
     /// Commitment to pubkey for withdrawals
     pub withdrawal_credentials: B256,

--- a/crates/common/consensus/src/withdrawal_request.rs
+++ b/crates/common/consensus/src/withdrawal_request.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use ream_bls::PubKey;
+use ream_bls::PublicKey;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
@@ -10,7 +10,8 @@ use crate::misc::checksummed_address;
 pub struct WithdrawalRequest {
     #[serde(with = "checksummed_address")]
     pub source_address: Address,
-    pub validator_pubkey: PubKey,
+    #[serde(rename = "validator_pubkey")]
+    pub validator_public_key: PublicKey,
     #[serde(with = "serde_utils::quoted_u64")]
     pub amount: u64,
 }

--- a/crates/common/validator/src/sync_committee.rs
+++ b/crates/common/validator/src/sync_committee.rs
@@ -62,13 +62,13 @@ pub fn is_assigned_to_sync_committee(
     if sync_committee_period == current_sync_committee_period {
         Ok(state
             .current_sync_committee
-            .pubkeys
-            .contains(&validator.pubkey))
+            .public_keys
+            .contains(&validator.public_key))
     } else {
         Ok(state
             .next_sync_committee
-            .pubkeys
-            .contains(&validator.pubkey))
+            .public_keys
+            .contains(&validator.public_key))
     }
 }
 
@@ -90,10 +90,10 @@ pub fn compute_subnets_for_sync_committee(
     };
 
     let sync_committee_indices: Vec<usize> = sync_committee
-        .pubkeys
+        .public_keys
         .iter()
         .enumerate()
-        .filter(|(_, pubkey)| **pubkey == target_validator.pubkey)
+        .filter(|(_, public_key)| **public_key == target_validator.public_key)
         .map(|(index, _)| index)
         .collect();
 

--- a/crates/crypto/bls/README.md
+++ b/crates/crypto/bls/README.md
@@ -43,10 +43,10 @@ The crate uses a **trait-based interface** to abstract over the specific backend
 ### Public Key Aggregation
 
 ```rust
-use ream_bls::{AggregatePubKey, PubKey};
+use ream_bls::{AggregatePublicKey, PublicKey};
 
-let pubkeys: &[&PubKey] = &[..];
-let agg_pubkey = AggregatePubKey::aggregate(pubkeys).unwrap();
+let public_keys: &[&PublicKey] = &[..];
+let aggregate_public_key = AggregatePublicKey::aggregate(public_keys).unwrap();
 ```
 
 ### Signing
@@ -63,23 +63,23 @@ let signature = private_key.sign(message);
 ### Signature Verification
 
 ```rust
-use ream_bls::{BLSSignature, PubKey};
+use ream_bls::{BLSSignature, PublicKey};
 
 let signature: BLSSignature = ..;
-let pubkey: PubKey = ..;
+let public_key: PublicKey = ..;
 let message = b"Hello, world!";
 
-let result = signature.verify(&pubkey, message);
+let result = signature.verify(&public_key, message);
 ```
 
 ### Fast Aggregate Verification
 
 ```rust
-use ream_bls::{AggregatePubKey, BLSSignature, PubKey};
+use ream_bls::{AggregatePublicKey, BLSSignature, PublicKey};
 
 let signature: BLSSignature = ..;
-let pubkeys: &[&PubKey] = &[..];
+let public_keys: &[&PublicKey] = &[..];
 let message = b"Hello, world!";
 
-let result = signature.fast_aggregate_verify(pubkeys, message);
+let result = signature.fast_aggregate_verify(public_keys, message);
 ```

--- a/crates/crypto/bls/src/lib.rs
+++ b/crates/crypto/bls/src/lib.rs
@@ -6,12 +6,12 @@
 pub mod constants;
 pub mod errors;
 pub mod private_key;
-pub mod pubkey;
+pub mod public_key;
 pub mod signature;
 pub mod traits;
 
 pub use private_key::PrivateKey;
-pub use pubkey::PubKey;
+pub use public_key::PublicKey;
 pub use signature::BLSSignature;
 
 #[cfg(feature = "supranational")]

--- a/crates/crypto/bls/src/public_key.rs
+++ b/crates/crypto/bls/src/public_key.rs
@@ -10,11 +10,17 @@ use tree_hash_derive::TreeHash;
 use crate::errors::BLSError;
 
 #[derive(Debug, PartialEq, Clone, Encode, Decode, TreeHash, Default, Eq, Hash)]
-pub struct PubKey {
+pub struct PublicKey {
     pub inner: FixedVector<u8, U48>,
 }
 
-impl Serialize for PubKey {
+impl PublicKey {
+    pub fn to_bytes(&self) -> &[u8] {
+        self.inner.iter().as_slice()
+    }
+}
+
+impl Serialize for PublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -24,7 +30,7 @@ impl Serialize for PubKey {
     }
 }
 
-impl<'de> Deserialize<'de> for PubKey {
+impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -36,13 +42,7 @@ impl<'de> Deserialize<'de> for PubKey {
     }
 }
 
-impl PubKey {
-    pub fn to_bytes(&self) -> &[u8] {
-        self.inner.iter().as_slice()
-    }
-}
-
-impl FromStr for PubKey {
+impl FromStr for PublicKey {
     type Err = BLSError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let clean_str = s.strip_prefix("0x").unwrap_or(s);
@@ -52,7 +52,7 @@ impl FromStr for PubKey {
             return Err(BLSError::InvalidByteLength);
         }
 
-        Ok(PubKey {
+        Ok(PublicKey {
             inner: FixedVector::from(bytes),
         })
     }

--- a/crates/crypto/bls/src/supranational/mod.rs
+++ b/crates/crypto/bls/src/supranational/mod.rs
@@ -1,4 +1,4 @@
 pub mod errors;
 pub mod private_key;
-pub mod pubkey;
+pub mod public_key;
 pub mod signature;

--- a/crates/crypto/bls/src/supranational/signature.rs
+++ b/crates/crypto/bls/src/supranational/signature.rs
@@ -8,7 +8,7 @@ use ssz_types::FixedVector;
 use crate::{
     constants::DST,
     errors::BLSError,
-    pubkey::PubKey,
+    public_key::PublicKey,
     signature::BLSSignature,
     traits::{Aggregatable, SupranationalAggregatable, SupranationalVerifiable, Verifiable},
 };
@@ -33,9 +33,9 @@ impl TryFrom<BlstSignature> for BLSSignature {
 impl Verifiable for BLSSignature {
     type Error = BLSError;
 
-    fn verify(&self, pubkey: &PubKey, message: &[u8]) -> Result<bool, BLSError> {
+    fn verify(&self, public_key: &PublicKey, message: &[u8]) -> Result<bool, BLSError> {
         let signature = self.to_blst_signature()?;
-        let public_key = pubkey.to_blst_pubkey()?;
+        let public_key = public_key.to_blst_public_key()?;
 
         Ok(
             signature.verify(true, message, DST, &[], &public_key, false)
@@ -43,15 +43,15 @@ impl Verifiable for BLSSignature {
         )
     }
 
-    fn fast_aggregate_verify<'a, P>(&self, pubkeys: P, message: &[u8]) -> Result<bool, BLSError>
+    fn fast_aggregate_verify<'a, P>(&self, public_keys: P, message: &[u8]) -> Result<bool, BLSError>
     where
-        P: AsRef<[&'a PubKey]>,
+        P: AsRef<[&'a PublicKey]>,
     {
         let signature = self.to_blst_signature()?;
-        let public_keys = pubkeys
+        let public_keys = public_keys
             .as_ref()
             .iter()
-            .map(|key| key.to_blst_pubkey())
+            .map(|key| key.to_blst_public_key())
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(signature.fast_aggregate_verify(

--- a/crates/crypto/bls/src/traits.rs
+++ b/crates/crypto/bls/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{BLSSignature, PubKey, errors::BLSError};
+use crate::{BLSSignature, PublicKey, errors::BLSError};
 
 /// Trait for aggregating BLS public keys.
 ///
@@ -57,27 +57,31 @@ pub trait Verifiable {
     /// Verifies a BLS signature against a public key and message.
     ///
     /// # Arguments
-    /// * `pubkey` - The public key to verify against
+    /// * `public_key` - The public key to verify against
     /// * `message` - The message that was signed
     ///
     /// # Returns
     /// * `Result<bool, BLSError>` - Ok(true) if the signature is valid, Ok(false) if verification
     ///   fails, or Err if there are issues with signature or public key bytes
-    fn verify(&self, pubkey: &PubKey, message: &[u8]) -> Result<bool, Self::Error>;
+    fn verify(&self, public_key: &PublicKey, message: &[u8]) -> Result<bool, Self::Error>;
 
     /// Verifies the signature against a message using an aggregate of multiple public keys
     ///
     /// # Arguments
-    /// * `pubkeys` - Collection of public key references to verify against
+    /// * `public_keys` - Collection of public key references to verify against
     /// * `message` - Message that was signed
     ///
     /// # Returns
     /// * `Result<bool, BLSError>` - Ok(true) if the signature is valid for the aggregate
     ///   verification, Ok(false) if verification fails, or Err if there are issues with signature
     ///   or public key bytes
-    fn fast_aggregate_verify<'a, P>(&self, pubkeys: P, message: &[u8]) -> Result<bool, Self::Error>
+    fn fast_aggregate_verify<'a, P>(
+        &self,
+        public_keys: P,
+        message: &[u8],
+    ) -> Result<bool, Self::Error>
     where
-        P: AsRef<[&'a PubKey]>;
+        P: AsRef<[&'a PublicKey]>;
 }
 
 /// Marker trait for zkcrypto/bls12_381 BLS signature verification implementation

--- a/crates/crypto/bls/src/zkcrypto/mod.rs
+++ b/crates/crypto/bls/src/zkcrypto/mod.rs
@@ -1,3 +1,3 @@
 pub mod private_key;
-pub mod pubkey;
+pub mod public_key;
 pub mod signature;

--- a/crates/crypto/bls/src/zkcrypto/public_key.rs
+++ b/crates/crypto/bls/src/zkcrypto/public_key.rs
@@ -1,12 +1,12 @@
 use bls12_381::{G1Affine, G1Projective};
 
 use crate::{
-    PubKey,
+    PublicKey,
     errors::BLSError,
     traits::{Aggregatable, ZkcryptoAggregatable},
 };
 
-impl From<G1Projective> for PubKey {
+impl From<G1Projective> for PublicKey {
     fn from(value: G1Projective) -> Self {
         Self {
             inner: G1Affine::from(value).to_compressed().to_vec().into(),
@@ -14,10 +14,10 @@ impl From<G1Projective> for PubKey {
     }
 }
 
-impl TryFrom<&PubKey> for G1Affine {
+impl TryFrom<&PublicKey> for G1Affine {
     type Error = BLSError;
 
-    fn try_from(value: &PubKey) -> Result<Self, Self::Error> {
+    fn try_from(value: &PublicKey) -> Result<Self, Self::Error> {
         match G1Affine::from_compressed(
             &value
                 .to_bytes()
@@ -32,10 +32,10 @@ impl TryFrom<&PubKey> for G1Affine {
     }
 }
 
-impl Aggregatable<PubKey> for PubKey {
+impl Aggregatable<PublicKey> for PublicKey {
     type Error = BLSError;
 
-    fn aggregate(public_keys: &[&PubKey]) -> Result<PubKey, Self::Error> {
+    fn aggregate(public_keys: &[&PublicKey]) -> Result<PublicKey, Self::Error> {
         let aggregate_point =
             public_keys
                 .iter()
@@ -43,8 +43,8 @@ impl Aggregatable<PubKey> for PubKey {
                     Ok(accumulator.add(&G1Projective::from(G1Affine::try_from(*public_key)?)))
                 })?;
 
-        Ok(PubKey::from(aggregate_point))
+        Ok(PublicKey::from(aggregate_point))
     }
 }
 
-impl ZkcryptoAggregatable<PubKey> for PubKey {}
+impl ZkcryptoAggregatable<PublicKey> for PublicKey {}

--- a/crates/crypto/keystore/src/keystore.rs
+++ b/crates/crypto/keystore/src/keystore.rs
@@ -2,7 +2,7 @@ use std::{fs, path::Path};
 
 use alloy_primitives::B256;
 use anyhow::{Result, anyhow, ensure};
-use ream_bls::{PrivateKey, PubKey as PublicKey};
+use ream_bls::{PrivateKey, PublicKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -12,7 +12,8 @@ use crate::{decrypt::aes128_ctr, hex_serde, pbkdf2::pbkdf2, scrypt::scrypt};
 pub struct EncryptedKeystore {
     pub crypto: Crypto,
     pub description: String,
-    pub pubkey: PublicKey,
+    #[serde(rename = "pubkey")]
+    pub public_key: PublicKey,
     pub path: String,
     pub uuid: String,
     pub version: u64,
@@ -95,7 +96,7 @@ impl EncryptedKeystore {
             }
         };
         Ok(Keystore {
-            public_key: self.pubkey.clone(),
+            public_key: self.public_key.clone(),
             private_key,
         })
     }
@@ -192,7 +193,7 @@ mod tests {
                 },
             },
             description: "Test Keystore".to_string(),
-            pubkey: PublicKey {
+            public_key: PublicKey {
                 inner: FixedVector::from(vec![0x12; 48]),
             },
             path: "m/44'/60'/0'/0/0".to_string(),
@@ -239,12 +240,12 @@ mod tests {
                         },
                     },
                     description: "".to_string(),
-                    pubkey: PublicKey {
+                    public_key: PublicKey {
                         inner: FixedVector::from(
                             hex::decode(
                                 "b69dfa082ca75d4e50ed4da8fa07d550ba9ec4019815409f42a98b79861d7ad96633a2476594b94c8a6e3048e1b2623e",
                             )
-                            .expect("Failed to decode pubkey"),
+                            .expect("Failed to decode public_key"),
                         ),
                     },
                     path: "m/12381/3600/0/0/0".to_string(),

--- a/crates/rpc/src/handlers/duties.rs
+++ b/crates/rpc/src/handlers/duties.rs
@@ -35,7 +35,7 @@ pub async fn get_proposer_duties(
             return Err(ApiError::ValidatorNotFound(format!("{validator_index}")));
         };
         duties.push(ProposerDuty {
-            pubkey: validator.pubkey.clone(),
+            public_key: validator.public_key.clone(),
             validator_index,
             slot,
         });
@@ -82,7 +82,7 @@ pub async fn get_attester_duties(
                 })?;
 
             duties.push(AttesterDuty {
-                pubkey: validator.pubkey.clone(),
+                public_key: validator.public_key.clone(),
                 validator_index,
                 committee_index,
                 committees_at_slot,

--- a/crates/rpc/src/handlers/light_client.rs
+++ b/crates/rpc/src/handlers/light_client.rs
@@ -72,8 +72,7 @@ pub async fn get_light_client_updates(
             })?
             .ok_or_else(|| {
                 ApiError::NotFound(format!(
-                    "No block root found for slot {} (period {})",
-                    slot, start_period
+                    "No block root found for slot {slot} (period {start_period})",
                 ))
             })?;
 

--- a/crates/rpc/src/handlers/state.rs
+++ b/crates/rpc/src/handlers/state.rs
@@ -247,13 +247,13 @@ pub async fn get_sync_committees(
     };
 
     let validators = sync_committee
-        .pubkeys
+        .public_keys
         .iter()
-        .filter_map(|pubkey| {
+        .filter_map(|public_key| {
             state
                 .validators
                 .iter()
-                .position(|validator| validator.pubkey == *pubkey)
+                .position(|validator| validator.public_key == *public_key)
                 .map(|position| position as u64)
         })
         .collect::<Vec<_>>();

--- a/crates/rpc/src/handlers/validator.rs
+++ b/crates/rpc/src/handlers/validator.rs
@@ -12,7 +12,7 @@ use ream_beacon_api_types::{
     responses::BeaconResponse,
     validator::{ValidatorBalance, ValidatorData, ValidatorStatus},
 };
-use ream_bls::PubKey;
+use ream_bls::PublicKey;
 use ream_consensus::validator::Validator;
 use ream_storage::db::ReamDB;
 use serde::Serialize;
@@ -34,7 +34,7 @@ fn build_validator_balances(
         .filter(|(idx, (validator, _))| match &filtered_ids {
             Some(ids) => {
                 ids.contains(&ValidatorID::Index(*idx as u64))
-                    || ids.contains(&ValidatorID::Address(validator.pubkey.clone()))
+                    || ids.contains(&ValidatorID::Address(validator.public_key.clone()))
             }
             None => true,
         })
@@ -63,17 +63,17 @@ pub async fn get_validator_from_state(
                     )));
                 }
             },
-            ValidatorID::Address(pubkey) => {
+            ValidatorID::Address(public_key) => {
                 match state
                     .validators
                     .iter()
                     .enumerate()
-                    .find(|(_, v)| v.pubkey == *pubkey)
+                    .find(|(_, v)| v.public_key == *public_key)
                 {
                     Some((i, validator)) => (i, validator.to_owned()),
                     None => {
                         return Err(ApiError::NotFound(format!(
-                            "Validator not found for pubkey: {pubkey:?}"
+                            "Validator not found for public_key: {public_key:?}"
                         )))?;
                     }
                 }
@@ -149,17 +149,17 @@ pub async fn get_validators_from_state(
                             )))?;
                         }
                     },
-                    ValidatorID::Address(pubkey) => {
+                    ValidatorID::Address(public_key) => {
                         match state
                             .validators
                             .iter()
                             .enumerate()
-                            .find(|(_, v)| v.pubkey == *pubkey)
+                            .find(|(_, v)| v.public_key == *public_key)
                         {
                             Some((i, validator)) => (i, validator.to_owned()),
                             None => {
                                 return Err(ApiError::NotFound(format!(
-                                    "Validator not found for pubkey: {pubkey:?}"
+                                    "Validator not found for public_key: {public_key:?}"
                                 )))?;
                             }
                         }
@@ -223,17 +223,17 @@ pub async fn post_validators_from_state(
                             )))?;
                         }
                     },
-                    ValidatorID::Address(pubkey) => {
+                    ValidatorID::Address(public_key) => {
                         match state
                             .validators
                             .iter()
                             .enumerate()
-                            .find(|(_, v)| v.pubkey == *pubkey)
+                            .find(|(_, v)| v.public_key == *public_key)
                         {
                             Some((i, validator)) => (i, validator.to_owned()),
                             None => {
                                 return Err(ApiError::NotFound(format!(
-                                    "Validator not found for pubkey: {pubkey:?}"
+                                    "Validator not found for public_key: {public_key:?}"
                                 )))?;
                             }
                         }
@@ -274,7 +274,7 @@ pub async fn post_validators_from_state(
 struct ValidatorIdentity {
     #[serde(with = "serde_utils::quoted_u64")]
     index: u64,
-    pubkey: PubKey,
+    public_key: PublicKey,
     #[serde(with = "serde_utils::quoted_u64")]
     activation_epoch: u64,
 }
@@ -295,11 +295,11 @@ pub async fn post_validator_identities_from_state(
         .enumerate()
         .filter_map(|(index, validator)| {
             if validator_ids_set.contains(&ValidatorID::Index(index as u64))
-                || validator_ids_set.contains(&ValidatorID::Address(validator.pubkey.clone()))
+                || validator_ids_set.contains(&ValidatorID::Address(validator.public_key.clone()))
             {
                 Some(ValidatorIdentity {
                     index: index as u64,
-                    pubkey: validator.pubkey.clone(),
+                    public_key: validator.public_key.clone(),
                     activation_epoch: validator.activation_epoch,
                 })
             } else {


### PR DESCRIPTION
### What are you trying to achieve?

Currently we are using the shorthand `PubKey` instead of `PublicKey`. This is inconsistent with practices done in the rest of our codebase and also inconsistent with `PrivateKey`. We should just rename it to `PublicKey` so it is more readable.

### How was it implemented/fixed?

renaming `PubKey` to `PublicKey`