### PR TITLE
feat: use create_dir_all instead of create_dir

### DIFF
--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -73,7 +73,7 @@ impl ReamDB {
         write_txn.open_table(UNREALIZED_JUSTIFED_CHECKPOINT_FIELD)?;
         write_txn.commit()?;
 
-        fs::create_dir(data_dir.join(BLOB_FOLDER_NAME))?;
+        fs::create_dir_all(data_dir.join(BLOB_FOLDER_NAME))?;
 
         Ok(Self {
             db: Arc::new(db),


### PR DESCRIPTION
### What are you trying to achieve?

Before I created a pr that stored the blobs in the data directory, instead of the database but i used create_dir which cause it to crash if the folder already exists.

### How was it implemented/fixed?

I used create_dir_all instead

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
