### PR TITLE
feat: fixed beacon node initialization from panicking

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -127,11 +127,7 @@ pub async fn run_beacon_node(config: BeaconNodeConfig, executor: ReamExecutor) {
 
     let network_state = network_manager.network_state.clone();
 
-    let execution_engine = network_manager
-        .beacon_chain
-        .execution_engine
-        .clone()
-        .expect("Execution engine must be initialized for API server");
+    let execution_engine = network_manager.beacon_chain.execution_engine.clone();
 
     let network_future = executor.spawn(async move {
         network_manager.start().await;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -20,7 +20,7 @@ pub async fn start_server(
     db: ReamDB,
     network_state: Arc<NetworkState>,
     operation_pool: Arc<OperationPool>,
-    execution_engine: ExecutionEngine,
+    execution_engine: Option<ExecutionEngine>,
 ) -> std::io::Result<()> {
     info!(
         "starting HTTP server on {:?}",


### PR DESCRIPTION
### What are you trying to achieve?

when running the beacon node I was running into a tokio panic error due to trying to unwrap the execution engine which is only optionally initialized

### How was it implemented/fixed?

fixed beacon node initialization by removing the expect
