### PR TITLE
chore: add DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ testing/ef-tests/mainnet/*
 
 # redb files: prevent accidental commits of database files
 *.redb
+
+# DS_Store: Desktop Services Store
+.DS_Store


### PR DESCRIPTION
### What are you trying to achieve?

It can be annoying to remove DS_Store files if accidentally committed. Best to ignore

