### PR TITLE
feat: add voluntary exit command to cli

### DIFF
--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -3,13 +3,14 @@ pub mod beacon_node;
 pub mod constants;
 pub mod import_keystores;
 pub mod validator_node;
+pub mod voluntary_exit;
 
 use clap::{Parser, Subcommand};
 use ream_node::version::FULL_VERSION;
 
 use crate::cli::{
     account_manager::AccountManagerConfig, beacon_node::BeaconNodeConfig,
-    validator_node::ValidatorNodeConfig,
+    validator_node::ValidatorNodeConfig, voluntary_exit::VoluntaryExitConfig,
 };
 
 #[derive(Debug, Parser)]
@@ -32,6 +33,10 @@ pub enum Commands {
     /// Manage validator accounts
     #[command(name = "account_manager")]
     AccountManager(Box<AccountManagerConfig>),
+
+    /// Perform voluntary exit for a validator
+    #[command(name = "voluntary_exit")]
+    VoluntaryExit(Box<VoluntaryExitConfig>),
 }
 
 #[cfg(test)]

--- a/bin/ream/src/cli/voluntary_exit.rs
+++ b/bin/ream/src/cli/voluntary_exit.rs
@@ -1,0 +1,57 @@
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use clap::Parser;
+use ream_network_spec::{cli::network_parser, networks::NetworkSpec};
+use url::Url;
+
+use crate::cli::{
+    constants::{DEFAULT_BEACON_API_ENDPOINT, DEFAULT_NETWORK, DEFAULT_REQUEST_TIMEOUT},
+    validator_node::duration_parser,
+};
+
+#[derive(Debug, Parser)]
+pub struct VoluntaryExitConfig {
+    /// Verbosity level
+    #[arg(short, long, default_value_t = 3)]
+    pub verbosity: u8,
+
+    #[arg(long, help = "Set HTTP url of the beacon api endpoint", default_value = DEFAULT_BEACON_API_ENDPOINT)]
+    pub beacon_api_endpoint: Url,
+
+    #[arg(long, help = "Set HTTP request timeout for beacon api calls", default_value = DEFAULT_REQUEST_TIMEOUT, value_parser = duration_parser)]
+    pub request_timeout: Duration,
+
+    #[arg(
+        long,
+        help = "Choose mainnet, holesky, sepolia, hoodi, dev or provide a path to a YAML config file",
+        default_value = DEFAULT_NETWORK,
+        value_parser = network_parser
+    )]
+    pub network: Arc<NetworkSpec>,
+
+    #[arg(long, help = "The directory for importing keystores")]
+    pub import_keystores: PathBuf,
+
+    #[arg(
+        long,
+        group = "password_source",
+        help = "The plaintext password file to use for keystores"
+    )]
+    pub password_file: Option<PathBuf>,
+
+    #[arg(
+        long,
+        group = "password_source",
+        help = "The password to use for keystores. It's recommended to use password-file over this in order to prevent your keystore password from appearing in the shell history"
+    )]
+    pub password: Option<String>,
+
+    #[arg(long, help = "The validator index to exit")]
+    pub validator_index: u64,
+
+    #[arg(long, help = "The epoch for the voluntary exit")]
+    pub epoch: u64,
+
+    #[arg(long, help = "Wait until the validator has fully exited")]
+    pub wait: bool,
+}

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -7,6 +7,7 @@ use ream::cli::{
     beacon_node::BeaconNodeConfig,
     import_keystores::{load_keystore_directory, load_password_file, process_password},
     validator_node::ValidatorNodeConfig,
+    voluntary_exit::VoluntaryExitConfig,
 };
 use ream_checkpoint_sync::initialize_db_from_checkpoint;
 use ream_consensus::constants::set_genesis_validator_root;
@@ -21,7 +22,7 @@ use ream_storage::{
     tables::Table,
 };
 use ream_validator::validator::ValidatorService;
-use tracing::info;
+use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
 pub const APP_NAME: &str = "ream";
