### PR TITLE
feat: Implement /eth/v1/validator/prepare_beacon_proposer endpoint

### DIFF
--- a/crates/common/beacon_api_types/src/request.rs
+++ b/crates/common/beacon_api_types/src/request.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use ream_bls::BLSSignature;
 use serde::{Deserialize, Serialize};
 
@@ -8,6 +8,13 @@ use crate::{id::ValidatorID, validator::ValidatorStatus};
 pub struct ValidatorsPostRequest {
     pub ids: Option<Vec<ValidatorID>>,
     pub statuses: Option<Vec<ValidatorStatus>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PrepareBeaconProposerItem {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    pub fee_recipient: Address,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/common/operation_pool/src/lib.rs
+++ b/crates/common/operation_pool/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use parking_lot::RwLock;
 use ream_consensus::{
     bls_to_execution_change::SignedBLSToExecutionChange, electra::beacon_state::BeaconState,
@@ -12,6 +12,7 @@ use tree_hash::TreeHash;
 pub struct OperationPool {
     signed_voluntary_exits: RwLock<HashMap<u64, SignedVoluntaryExit>>,
     signed_bls_to_execution_changes: RwLock<HashMap<B256, SignedBLSToExecutionChange>>,
+    proposer_preparations: RwLock<HashMap<u64, Address>>,
 }
 
 impl OperationPool {
@@ -59,5 +60,45 @@ impl OperationPool {
 
     pub fn remove_signed_bls_to_execution_change(&self, root: B256) {
         self.signed_bls_to_execution_changes.write().remove(&root);
+    }
+
+    pub fn insert_proposer_preparation(&self, validator_index: u64, fee_recipient: Address) {
+        self.proposer_preparations
+            .write()
+            .insert(validator_index, fee_recipient);
+    }
+
+    pub fn get_proposer_preparation(&self, validator_index: u64) -> Option<Address> {
+        self.proposer_preparations.read().get(&validator_index).copied()
+    }
+
+    pub fn get_all_proposer_preparations(&self) -> HashMap<u64, Address> {
+        self.proposer_preparations.read().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proposer_preparation_operations() {
+        let operation_pool = OperationPool::default();
+        let fee_recipient1 = Address::from([0x11; 20]);
+        let fee_recipient2 = Address::from([0x22; 20]);
+
+        assert_eq!(operation_pool.get_proposer_preparation(1), None);
+
+        operation_pool.insert_proposer_preparation(1, fee_recipient1);
+        assert_eq!(operation_pool.get_proposer_preparation(1), Some(fee_recipient1));
+
+        operation_pool.insert_proposer_preparation(2, fee_recipient2);
+        let all_preparations = operation_pool.get_all_proposer_preparations();
+        assert_eq!(all_preparations.len(), 2);
+        assert_eq!(all_preparations.get(&1), Some(&fee_recipient1));
+        assert_eq!(all_preparations.get(&2), Some(&fee_recipient2));
+
+        operation_pool.insert_proposer_preparation(1, fee_recipient2);
+        assert_eq!(operation_pool.get_proposer_preparation(1), Some(fee_recipient2));
     }
 }

--- a/crates/rpc/src/handlers/mod.rs
+++ b/crates/rpc/src/handlers/mod.rs
@@ -7,6 +7,7 @@ pub mod header;
 pub mod light_client;
 pub mod peers;
 pub mod pool;
+pub mod prepare_beacon_proposer;
 pub mod state;
 pub mod syncing;
 pub mod validator;

--- a/crates/rpc/src/handlers/prepare_beacon_proposer.rs
+++ b/crates/rpc/src/handlers/prepare_beacon_proposer.rs
@@ -1,0 +1,106 @@
+use actix_web::{HttpResponse, Responder, post, web::{Data, Json}};
+use ream_beacon_api_types::{error::ApiError, request::PrepareBeaconProposerItem};
+use ream_operation_pool::OperationPool;
+
+#[post("/eth/v1/validator/prepare_beacon_proposer")]
+pub async fn prepare_beacon_proposer(
+    operation_pool: Data<OperationPool>,
+    prepare_beacon_proposer_items: Json<Vec<PrepareBeaconProposerItem>>,
+) -> Result<impl Responder, ApiError> {
+    let items = prepare_beacon_proposer_items.into_inner();
+
+    if items.is_empty() {
+        return Err(ApiError::BadRequest("Empty request body".to_string()));
+    }
+
+    for item in items {
+        operation_pool.insert_proposer_preparation(item.validator_index, item.fee_recipient);
+    }
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{http::StatusCode, test, App};
+    use alloy_primitives::Address;
+    use std::sync::Arc;
+
+    #[actix_web::test]
+    async fn test_prepare_beacon_proposer_success() {
+        let operation_pool = Arc::new(OperationPool::default());
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::from(operation_pool))
+                .service(prepare_beacon_proposer)
+        ).await;
+
+        let fee_recipient = Address::from([0x42; 20]);
+        let items = vec![
+            PrepareBeaconProposerItem {
+                validator_index: 1,
+                fee_recipient,
+            },
+            PrepareBeaconProposerItem {
+                validator_index: 2,
+                fee_recipient,
+            },
+        ];
+
+        let req = test::TestRequest::post()
+            .uri("/eth/v1/validator/prepare_beacon_proposer")
+            .set_json(&items)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[actix_web::test]
+    async fn test_prepare_beacon_proposer_empty_request() {
+        let operation_pool = Arc::new(OperationPool::default());
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::from(operation_pool))
+                .service(prepare_beacon_proposer)
+        ).await;
+
+        let items: Vec<PrepareBeaconProposerItem> = vec![];
+
+        let req = test::TestRequest::post()
+            .uri("/eth/v1/validator/prepare_beacon_proposer")
+            .set_json(&items)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn test_prepare_beacon_proposer_stores_data() {
+        let operation_pool = Arc::new(OperationPool::default());
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::from(operation_pool.clone()))
+                .service(prepare_beacon_proposer)
+        ).await;
+
+        let fee_recipient = Address::from([0x42; 20]);
+        let items = vec![PrepareBeaconProposerItem {
+            validator_index: 123,
+            fee_recipient,
+        }];
+
+        let req = test::TestRequest::post()
+            .uri("/eth/v1/validator/prepare_beacon_proposer")
+            .set_json(&items)
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let stored_fee_recipient = operation_pool.get_proposer_preparation(123);
+        assert_eq!(stored_fee_recipient, Some(fee_recipient));
+    }
+}

--- a/crates/rpc/src/routes/validator.rs
+++ b/crates/rpc/src/routes/validator.rs
@@ -1,8 +1,12 @@
 use actix_web::web::ServiceConfig;
 
-use crate::handlers::duties::{get_attester_duties, get_proposer_duties};
+use crate::handlers::{
+    duties::{get_attester_duties, get_proposer_duties},
+    prepare_beacon_proposer::prepare_beacon_proposer,
+};
 
 pub fn register_validator_routes(config: &mut ServiceConfig) {
     config.service(get_proposer_duties);
     config.service(get_attester_duties);
+    config.service(prepare_beacon_proposer);
 }


### PR DESCRIPTION
## Summary
- Implements the `/eth/v1/validator/prepare_beacon_proposer` endpoint as specified in issue #241
- Allows validators to register their fee recipient addresses with the beacon node
- Enables the beacon node to prepare blocks in advance with the correct fee recipient

## Changes
1. **Added request types**: Created `PrepareBeaconProposerItem` struct in `beacon_api_types` for the endpoint request body
2. **Extended OperationPool**: Added storage for proposer preparations (validator index → fee recipient mappings)
3. **Implemented handler**: Created the POST endpoint handler that validates requests and stores fee recipient mappings
4. **Added route registration**: Integrated the endpoint into the validator routes
5. **Added comprehensive tests**: Unit tests for both OperationPool storage and HTTP endpoint functionality

## Test plan
- [x] Unit tests for OperationPool proposer preparation methods
- [x] Unit tests for the HTTP endpoint (success, empty request, data storage verification)
- [x] All tests pass: `cargo test -p ream-operation-pool` and `cargo test -p ream-rpc prepare_beacon_proposer`
- [x] Code compiles without warnings: `cargo check --workspace`

Closes #241

🤖 Generated with [Claude Code](https://claude.ai/code)