### PR TITLE
perf: save 3 seconds by reusing the calculated state root in the checkpoint sync crate

### DIFF
--- a/crates/common/checkpoint_sync/src/lib.rs
+++ b/crates/common/checkpoint_sync/src/lib.rs
@@ -97,16 +97,13 @@ pub async fn initialize_db_from_checkpoint(
 
     info!("Fetching initial state...");
     let state = get_state(&checkpoint_sync_url, slot).await?;
-    info!(
-        "Downloaded state with root: {}. Slot: {}",
-        state.state_root(),
-        slot
-    );
+    let state_root = state.state_root();
+    info!("Downloaded state with root: {}. Slot: {}", state_root, slot);
 
     ensure!(block.message.slot == state.slot, "Slot mismatch");
 
-    ensure!(block.message.state_root == state.state_root());
-    let mut store = get_forkchoice_store(state.clone(), block.message, db)?;
+    ensure!(block.message.state_root == state_root);
+    let mut store = get_forkchoice_store(state.clone(), block.message, db, Some(state_root))?;
 
     let time = network_spec().min_genesis_time + SECONDS_PER_SLOT * (slot + 1);
     on_tick(&mut store, time)?;

--- a/crates/common/fork_choice/src/store.rs
+++ b/crates/common/fork_choice/src/store.rs
@@ -775,8 +775,11 @@ pub fn get_forkchoice_store(
     anchor_state: BeaconState,
     anchor_block: BeaconBlock,
     db: ReamDB,
+    anchor_state_root: Option<B256>,
 ) -> anyhow::Result<Store> {
-    ensure!(anchor_block.state_root == anchor_state.tree_hash_root());
+    let anchor_state_root = anchor_state_root.unwrap_or_else(|| anchor_state.state_root());
+    ensure!(anchor_block.state_root == anchor_state_root);
+
     let anchor_root = anchor_block.tree_hash_root();
     let anchor_epoch = anchor_state.get_current_epoch();
     let justified_checkpoint = Checkpoint {
@@ -814,7 +817,7 @@ pub fn get_forkchoice_store(
     db.beacon_state_provider()
         .insert(anchor_root, anchor_state.clone())?;
     db.state_root_index_provider()
-        .insert(anchor_state.tree_hash_root(), anchor_root)?;
+        .insert(anchor_state_root, anchor_root)?;
     db.slot_index_provider()
         .insert(anchor_state.slot, anchor_root)?;
     db.checkpoint_states_provider()

--- a/testing/ef-tests/src/macros/fork_choice.rs
+++ b/testing/ef-tests/src/macros/fork_choice.rs
@@ -127,7 +127,7 @@ macro_rules! test_fork_choice {
 
                         let ream_dir = setup_data_dir("ream", None, true).expect("Failed to create data dir");
                         let reamdb = ReamDB::new(ream_dir).expect("count not find reabdb");
-                        let mut store = get_forkchoice_store(anchor_state, anchor_block, reamdb)
+                        let mut store = get_forkchoice_store(anchor_state, anchor_block, reamdb, None)
                             .expect("get_forkchoice_store failed");
 
                         for step in steps {


### PR DESCRIPTION
### What are you trying to achieve?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

While a node is syncing from the checkpoint, the node calculates the state root of the checkpoint state repeatedly, which leads to bad UX/DX. In my current environment (M4 Macbook Air with WiFi connection of 200 mbps, syncing from Holesky), it takes about ~5 minutes for every state root calculation. 

### How was it implemented/fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

This PR caches the calculation result so it is used in the very near future.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