@@ -53,6 +54,9 @@ fn main() {
         }
         Commands::AccountManager(config) => {
             executor_clone.spawn(async move { run_account_manager(*config).await });
+        }
+        Commands::VoluntaryExit(config) => {
+            executor_clone.spawn(async move { run_voluntary_exit(*config, executor).await });
         }
     }
 
@@ -227,4 +231,55 @@ pub async fn run_account_manager(mut config: AccountManagerConfig) {
     ream_account_manager::generate_keys(&seed_phrase);
 
     info!("Account manager completed successfully");
+}
+
+/// Runs the voluntary exit process.
+///
+/// This function initializes the voluntary exit process by setting up the network specification,
+/// loading the keystores, creating a validator service, and processing the voluntary exit.
+pub async fn run_voluntary_exit(config: VoluntaryExitConfig, executor: ReamExecutor) {
+    info!("Starting voluntary exit process...");
+
+    set_network_spec(config.network.clone());
+
+    let password = process_password({
+        if let Some(ref password_file) = config.password_file {
+            load_password_file(password_file).expect("Failed to read password from password file")
+        } else if let Some(password_str) = config.password {
+            password_str
+        } else {
+            panic!("Expected either password or password-file to be set")
+        }
+    });
+
+    let key_stores = load_keystore_directory(&config.import_keystores)
+        .expect("Failed to load keystore directory")
+        .into_iter()
+        .map(|encrypted_keystore| {
+            encrypted_keystore
+                .decrypt(password.as_bytes())
+                .expect("Could not decrypt a keystore")
+        })
+        .collect::<Vec<_>>();
+
+    let validator_service = ValidatorService::new(
+        key_stores,
+        Default::default(), // Fee recipient not needed for voluntary exit
+        config.beacon_api_endpoint,
+        config.request_timeout,
+        executor,
+    )
+    .expect("Failed to create validator service");
+
+    match ream_validator::voluntary_exit::process_voluntary_exit(
+        validator_service,
+        config.validator_index,
+        config.epoch,
+        config.wait,
+    )
+    .await
+    {
+        Ok(()) => info!("Voluntary exit completed successfully"),
+        Err(err) => error!("Voluntary exit failed: {}", err),
+    }
 }

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -9,5 +9,6 @@
     - [`ream beacon_node`](./cli/ream/beacon_node.md)
     - [`ream validator_node`](./cli/ream/validator_node.md)
     - [`ream account_manager`](./cli/ream/account_manager.md)
+    - [`ream voluntary_exit`](./cli/ream/voluntary_exit.md)
 - [Changelog](./Changelog.md) <!-- CLI_REFERENCE END -->
 

--- a/book/cli/SUMMARY.md
+++ b/book/cli/SUMMARY.md
@@ -2,4 +2,5 @@
   - [`ream beacon_node`](./ream/beacon_node.md)
   - [`ream validator_node`](./ream/validator_node.md)
   - [`ream account_manager`](./ream/account_manager.md)
+  - [`ream voluntary_exit`](./ream/voluntary_exit.md)
 

--- a/book/cli/ream.md
+++ b/book/cli/ream.md
@@ -12,6 +12,7 @@ Commands:
   beacon_node      Start the beacon node
   validator_node   Start the validator node
   account_manager  Manage validator accounts
+  voluntary_exit   Perform voluntary exit for a validator
   help             Print this message or the help of the given subcommand(s)
 
 Options:

--- a/book/cli/ream/voluntary_exit.md
+++ b/book/cli/ream/voluntary_exit.md
@@ -1,0 +1,34 @@
+# ream voluntary_exit
+
+Perform voluntary exit for a validator
+
+```bash
+$ ream voluntary_exit --help
+```
+```txt
+Usage: ream voluntary_exit [OPTIONS] --import-keystores <IMPORT_KEYSTORES> --validator-index <VALIDATOR_INDEX> --epoch <EPOCH>
+
+Options:
+  -v, --verbosity <VERBOSITY>
+          Verbosity level [default: 3]
+      --beacon-api-endpoint <BEACON_API_ENDPOINT>
+          Set HTTP url of the beacon api endpoint [default: http://localhost:5052]
+      --request-timeout <REQUEST_TIMEOUT>
+          Set HTTP request timeout for beacon api calls [default: 60]
+      --network <NETWORK>
+          Choose mainnet, holesky, sepolia, hoodi, dev or provide a path to a YAML config file [default: mainnet]
+      --import-keystores <IMPORT_KEYSTORES>
+          The directory for importing keystores
+      --password-file <PASSWORD_FILE>
+          The plaintext password file to use for keystores
+      --password <PASSWORD>
+          The password to use for keystores. It's recommended to use password-file over this in order to prevent your keystore password from appearing in the shell history
+      --validator-index <VALIDATOR_INDEX>
+          The validator index to exit
+      --epoch <EPOCH>
+          The epoch for the voluntary exit
+      --wait
+          Wait until the validator has fully exited
+  -h, --help
+          Print help
+```

