### PR TITLE
fix: register /beacon/heads to /eth/v2/debug

### DIFF
--- a/crates/rpc/src/routes/debug.rs
+++ b/crates/rpc/src/routes/debug.rs
@@ -2,10 +2,10 @@ use actix_web::web::{ServiceConfig, scope};
 
 use crate::handlers::{block::get_beacon_heads, state::get_beacon_state};
 
-pub fn register_debug_routes(cfg: &mut ServiceConfig) {
-    cfg.service(scope("/debug").service(get_beacon_heads));
-}
-
 pub fn register_debug_routes_v2(cfg: &mut ServiceConfig) {
-    cfg.service(scope("/debug").service(get_beacon_state));
+    cfg.service(
+        scope("/debug")
+            .service(get_beacon_state)
+            .service(get_beacon_heads),
+    );
 }

--- a/crates/rpc/src/routes/mod.rs
+++ b/crates/rpc/src/routes/mod.rs
@@ -10,7 +10,6 @@ pub fn get_v1_routes(config: &mut ServiceConfig) {
     config.service(
         scope("/eth/v1")
             .configure(beacon::register_beacon_routes)
-            .configure(debug::register_debug_routes)
             .configure(node::register_node_routes)
             .configure(config::register_config_routes)
             .configure(validator::register_validator_routes),


### PR DESCRIPTION
### What are you trying to achieve?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Fixes to link `/eth/v2/debug/beacon/heads` with current implementation (`get_beacon_heads`). Refer to [Beacon API Specification](https://ethereum.github.io/beacon-APIs/#/Debug/getDebugChainHeadsV2).

### How was it implemented/fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

`/eth/v1/debug/fork_choice` (related issue: #221) is the only endpoint that has a path starting with `/eth/v1/debug`, so I simply deleted the `register_debug_routes` as it is not implemented yet.


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
