### PR TITLE
feat: implement `/eth/v1/debug/fork_choice` endpoint

### DIFF
--- a/crates/common/beacon_api_types/src/responses.rs
+++ b/crates/common/beacon_api_types/src/responses.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::B256;
+use ream_consensus::checkpoint::Checkpoint;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
@@ -188,4 +189,84 @@ impl BeaconHeadResponse {
             execution_optimistic: EXECUTION_OPTIMISTIC,
         }
     }
+}
+
+/// A ForkChoiceResponse data struct that is used for /debug/fork_choice endpoint.
+///
+/// # Example
+///
+/// ```json
+/// {
+///   "justified_checkpoint": {
+///     "epoch": "1",
+///     "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+///   },
+///   "finalized_checkpoint": {
+///     "epoch": "1",
+///     "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+///   },
+///   "fork_choice_nodes": [
+///     {
+///       "slot": "1",
+///       "block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+///       "parent_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+///       "justified_epoch": "1",
+///       "finalized_epoch": "1",
+///       "weight": "1",
+///       "validity": "valid",
+///       "execution_block_hash": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+///       "extra_data": {}
+///     }
+///   ],
+///   "extra_data": {}
+/// }
+/// ```
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ForkChoiceResponse {
+    pub justified_checkpoint: Checkpoint,
+    pub finalized_checkpoint: Checkpoint,
+    pub fork_choice_nodes: Vec<ForkChoiceNode>,
+    #[serde(default)]
+    pub extra_data: serde_json::Value,
+}
+
+impl ForkChoiceResponse {
+    pub fn new(
+        justified_checkpoint: Checkpoint,
+        finalized_checkpoint: Checkpoint,
+        fork_choice_nodes: Vec<ForkChoiceNode>,
+    ) -> Self {
+        Self {
+            justified_checkpoint,
+            finalized_checkpoint,
+            fork_choice_nodes,
+            extra_data: serde_json::Value::default(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ForkChoiceNode {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub slot: u64,
+    pub block_root: B256,
+    pub parent_root: B256,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub justified_epoch: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub finalized_epoch: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub weight: u64,
+    pub validity: ForkChoiceValidity,
+    pub execution_block_hash: B256,
+    #[serde(default)]
+    pub extra_data: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum ForkChoiceValidity {
+    Valid,
+    Invalid,
+    Optimistic,
 }

--- a/crates/rpc/src/handlers/block.rs
+++ b/crates/rpc/src/handlers/block.rs
@@ -1,17 +1,13 @@
-use std::{collections::HashSet, sync::Arc};
-
 use actix_web::{
     HttpRequest, HttpResponse, Responder, get, post,
     web::{Data, Json, Path},
 };
 use alloy_primitives::B256;
-use hashbrown::HashMap;
 use ream_beacon_api_types::{
     error::ApiError,
     id::{ID, ValidatorID},
     responses::{
-        BeaconHeadResponse, BeaconResponse, BeaconVersionedResponse, DataResponse, RootResponse,
-        SSZ_CONTENT_TYPE,
+        BeaconResponse, BeaconVersionedResponse, DataResponse, RootResponse, SSZ_CONTENT_TYPE,
     },
 };
 use ream_consensus::{
@@ -19,9 +15,7 @@ use ream_consensus::{
     electra::{beacon_block::SignedBeaconBlock, beacon_state::BeaconState},
     genesis::Genesis,
 };
-use ream_fork_choice::store::Store;
 use ream_network_spec::networks::network_spec;
-use ream_operation_pool::OperationPool;
 use ream_storage::{
     db::ReamDB,
     tables::{Field, Table},
@@ -298,47 +292,6 @@ pub async fn post_sync_committee_rewards(
     };
 
     Ok(HttpResponse::Ok().json(BeaconResponse::new(reward_data)))
-}
-
-/// Called by `/beacon/heads` to get fork choice leaves.
-#[get("/beacon/heads")]
-pub async fn get_beacon_heads(db: Data<ReamDB>) -> Result<impl Responder, ApiError> {
-    let justified_checkpoint = db.justified_checkpoint_provider().get().map_err(|err| {
-        ApiError::InternalError(format!(
-            "Failed to get justified_checkpoint, error: {err:?}"
-        ))
-    })?;
-
-    let mut blocks = HashMap::new();
-    let store = Store {
-        db: db.get_ref().clone(),
-        operation_pool: Arc::new(OperationPool::default()),
-    };
-
-    store
-        .filter_block_tree(justified_checkpoint.root, &mut blocks)
-        .map_err(|err| {
-            ApiError::InternalError(format!("Failed to filter block tree, error: {err:?}"))
-        })?;
-
-    let mut leaves = vec![];
-    let mut referenced_parents = HashSet::new();
-
-    for block in blocks.values() {
-        referenced_parents.insert(block.parent_root);
-    }
-
-    for (block_root, block) in &blocks {
-        if !referenced_parents.contains(block_root) {
-            leaves.push(BeaconHeadResponse {
-                root: block.block_root(),
-                slot: block.slot,
-                execution_optimistic: false,
-            });
-        }
-    }
-
-    Ok(HttpResponse::Ok().json(DataResponse::new(leaves)))
 }
 
 #[get("/beacon/blind_block/{block_id}")]

--- a/crates/rpc/src/handlers/debug.rs
+++ b/crates/rpc/src/handlers/debug.rs
@@ -8,7 +8,7 @@ use hashbrown::HashMap;
 use ream_beacon_api_types::{
     error::ApiError,
     id::ID,
-    responses::{BeaconHeadResponse, BeaconResponse, DataResponse},
+    responses::{BeaconHeadResponse, BeaconResponse, DataResponse, ForkChoiceResponse},
 };
 use ream_fork_choice::store::Store;
 use ream_operation_pool::OperationPool;
@@ -64,4 +64,17 @@ pub async fn get_beacon_heads(db: Data<ReamDB>) -> Result<impl Responder, ApiErr
     }
 
     Ok(HttpResponse::Ok().json(DataResponse::new(leaves)))
+}
+
+#[get("/debug/fork_choice")]
+pub async fn get_fork_choice(db: Data<ReamDB>) -> Result<impl Responder, ApiError> {
+    let justified_checkpoint = todo!();
+    let finalized_checkpoint = todo!();
+    let fork_choice_nodes = vec![];
+
+    Ok(HttpResponse::Ok().json(ForkChoiceResponse::new(
+        justified_checkpoint,
+        finalized_checkpoint,
+        fork_choice_nodes,
+    )))
 }

--- a/crates/rpc/src/handlers/debug.rs
+++ b/crates/rpc/src/handlers/debug.rs
@@ -20,7 +20,7 @@ use ream_storage::{db::ReamDB, tables::Field};
 use crate::handlers::state::get_state_from_id;
 
 #[get("/debug/beacon/states/{state_id}")]
-pub async fn get_beacon_state(
+pub async fn get_debug_beacon_state(
     db: Data<ReamDB>,
     state_id: Path<ID>,
 ) -> Result<impl Responder, ApiError> {
@@ -30,7 +30,7 @@ pub async fn get_beacon_state(
 }
 
 #[get("/debug/beacon/heads")]
-pub async fn get_beacon_heads(db: Data<ReamDB>) -> Result<impl Responder, ApiError> {
+pub async fn get_debug_beacon_heads(db: Data<ReamDB>) -> Result<impl Responder, ApiError> {
     let justified_checkpoint = db.justified_checkpoint_provider().get().map_err(|err| {
         ApiError::InternalError(format!(
             "Failed to get justified_checkpoint, error: {err:?}"
@@ -70,7 +70,7 @@ pub async fn get_beacon_heads(db: Data<ReamDB>) -> Result<impl Responder, ApiErr
 }
 
 #[get("/debug/fork_choice")]
-pub async fn get_fork_choice(db: Data<ReamDB>) -> Result<impl Responder, ApiError> {
+pub async fn get_debug_fork_choice(db: Data<ReamDB>) -> Result<impl Responder, ApiError> {
     let justified_checkpoint = db.justified_checkpoint_provider().get().map_err(|err| {
         ApiError::InternalError(format!(
             "Failed to get justified_checkpoint, error: {err:?}"

--- a/crates/rpc/src/handlers/debug.rs
+++ b/crates/rpc/src/handlers/debug.rs
@@ -8,7 +8,10 @@ use hashbrown::HashMap;
 use ream_beacon_api_types::{
     error::ApiError,
     id::ID,
-    responses::{BeaconHeadResponse, BeaconResponse, DataResponse, ForkChoiceResponse},
+    responses::{
+        BeaconHeadResponse, BeaconResponse, DataResponse, ForkChoiceNode, ForkChoiceResponse,
+        ForkChoiceValidity,
+    },
 };
 use ream_fork_choice::store::Store;
 use ream_operation_pool::OperationPool;
@@ -68,9 +71,48 @@ pub async fn get_beacon_heads(db: Data<ReamDB>) -> Result<impl Responder, ApiErr
 
 #[get("/debug/fork_choice")]
 pub async fn get_fork_choice(db: Data<ReamDB>) -> Result<impl Responder, ApiError> {
-    let justified_checkpoint = todo!();
-    let finalized_checkpoint = todo!();
-    let fork_choice_nodes = vec![];
+    let justified_checkpoint = db.justified_checkpoint_provider().get().map_err(|err| {
+        ApiError::InternalError(format!(
+            "Failed to get justified_checkpoint, error: {err:?}"
+        ))
+    })?;
+    let finalized_checkpoint = db.finalized_checkpoint_provider().get().map_err(|err| {
+        ApiError::InternalError(format!(
+            "Failed to get finalized_checkpoint, error: {err:?}"
+        ))
+    })?;
+
+    let store = Store {
+        db: db.get_ref().clone(),
+        operation_pool: Arc::new(OperationPool::default()),
+    };
+    let blocks = store.get_filtered_block_tree().map_err(|err| {
+        ApiError::InternalError(format!("Failed to get filtered block tree, error: {err:?}"))
+    })?;
+    let mut fork_choice_nodes = Vec::with_capacity(blocks.len());
+    for (block_root, block) in blocks {
+        let weight = store.get_weight(block_root).map_err(|err| {
+            ApiError::InternalError(format!(
+                "Failed to get weight for block {block_root:?}, error: {err:?}"
+            ))
+        })?;
+
+        // TODO: Fetch epoch info
+        let (justified_epoch, finalized_epoch) = (1, 1);
+
+        fork_choice_nodes.push(ForkChoiceNode {
+            slot: block.slot,
+            block_root,
+            parent_root: block.parent_root,
+            justified_epoch,
+            finalized_epoch,
+            weight,
+            // NOTE: As `EXECUTION_OPTIMISTIC` is default to false, validity will be always "valid" in this context.
+            validity: ForkChoiceValidity::Valid,
+            execution_block_hash: block.body.execution_payload.block_hash,
+            extra_data: Default::default(),
+        });
+    }
 
     Ok(HttpResponse::Ok().json(ForkChoiceResponse::new(
         justified_checkpoint,

--- a/crates/rpc/src/handlers/debug.rs
+++ b/crates/rpc/src/handlers/debug.rs
@@ -1,0 +1,67 @@
+use std::{collections::HashSet, sync::Arc};
+
+use actix_web::{
+    HttpResponse, Responder, get,
+    web::{Data, Path},
+};
+use hashbrown::HashMap;
+use ream_beacon_api_types::{
+    error::ApiError,
+    id::ID,
+    responses::{BeaconHeadResponse, BeaconResponse, DataResponse},
+};
+use ream_fork_choice::store::Store;
+use ream_operation_pool::OperationPool;
+use ream_storage::{db::ReamDB, tables::Field};
+
+use crate::handlers::state::get_state_from_id;
+
+#[get("/debug/beacon/states/{state_id}")]
+pub async fn get_beacon_state(
+    db: Data<ReamDB>,
+    state_id: Path<ID>,
+) -> Result<impl Responder, ApiError> {
+    let state = get_state_from_id(state_id.into_inner(), &db).await?;
+
+    Ok(HttpResponse::Ok().json(BeaconResponse::new(state)))
+}
+
+#[get("/debug/beacon/heads")]
+pub async fn get_beacon_heads(db: Data<ReamDB>) -> Result<impl Responder, ApiError> {
+    let justified_checkpoint = db.justified_checkpoint_provider().get().map_err(|err| {
+        ApiError::InternalError(format!(
+            "Failed to get justified_checkpoint, error: {err:?}"
+        ))
+    })?;
+
+    let mut blocks = HashMap::new();
+    let store = Store {
+        db: db.get_ref().clone(),
+        operation_pool: Arc::new(OperationPool::default()),
+    };
+
+    store
+        .filter_block_tree(justified_checkpoint.root, &mut blocks)
+        .map_err(|err| {
+            ApiError::InternalError(format!("Failed to filter block tree, error: {err:?}"))
+        })?;
+
+    let mut leaves = vec![];
+    let mut referenced_parents = HashSet::new();
+
+    for block in blocks.values() {
+        referenced_parents.insert(block.parent_root);
+    }
+
+    for (block_root, block) in &blocks {
+        if !referenced_parents.contains(block_root) {
+            leaves.push(BeaconHeadResponse {
+                root: block.block_root(),
+                slot: block.slot,
+                execution_optimistic: false,
+            });
+        }
+    }
+
+    Ok(HttpResponse::Ok().json(DataResponse::new(leaves)))
+}

--- a/crates/rpc/src/handlers/mod.rs
+++ b/crates/rpc/src/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod blob_sidecar;
 pub mod block;
 pub mod committee;
 pub mod config;
+pub mod debug;
 pub mod duties;
 pub mod header;
 pub mod light_client;

--- a/crates/rpc/src/handlers/state.rs
+++ b/crates/rpc/src/handlers/state.rs
@@ -104,16 +104,6 @@ pub async fn get_state_from_id(state_id: ID, db: &ReamDB) -> Result<BeaconState,
         .ok_or_else(|| ApiError::NotFound(format!("Failed to find `block_root` from {state_id:?}")))
 }
 
-#[get("/beacon/states/{state_id}")]
-pub async fn get_beacon_state(
-    db: Data<ReamDB>,
-    state_id: Path<ID>,
-) -> Result<impl Responder, ApiError> {
-    let state = get_state_from_id(state_id.into_inner(), &db).await?;
-
-    Ok(HttpResponse::Ok().json(BeaconResponse::new(state)))
-}
-
 #[get("/beacon/states/{state_id}/root")]
 pub async fn get_state_root(
     db: Data<ReamDB>,

--- a/crates/rpc/src/routes/debug.rs
+++ b/crates/rpc/src/routes/debug.rs
@@ -1,11 +1,14 @@
 use actix_web::web::ServiceConfig;
 
-use crate::handlers::debug::{get_beacon_heads, get_beacon_state, get_fork_choice};
+use crate::handlers::debug::{
+    get_debug_beacon_heads, get_debug_beacon_state, get_debug_fork_choice,
+};
 
 pub fn register_debug_routes_v1(cfg: &mut ServiceConfig) {
-    cfg.service(get_fork_choice);
+    cfg.service(get_debug_fork_choice);
 }
 
 pub fn register_debug_routes_v2(cfg: &mut ServiceConfig) {
-    cfg.service(get_beacon_state).service(get_beacon_heads);
+    cfg.service(get_debug_beacon_state)
+        .service(get_debug_beacon_heads);
 }

--- a/crates/rpc/src/routes/debug.rs
+++ b/crates/rpc/src/routes/debug.rs
@@ -1,11 +1,7 @@
-use actix_web::web::{ServiceConfig, scope};
+use actix_web::web::ServiceConfig;
 
-use crate::handlers::{block::get_beacon_heads, state::get_beacon_state};
+use crate::handlers::debug::{get_beacon_heads, get_beacon_state};
 
 pub fn register_debug_routes_v2(cfg: &mut ServiceConfig) {
-    cfg.service(
-        scope("/debug")
-            .service(get_beacon_state)
-            .service(get_beacon_heads),
-    );
+    cfg.service(get_beacon_state).service(get_beacon_heads);
 }

--- a/crates/rpc/src/routes/debug.rs
+++ b/crates/rpc/src/routes/debug.rs
@@ -1,6 +1,10 @@
 use actix_web::web::ServiceConfig;
 
-use crate::handlers::debug::{get_beacon_heads, get_beacon_state};
+use crate::handlers::debug::{get_beacon_heads, get_beacon_state, get_fork_choice};
+
+pub fn register_debug_routes_v1(cfg: &mut ServiceConfig) {
+    cfg.service(get_fork_choice);
+}
 
 pub fn register_debug_routes_v2(cfg: &mut ServiceConfig) {
     cfg.service(get_beacon_state).service(get_beacon_heads);

--- a/crates/rpc/src/routes/mod.rs
+++ b/crates/rpc/src/routes/mod.rs
@@ -12,7 +12,8 @@ pub fn get_v1_routes(config: &mut ServiceConfig) {
             .configure(beacon::register_beacon_routes)
             .configure(node::register_node_routes)
             .configure(config::register_config_routes)
-            .configure(validator::register_validator_routes),
+            .configure(validator::register_validator_routes)
+            .configure(debug::register_debug_routes_v1),
     );
 }
 


### PR DESCRIPTION
### What are you trying to achieve?

Ref #221 

### How was it implemented/fixed?

- Refactored handlers for debug endpoints to be placed in the same file.
- `fork_choice/store.rs` has a notable change: As we should track the map between block(node) and its justified/finalized epoch, function signatures of `filter_block_tree` and `get_filter_block_tree` have changed to maintain a tuple as a value.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [xI have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