--- a/crates/common/validator/src/voluntary_exit.rs
+++ b/crates/common/validator/src/voluntary_exit.rs
@@ -1,4 +1,10 @@
+use std::time::Duration;
+
 use anyhow::anyhow;
+use ream_beacon_api_types::{
+    id::{ID, ValidatorID},
+    validator::ValidatorStatus,
+};
 use ream_bls::{PrivateKey, traits::Signable};
 use ream_consensus::{
     constants::DOMAIN_VOLUNTARY_EXIT,
@@ -6,6 +12,9 @@ use ream_consensus::{
     voluntary_exit::{SignedVoluntaryExit, VoluntaryExit},
 };
 use ream_network_spec::networks::network_spec;
+use tokio::time::sleep;
+
+use crate::validator::ValidatorService;
 
 pub fn sign_voluntary_exit(
     epoch: u64,
@@ -33,4 +42,55 @@ pub fn sign_voluntary_exit(
             .map_err(|err| anyhow!("Failed to sign voluntary exit: {err}"))?,
         message: voluntary_exit,
     })
+}
+
+pub async fn process_voluntary_exit(
+    validator_service: ValidatorService,
+    validator_index: u64,
+    epoch: u64,
+    wait_till_exit: bool,
+) -> anyhow::Result<()> {
+    let sync_status = validator_service
+        .beacon_api_client
+        .get_node_syncing_status()
+        .await?;
+
+    if sync_status.data.is_syncing {
+        return Err(anyhow!(
+            "Cannot process voluntary exit while node is syncing"
+        ));
+    }
+
+    validator_service
+        .submit_voluntary_exit(validator_index, epoch)
+        .await?;
+
+    if wait_till_exit {
+        loop {
+            match validator_service
+                .beacon_api_client
+                .get_state_validator(ID::Head, ValidatorID::Index(validator_index))
+                .await?
+                .data
+                .status
+            {
+                ValidatorStatus::ActiveExiting => {
+                    println!(
+                        "Voluntary exit has been published to beacon chain but validator has not yet exited."
+                    );
+                    sleep(Duration::from_secs(network_spec().seconds_per_slot)).await;
+                }
+                ValidatorStatus::ExitedSlashed | ValidatorStatus::ExitedUnslashed => {
+                    println!("Validator has successfully exited");
+                    break;
+                }
+                _ => {
+                    println!("Voluntary exit has not yet been published to beacon chain.");
+                    sleep(Duration::from_secs(network_spec().seconds_per_slot)).await;
+                }
+            }
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
### What are you trying to achieve?

Fixes: #617 

### How was it implemented/fixed?

I first created the function to process the voluntary exit. This function currently takes in a validator index for a validator for which to exit, however, I am finding it to be common practice to exit all validators in the provided keystore. I am going to do more research into this and decide if we want the ability to exit individual validators. 

I then created the CLI components for this and updated the docs.

This is what the voluntary exit command will look like:
```cmd
./ream voluntary_exit \
    --beacon-api-endpoint http://localhost:5052 \
    --import-keystores ./keystores \
    --password-file ./password.txt \
    --validator-index 12345 \
    --epoch 150000 \
    --wait
```

I find (existing implementations)(https://www.coincashew.com/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-iii-tips/voluntary-exiting-a-validator) to be follow a similar structure for exits.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
