### PR TITLE
feat: add forward syncer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,6 +2035,7 @@ dependencies = [
  "ream-consensus",
  "ream-fork-choice",
  "ream-merkle",
+ "ream-network-spec",
  "ream-storage",
  "rstest",
  "serde",
@@ -5304,6 +5305,7 @@ dependencies = [
 name = "ream-executor"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "futures",
  "tokio",
  "tracing",
@@ -5559,10 +5561,23 @@ dependencies = [
 name = "ream-syncer"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
+ "ethereum_ssz",
+ "futures",
+ "libp2p",
+ "libp2p-identity",
+ "libp2p-mplex",
  "ream-beacon-chain",
+ "ream-bls",
+ "ream-consensus",
+ "ream-executor",
+ "ream-network-spec",
  "ream-p2p",
+ "ream-storage",
  "tokio",
+ "tracing",
+ "tree_hash",
 ]
 
 [[package]]

--- a/crates/common/beacon_chain/src/beacon_chain.rs
+++ b/crates/common/beacon_chain/src/beacon_chain.rs
@@ -41,7 +41,13 @@ impl BeaconChain {
 
     pub async fn process_block(&self, signed_block: SignedBeaconBlock) -> anyhow::Result<()> {
         let mut store = self.store.lock().await;
-        on_block(&mut store, &signed_block, &self.execution_engine).await?;
+        on_block(
+            &mut store,
+            &signed_block,
+            &self.execution_engine,
+            signed_block.message.slot >= network_spec().slot_n_days_ago(17),
+        )
+        .await?;
         Ok(())
     }
 

--- a/crates/common/consensus/src/blob_sidecar.rs
+++ b/crates/common/consensus/src/blob_sidecar.rs
@@ -27,7 +27,7 @@ pub struct BlobSidecar {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Deserialize, Encode, Decode, Ord, PartialOrd, Default,
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Encode, Decode, Ord, PartialOrd, Default,
 )]
 pub struct BlobIdentifier {
     pub block_root: B256,

--- a/crates/common/consensus/src/electra/beacon_block.rs
+++ b/crates/common/consensus/src/electra/beacon_block.rs
@@ -108,7 +108,9 @@ impl SignedBeaconBlock {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Default,
+)]
 pub struct BeaconBlock {
     #[serde(with = "serde_utils::quoted_u64")]
     pub slot: u64,

--- a/crates/common/consensus/src/electra/beacon_block_body.rs
+++ b/crates/common/consensus/src/electra/beacon_block_body.rs
@@ -28,7 +28,9 @@ use crate::{
     voluntary_exit::SignedVoluntaryExit,
 };
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Default,
+)]
 pub struct BeaconBlockBody {
     pub randao_reveal: BLSSignature,
 

--- a/crates/common/consensus/src/electra/execution_payload.rs
+++ b/crates/common/consensus/src/electra/execution_payload.rs
@@ -23,7 +23,9 @@ const EMPTY_UNCLE_ROOT_HASH: B256 =
 
 pub type Transactions = VariableList<VariableList<u8, U1073741824>, U1048576>;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Default,
+)]
 pub struct ExecutionPayload {
     // Execution block header fields
     pub parent_hash: B256,

--- a/crates/common/consensus/src/eth_1_data.rs
+++ b/crates/common/consensus/src/eth_1_data.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Hash)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Hash, Default,
+)]
 pub struct Eth1Data {
     pub deposit_root: B256,
     #[serde(with = "serde_utils::quoted_u64")]

--- a/crates/common/consensus/src/execution_engine/rpc_types/get_blobs.rs
+++ b/crates/common/consensus/src/execution_engine/rpc_types/get_blobs.rs
@@ -3,7 +3,10 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, serde_utils::hex_fixed_vec, typenum::U131072};
 use tree_hash_derive::TreeHash;
 
-use crate::{constants::BYTES_PER_BLOB, polynomial_commitments::kzg_proof::KZGProof};
+use crate::{
+    blob_sidecar::BlobSidecar, constants::BYTES_PER_BLOB,
+    polynomial_commitments::kzg_proof::KZGProof,
+};
 
 #[derive(
     Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Decode, Encode, TreeHash, Default,
@@ -27,4 +30,13 @@ impl Blob {
 pub struct BlobAndProofV1 {
     pub blob: Blob,
     pub proof: KZGProof,
+}
+
+impl From<BlobSidecar> for BlobAndProofV1 {
+    fn from(blob_sidecar: BlobSidecar) -> Self {
+        BlobAndProofV1 {
+            blob: blob_sidecar.blob,
+            proof: blob_sidecar.kzg_proof,
+        }
+    }
 }

--- a/crates/common/consensus/src/execution_requests.rs
+++ b/crates/common/consensus/src/execution_requests.rs
@@ -11,7 +11,9 @@ use crate::{
     withdrawal_request::WithdrawalRequest,
 };
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Default,
+)]
 pub struct ExecutionRequests {
     pub deposits: VariableList<DepositRequest, U8192>,
     pub withdrawals: VariableList<WithdrawalRequest, U16>,

--- a/crates/common/consensus/src/sync_aggregate.rs
+++ b/crates/common/consensus/src/sync_aggregate.rs
@@ -4,7 +4,9 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{BitVector, typenum::U512};
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Default,
+)]
 pub struct SyncAggregate {
     pub sync_committee_bits: BitVector<U512>,
     pub sync_committee_signature: BLSSignature,

--- a/crates/common/executor/Cargo.toml
+++ b/crates/common/executor/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 futures.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/networking/p2p/src/channel.rs
+++ b/crates/networking/p2p/src/channel.rs
@@ -1,4 +1,6 @@
+use alloy_primitives::B256;
 use libp2p::{PeerId, swarm::ConnectionId};
+use ream_consensus::blob_sidecar::BlobIdentifier;
 use tokio::sync::mpsc;
 
 use crate::req_resp::{
@@ -25,6 +27,16 @@ pub enum P2PRequest {
         peer_id: PeerId,
         start: u64,
         count: u64,
+        callback: mpsc::Sender<anyhow::Result<P2PCallbackResponse>>,
+    },
+    BlockRoots {
+        peer_id: PeerId,
+        roots: Vec<B256>,
+        callback: mpsc::Sender<anyhow::Result<P2PCallbackResponse>>,
+    },
+    BlobIdentifiers {
+        peer_id: PeerId,
+        blob_identifiers: Vec<BlobIdentifier>,
         callback: mpsc::Sender<anyhow::Result<P2PCallbackResponse>>,
     },
 }

--- a/crates/networking/p2p/src/network_state.rs
+++ b/crates/networking/p2p/src/network_state.rs
@@ -51,4 +51,14 @@ impl NetworkState {
             .map_err(|err| anyhow!("Failed to write meta data to disk: {err:?}"))?;
         Ok(())
     }
+
+    /// Gets a vector of all connected peers.
+    pub fn connected_peers(&self) -> Vec<CachedPeer> {
+        self.peer_table
+            .read()
+            .values()
+            .filter(|peer| peer.state == ConnectionState::Connected)
+            .cloned()
+            .collect()
+    }
 }

--- a/crates/networking/p2p/src/req_resp/handler.rs
+++ b/crates/networking/p2p/src/req_resp/handler.rs
@@ -523,7 +523,6 @@ async fn send_response_message_to_inbound_stream(
 
     let is_error = matches!(response_message, RespMessage::Error(_));
     let result = inbound_stream.send(response_message).await;
-
     if is_error || result.is_err() {
         inbound_stream.close().await?;
     }

--- a/crates/networking/p2p/src/req_resp/messages/beacon_blocks.rs
+++ b/crates/networking/p2p/src/req_resp/messages/beacon_blocks.rs
@@ -25,3 +25,12 @@ impl BeaconBlocksByRangeV2Request {
 pub struct BeaconBlocksByRootV2Request {
     pub inner: VariableList<B256, U1024>,
 }
+
+/// Will panic if over 1024 roots are requested
+impl BeaconBlocksByRootV2Request {
+    pub fn new(roots: Vec<B256>) -> Self {
+        Self {
+            inner: VariableList::new(roots).expect("Too many roots were requested"),
+        }
+    }
+}

--- a/crates/networking/p2p/src/req_resp/messages/blob_sidecars.rs
+++ b/crates/networking/p2p/src/req_resp/messages/blob_sidecars.rs
@@ -27,3 +27,12 @@ pub struct BlobSidecarsByRangeV1Request {
 pub struct BlobSidecarsByRootV1Request {
     pub inner: VariableList<BlobIdentifier, MaxRequestBlobSidecarsElectra>,
 }
+
+impl BlobSidecarsByRootV1Request {
+    pub fn new(blob_identifiers: Vec<BlobIdentifier>) -> Self {
+        Self {
+            inner: VariableList::new(blob_identifiers)
+                .expect("Too many blob identifiers were requested"),
+        }
+    }
+}

--- a/crates/networking/syncer/Cargo.toml
+++ b/crates/networking/syncer/Cargo.toml
@@ -10,9 +10,22 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+alloy-primitives.workspace = true
 anyhow.workspace = true
+ethereum_ssz.workspace = true
+futures.workspace = true
+libp2p.workspace = true
+libp2p-identity.workspace = true
+libp2p-mplex.workspace = true
+ream-beacon-chain.workspace = true
+ream-bls.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+tree_hash.workspace = true
 
 # ream dependencies
-ream-beacon-chain.workspace = true
+ream-consensus.workspace = true
+ream-executor.workspace = true
+ream-network-spec.workspace = true
 ream-p2p.workspace = true
+ream-storage.workspace = true

--- a/crates/networking/syncer/src/block_range/block_cache.rs
+++ b/crates/networking/syncer/src/block_range/block_cache.rs
@@ -1,0 +1,327 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+};
+
+use alloy_primitives::B256;
+use anyhow::{bail, ensure};
+use ream_consensus::{
+    blob_sidecar::{BlobIdentifier, BlobSidecar},
+    electra::beacon_block::SignedBeaconBlock,
+};
+use ream_network_spec::networks::network_spec;
+use ssz::Encode;
+use tree_hash::TreeHash;
+
+use super::{MAX_BLOCKS_PER_REQUEST, peer_range_downloader::Range};
+
+/// The size of blobs is 32 * 4096 bytes, which is 131072 bytes or 128 KiB.
+const BLOB_SIZE: u64 = 131_072;
+/// Assume a default average block size if we have no blocks yet
+const DEFAULT_BLOCK_SIZE: u64 = 86_876;
+pub const HUNDRED_MEGA_BYTES: u64 = 100 * 1024 * 1024;
+
+pub struct BlockAndBlobBundle {
+    pub block: SignedBeaconBlock,
+    pub blobs: HashMap<BlobIdentifier, BlobSidecar>,
+}
+
+impl BlockAndBlobBundle {
+    pub fn new(block: SignedBeaconBlock) -> Self {
+        Self {
+            block,
+            blobs: HashMap::new(),
+        }
+    }
+}
+
+pub struct BlockCache {
+    blocks_and_blobs: HashMap<B256, BlockAndBlobBundle>,
+    current_cache_size: u64,
+    target_size: u64,
+    initial_parent_root: B256,
+    block_ranges_to_retry: Vec<Range>,
+    next_start_slot: u64,
+    block_roots_in_progress: HashSet<B256>,
+    blob_identifiers_in_progress: HashSet<BlobIdentifier>,
+}
+
+impl BlockCache {
+    pub fn new(target_size: u64, initial_parent_root: B256, next_start_slot: u64) -> Self {
+        Self {
+            blocks_and_blobs: HashMap::new(),
+            current_cache_size: 0,
+            target_size,
+            initial_parent_root,
+            block_ranges_to_retry: vec![],
+            next_start_slot,
+            block_roots_in_progress: HashSet::new(),
+            blob_identifiers_in_progress: HashSet::new(),
+        }
+    }
+
+    pub fn add_blocks(&mut self, blocks: Vec<SignedBeaconBlock>) -> anyhow::Result<()> {
+        // Ensure that all blocks form a chain
+        for (index, block) in blocks.iter().enumerate().rev() {
+            if index > 0 {
+                ensure!(
+                    block.message.parent_root == blocks[index - 1].message.tree_hash_root(),
+                    "Block at index {index} has a parent root that does not match the previous block's tree hash root",
+                );
+            }
+        }
+
+        for block in blocks {
+            self.current_cache_size += block.as_ssz_bytes().len() as u64;
+            self.blocks_and_blobs.insert(
+                block.message.tree_hash_root(),
+                BlockAndBlobBundle::new(block),
+            );
+        }
+
+        Ok(())
+    }
+
+    pub fn add_blobs(&mut self, blobs: Vec<BlobSidecar>) -> anyhow::Result<()> {
+        for blob_sidecar in blobs {
+            let block_root = blob_sidecar.signed_block_header.message.tree_hash_root();
+
+            if let Some(bundle) = self.blocks_and_blobs.get_mut(&block_root) {
+                bundle.blobs.insert(
+                    BlobIdentifier {
+                        block_root,
+                        index: blob_sidecar.index,
+                    },
+                    blob_sidecar,
+                );
+            } else {
+                bail!("Block root {block_root} not found in cache, this should be impossible");
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn extend_block_roots_in_progress(&mut self, block_roots: &[B256]) {
+        self.block_roots_in_progress.extend(block_roots);
+    }
+
+    pub fn remove_block_roots_in_progress(&mut self, block_roots: &[B256]) {
+        for root in block_roots {
+            self.block_roots_in_progress.remove(root);
+        }
+    }
+
+    pub fn extend_blob_identifiers_in_progress(&mut self, blob_identifiers: &[BlobIdentifier]) {
+        self.blob_identifiers_in_progress.extend(blob_identifiers);
+    }
+
+    pub fn remove_blob_identifiers_in_progress(&mut self, blob_identifiers: &[BlobIdentifier]) {
+        for identifier in blob_identifiers {
+            self.blob_identifiers_in_progress.remove(identifier);
+        }
+    }
+
+    pub fn block_count(&self) -> u64 {
+        self.blocks_and_blobs.len() as u64
+    }
+
+    pub fn blob_count(&self) -> u64 {
+        self.blocks_and_blobs
+            .values()
+            .map(|bundle| bundle.block.message.body.blob_kzg_commitments.len() as u64)
+            .sum()
+    }
+
+    pub fn downloaded_blob_count(&self) -> u64 {
+        self.blocks_and_blobs
+            .values()
+            .map(|bundle| bundle.blobs.len() as u64)
+            .sum()
+    }
+
+    pub fn estimated_blocks_to_fetch(&self) -> u64 {
+        if self.blocks_and_blobs.is_empty() || self.current_cache_size == 0 {
+            return self.target_size.div_ceil(DEFAULT_BLOCK_SIZE);
+        }
+
+        let number_of_blocks = self.blocks_and_blobs.len() as u64;
+        let average_block_size = self.current_cache_size / number_of_blocks;
+        let total_blobs: u64 = self.blob_count();
+        let average_blobs_per_block = total_blobs / number_of_blocks;
+        let average_total_size_per_block = average_block_size + average_blobs_per_block * BLOB_SIZE;
+        let total_cache_size = self.current_cache_size + total_blobs * BLOB_SIZE;
+        let remaining_size = self.target_size.saturating_sub(total_cache_size);
+
+        remaining_size.div_ceil(average_total_size_per_block)
+    }
+
+    pub fn push_retry_range(&mut self, range: Range) {
+        self.block_ranges_to_retry.push(range);
+    }
+
+    pub fn data_to_fetch(&mut self, finalized_slot: u64) -> DataToFetch {
+        match self.block_ranges_to_retry.pop() {
+            Some(range) => return DataToFetch::BlockRange(range),
+            None => {
+                let estimated_blocks_to_fetch = self.estimated_blocks_to_fetch();
+                if estimated_blocks_to_fetch > 0 && self.next_start_slot <= finalized_slot {
+                    let blocks_to_fill = estimated_blocks_to_fetch
+                        .min(MAX_BLOCKS_PER_REQUEST.min(finalized_slot - self.next_start_slot));
+                    self.next_start_slot += blocks_to_fill;
+                    return DataToFetch::BlockRange(Range::new(
+                        self.next_start_slot,
+                        blocks_to_fill,
+                    ));
+                }
+            }
+        }
+
+        let mut block_roots_left_to_fetch = self.get_missing_block_roots();
+        let missing_block_roots_len = block_roots_left_to_fetch.len();
+        block_roots_left_to_fetch.retain(|root| !self.block_roots_in_progress.contains(root));
+
+        let mut blob_identifiers_left_to_fetch = self.get_missing_blob_identifiers();
+        let missing_blob_identifiers_len = blob_identifiers_left_to_fetch.len();
+        blob_identifiers_left_to_fetch
+            .retain(|blob_identifier| !self.blob_identifiers_in_progress.contains(blob_identifier));
+
+        if !block_roots_left_to_fetch.is_empty() {
+            return DataToFetch::MissingBlockRoots(block_roots_left_to_fetch);
+        }
+
+        if !blob_identifiers_left_to_fetch.is_empty() {
+            return DataToFetch::MissingBlobIdentifiers(blob_identifiers_left_to_fetch);
+        }
+
+        if missing_block_roots_len > 0 || missing_blob_identifiers_len > 0 {
+            return DataToFetch::DownloadsInProgress;
+        }
+
+        DataToFetch::Finished
+    }
+
+    /// Return the blocks in sorted order to be processed.
+    pub fn get_blocks_and_blobs(mut self) -> anyhow::Result<Vec<BlockAndBlobBundle>> {
+        let missing_block_roots = self.get_missing_block_roots();
+        if !missing_block_roots.is_empty() {
+            bail!("Missing block roots: {}", missing_block_roots.len());
+        } else {
+            let mut blocks_and_blobs = self
+                .blocks_and_blobs
+                .drain()
+                .map(|(_, block)| block)
+                .collect::<Vec<_>>();
+            blocks_and_blobs.sort_by_key(|block| block.block.message.slot);
+            Ok(blocks_and_blobs)
+        }
+    }
+
+    fn get_missing_block_roots(&self) -> Vec<B256> {
+        let mut missing_roots = Vec::new();
+        for block in self.blocks_and_blobs.values() {
+            if !self
+                .blocks_and_blobs
+                .contains_key(&block.block.message.parent_root)
+                && block.block.message.parent_root != self.initial_parent_root
+            {
+                missing_roots.push(block.block.message.parent_root);
+            }
+        }
+        missing_roots
+    }
+
+    fn get_missing_blob_identifiers(&self) -> Vec<BlobIdentifier> {
+        let slot_17_days_ago = network_spec().slot_n_days_ago(17);
+        let mut missing_roots = Vec::new();
+        for block in self.blocks_and_blobs.values() {
+            if block.block.message.slot < slot_17_days_ago {
+                continue;
+            }
+
+            let block_root = block.block.message.tree_hash_root();
+            for index in 0..block.block.message.body.blob_kzg_commitments.len() {
+                let blob_identifier = BlobIdentifier {
+                    block_root,
+                    index: index as u64,
+                };
+                if block.blobs.contains_key(&blob_identifier) {
+                    continue;
+                }
+                missing_roots.push(blob_identifier);
+            }
+        }
+        missing_roots
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataToFetch {
+    BlockRange(Range),
+    MissingBlockRoots(Vec<B256>),
+    MissingBlobIdentifiers(Vec<BlobIdentifier>),
+    DownloadsInProgress,
+    Finished,
+}
+
+impl Display for DataToFetch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataToFetch::BlockRange(range) => write!(f, "BlockRange({range:?})"),
+            DataToFetch::MissingBlockRoots(roots) => {
+                write!(f, "MissingBlockRoots({})", roots.len())
+            }
+            DataToFetch::MissingBlobIdentifiers(identifiers) => {
+                write!(f, "MissingBlobIdentifiers({})", identifiers.len())
+            }
+            DataToFetch::DownloadsInProgress => write!(f, "DownloadsInProgress"),
+            DataToFetch::Finished => write!(f, "Finished"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use ream_bls::BLSSignature;
+    use ream_consensus::electra::beacon_block::BeaconBlock;
+
+    use super::*;
+
+    #[test]
+    fn test_estimated_blocks_to_fetch() {
+        let block_count = 2;
+        let mut blocks = vec![];
+        let mut current_size = 0;
+        let mut parent_root = B256::ZERO;
+        for i in 1..=2 {
+            let block = SignedBeaconBlock {
+                message: BeaconBlock {
+                    slot: i,
+                    parent_root,
+                    ..Default::default()
+                },
+                signature: BLSSignature::infinity(),
+            };
+            parent_root = block.message.tree_hash_root();
+            current_size += block.as_ssz_bytes().len() as u64;
+            blocks.push(block);
+        }
+
+        let mut cache = BlockCache::new(current_size / block_count * 10, B256::ZERO, 1);
+
+        cache.add_blocks(blocks).unwrap();
+
+        assert_eq!(cache.current_cache_size, current_size);
+        assert_eq!(cache.estimated_blocks_to_fetch(), 8);
+    }
+
+    #[test]
+    fn test_empty_cache_estimated_blocks() {
+        let cache = BlockCache::new(HUNDRED_MEGA_BYTES, B256::ZERO, 1);
+        assert_eq!(
+            cache.estimated_blocks_to_fetch(),
+            HUNDRED_MEGA_BYTES.div_ceil(DEFAULT_BLOCK_SIZE)
+        );
+    }
+}

--- a/crates/networking/syncer/src/block_range/mod.rs
+++ b/crates/networking/syncer/src/block_range/mod.rs
@@ -1,19 +1,423 @@
-use std::sync::Arc;
+mod block_cache;
+mod peer_manager;
+mod peer_range_downloader;
 
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use alloy_primitives::B256;
+use anyhow::{anyhow, bail};
+use block_cache::{BlockAndBlobBundle, BlockCache, DataToFetch, HUNDRED_MEGA_BYTES};
+use futures::task::noop_waker;
+use libp2p::PeerId;
+use peer_manager::PeerManager;
+use peer_range_downloader::{PeerBlobIdentifierDownloader, PeerRootsDownloader};
 use ream_beacon_chain::beacon_chain::BeaconChain;
-use ream_p2p::channel::P2PMessage;
-use tokio::sync::mpsc::UnboundedSender;
+use ream_consensus::{
+    blob_sidecar::{BlobIdentifier, BlobSidecar},
+    electra::beacon_block::SignedBeaconBlock,
+};
+use ream_executor::ReamExecutor;
+use ream_p2p::{
+    channel::P2PMessage, network_state::NetworkState, req_resp::MAX_CONCURRENT_REQUESTS,
+};
+use ream_storage::tables::Table;
+use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle, time::sleep};
+use tracing::{info, warn};
+
+use crate::block_range::peer_range_downloader::{PeerRangeDownloader, Range};
+
+const MAX_BLOBS_PER_REQUEST: usize = 6;
+const MAX_BLOCKS_PER_REQUEST: u64 = 30;
+const SLEEP_DURATION: Duration = Duration::from_secs(5);
 
 pub struct BlockRangeSyncer {
     pub beacon_chain: Arc<BeaconChain>,
+    pub peer_manager: PeerManager,
     pub p2p_sender: UnboundedSender<P2PMessage>,
+    pub executor: ReamExecutor,
 }
 
 impl BlockRangeSyncer {
-    pub fn new(beacon_chain: Arc<BeaconChain>, p2p_sender: UnboundedSender<P2PMessage>) -> Self {
+    pub fn new(
+        beacon_chain: Arc<BeaconChain>,
+        p2p_sender: UnboundedSender<P2PMessage>,
+        network_state: Arc<NetworkState>,
+        executor: ReamExecutor,
+    ) -> Self {
         Self {
             beacon_chain,
             p2p_sender,
+            peer_manager: PeerManager::new(network_state),
+            executor,
         }
     }
+
+    pub async fn is_synced_to_finalized_slot(&self) -> bool {
+        let finalized_slot = self.peer_manager.finalized_slot();
+        let latest_synced_slot = self
+            .beacon_chain
+            .store
+            .lock()
+            .await
+            .db
+            .slot_index_provider()
+            .get_highest_slot()
+            .unwrap_or_default()
+            .unwrap_or(0);
+
+        finalized_slot <= Some(latest_synced_slot)
+    }
+
+    pub fn start(mut self) -> JoinHandle<anyhow::Result<anyhow::Result<BlockRangeSyncer>>> {
+        let executor = self.executor.clone();
+        executor.spawn(async move {
+            let Some(latest_synced_root) = self
+                .beacon_chain
+                .store
+                .lock()
+                .await
+                .db
+                .slot_index_provider()
+                .get_highest_root()
+                .map_err(|err| anyhow!("Failed to get highest root: {err}"))?
+            else {
+                bail!("No synced root found in the database");
+            };
+
+            let Some(latest_synced_slot) = self
+                .beacon_chain
+                .store
+                .lock()
+                .await
+                .db
+                .slot_index_provider()
+                .get_highest_slot()
+                .map_err(|err| anyhow!("Failed to get highest slot: {err}"))?
+            else {
+                bail!("No synced slot found in the database");
+            };
+
+            // phase 1: download majority of blocks from ranges
+            let mut block_cache =
+                BlockCache::new(HUNDRED_MEGA_BYTES, latest_synced_root, latest_synced_slot);
+            let mut task_handles = vec![];
+            loop {
+                poll_ready_tasks(&mut task_handles, &mut block_cache, &mut self.peer_manager)?;
+
+                let finalized_slot = match self.peer_manager.finalized_slot() {
+                    Some(finalized_slot) => finalized_slot,
+                    None => {
+                        warn!("No peers available to determine finalized slot, retrying...");
+                        sleep(SLEEP_DURATION).await;
+                        self.peer_manager.update_peer_set();
+                        continue;
+                    }
+                };
+
+                let data_to_fetch = block_cache.data_to_fetch(finalized_slot);
+                info!(
+                    "Forward sync status: Downloaded Blocks {}, Downloaded Blobs {}/{}, Stage {data_to_fetch}",
+                    block_cache.block_count(),
+                    block_cache.downloaded_blob_count(),
+                    block_cache.blob_count(),
+                );
+
+                match data_to_fetch {
+                    DataToFetch::BlockRange(range) => {
+                        let Some(peer) = self.peer_manager.fetch_idle_peer() else {
+                            self.peer_manager.update_peer_set();
+                            info!("No idle peers available for block range sync.");
+                            sleep(SLEEP_DURATION).await;
+                            continue;
+                        };
+
+                        task_handles.push(DownloadTask::new_block_range(
+                            PeerRangeDownloader::start(
+                                peer.peer_id,
+                                self.p2p_sender.clone(),
+                                self.executor.clone(),
+                                range,
+                            ),
+                            range,
+                            peer.peer_id,
+                        ));
+                    }
+                    DataToFetch::MissingBlockRoots(block_roots) => {
+                        for block_roots_chunk in block_roots.chunks(MAX_CONCURRENT_REQUESTS) {
+                            let Some(peer) = self.peer_manager.fetch_idle_peer() else {
+                                self.peer_manager.update_peer_set();
+                                info!("No idle peers available for block roots sync.");
+                                sleep(SLEEP_DURATION).await;
+                                break;
+                            };
+                            block_cache.extend_block_roots_in_progress(block_roots_chunk);
+
+                            task_handles.push(DownloadTask::new_block_roots(
+                                PeerRootsDownloader::start(
+                                    peer.peer_id,
+                                    self.p2p_sender.clone(),
+                                    self.executor.clone(),
+                                    block_roots_chunk.to_vec(),
+                                ),
+                                block_roots_chunk.to_vec(),
+                                peer.peer_id,
+                            ));
+                        }
+                    }
+                    DataToFetch::MissingBlobIdentifiers(blob_identifiers) => {
+                        for blob_identifiers_chunk in blob_identifiers.chunks(MAX_BLOBS_PER_REQUEST) {
+                            let Some(peer) = self.peer_manager.fetch_idle_peer() else {
+                                self.peer_manager.update_peer_set();
+                                info!("No idle peers available for blob sync.");
+                                sleep(SLEEP_DURATION).await;
+                                break;
+                            };
+
+                            block_cache.extend_blob_identifiers_in_progress(blob_identifiers_chunk);
+
+                            task_handles.push(DownloadTask::new_blob_identifiers(
+                                PeerBlobIdentifierDownloader::start(
+                                    peer.peer_id,
+                                    self.p2p_sender.clone(),
+                                    self.executor.clone(),
+                                    blob_identifiers_chunk.to_vec(),
+                                ),
+                                blob_identifiers_chunk.to_vec(),
+                                peer.peer_id,
+                            ));
+                        }
+                    }
+                    DataToFetch::DownloadsInProgress => {
+                        sleep(Duration::from_secs(10)).await;
+                    }
+                    DataToFetch::Finished => break,
+                }
+            }
+
+            info!("Block range sync completed a segment successfully with {} blocks and {} blobs.",
+                block_cache.block_count(),
+                block_cache.downloaded_blob_count(),
+            );
+
+            // execute all the blocks downloaded
+            for BlockAndBlobBundle { block, blobs } in block_cache.get_blocks_and_blobs()?  {
+                for (blob_identifier, blob_sidecar) in blobs {
+                    if let Err(err) = self
+                        .beacon_chain
+                        .store
+                        .lock()
+                        .await
+                        .db
+                        .blobs_and_proofs_provider()
+                        .insert(blob_identifier, blob_sidecar.into())
+                    {
+                        warn!("Failed to insert blob into database: {err}");
+                    }
+                }
+
+                self.beacon_chain.process_block(block).await?;
+            }
+
+            Ok(self)
+        })
+    }
+}
+
+pub enum DownloadTask {
+    BlockRange {
+        handle: JoinHandle<anyhow::Result<Vec<SignedBeaconBlock>>>,
+        range: Range,
+        peer_id: PeerId,
+    },
+    BlockRoots {
+        handle: JoinHandle<anyhow::Result<Vec<SignedBeaconBlock>>>,
+        roots: Vec<B256>,
+        peer_id: PeerId,
+    },
+    BlobIdentifiers {
+        handle: JoinHandle<anyhow::Result<Vec<BlobSidecar>>>,
+        blob_identifiers: Vec<BlobIdentifier>,
+        peer_id: PeerId,
+    },
+}
+
+impl DownloadTask {
+    pub fn new_block_range(
+        handle: JoinHandle<anyhow::Result<Vec<SignedBeaconBlock>>>,
+        range: Range,
+        peer_id: PeerId,
+    ) -> Self {
+        DownloadTask::BlockRange {
+            handle,
+            range,
+            peer_id,
+        }
+    }
+
+    pub fn new_block_roots(
+        handle: JoinHandle<anyhow::Result<Vec<SignedBeaconBlock>>>,
+        roots: Vec<B256>,
+        peer_id: PeerId,
+    ) -> Self {
+        DownloadTask::BlockRoots {
+            handle,
+            roots,
+            peer_id,
+        }
+    }
+
+    pub fn new_blob_identifiers(
+        handle: JoinHandle<anyhow::Result<Vec<BlobSidecar>>>,
+        blob_identifiers: Vec<BlobIdentifier>,
+        peer_id: PeerId,
+    ) -> Self {
+        DownloadTask::BlobIdentifiers {
+            handle,
+            blob_identifiers,
+            peer_id,
+        }
+    }
+}
+
+fn poll_ready_tasks(
+    tasks: &mut Vec<DownloadTask>,
+    block_cache: &mut BlockCache,
+    peer_manager: &mut PeerManager,
+) -> anyhow::Result<()> {
+    let waker = noop_waker();
+    let mut context = Context::from_waker(&waker);
+    let mut indexes_to_remove = vec![];
+
+    for index in (0..tasks.len()).rev() {
+        let Some(task) = tasks.get_mut(index) else {
+            bail!("Task handle not found at index {index}");
+        };
+
+        match task {
+            DownloadTask::BlockRange {
+                handle,
+                range,
+                peer_id,
+            } => {
+                let pinned = Pin::new(handle);
+
+                match pinned.poll(&mut context) {
+                    Poll::Ready(Ok(blocks_result)) => {
+                        indexes_to_remove.push(index);
+                        peer_manager.mark_peer_as_idle(peer_id);
+                        let blocks = match blocks_result {
+                            Ok(blocks) => blocks,
+                            Err(err) => {
+                                warn!("Failed to fetch blocks from peer: {err:?}");
+                                block_cache.push_retry_range(*range);
+                                continue;
+                            }
+                        };
+
+                        if blocks.is_empty() {
+                            warn!("Received empty block range from peer: {peer_id}");
+                            block_cache.push_retry_range(*range);
+                            peer_manager.ban_peer(peer_id);
+                            continue;
+                        }
+
+                        if let Err(err) = block_cache.add_blocks(blocks) {
+                            warn!("Failed to add downloaded blocks to cache: {err:?}");
+                            block_cache.push_retry_range(*range);
+                        }
+                    }
+                    Poll::Ready(Err(err)) => {
+                        warn!("Forward fill task failed: {err}");
+                        indexes_to_remove.push(index);
+                    }
+                    Poll::Pending => {}
+                }
+            }
+            DownloadTask::BlockRoots {
+                handle,
+                roots,
+                peer_id,
+            } => {
+                let pinned = Pin::new(handle);
+
+                match pinned.poll(&mut context) {
+                    Poll::Ready(Ok(blocks_result)) => {
+                        indexes_to_remove.push(index);
+                        block_cache.remove_block_roots_in_progress(roots);
+                        peer_manager.mark_peer_as_idle(peer_id);
+                        let blocks = match blocks_result {
+                            Ok(blocks) => blocks,
+                            Err(err) => {
+                                warn!("Failed to fetch blocks from peer: {err:?}");
+                                continue;
+                            }
+                        };
+
+                        if blocks.is_empty() {
+                            warn!("Received empty block roots from peer: {peer_id}");
+                            peer_manager.ban_peer(peer_id);
+                            continue;
+                        }
+
+                        if let Err(err) = block_cache.add_blocks(blocks) {
+                            warn!("Failed to add downloaded blocks to cache: {err:?}");
+                        }
+                    }
+                    Poll::Ready(Err(err)) => {
+                        warn!("Forward fill task failed: {err}");
+                        indexes_to_remove.push(index);
+                    }
+                    Poll::Pending => {}
+                }
+            }
+            DownloadTask::BlobIdentifiers {
+                handle,
+                blob_identifiers,
+                peer_id,
+            } => {
+                let pinned = Pin::new(handle);
+
+                match pinned.poll(&mut context) {
+                    Poll::Ready(Ok(blob_sidecars_result)) => {
+                        indexes_to_remove.push(index);
+                        block_cache.remove_blob_identifiers_in_progress(blob_identifiers);
+                        peer_manager.mark_peer_as_idle(peer_id);
+                        let blob_sidecars = match blob_sidecars_result {
+                            Ok(blob_sidecars) => blob_sidecars,
+                            Err(err) => {
+                                warn!("Failed to fetch blobs from peer: {err:?}");
+                                continue;
+                            }
+                        };
+
+                        if blob_sidecars.is_empty() {
+                            warn!("Received empty blob identifiers from peer: {peer_id}");
+                            peer_manager.ban_peer(peer_id);
+                            continue;
+                        }
+
+                        if let Err(err) = block_cache.add_blobs(blob_sidecars) {
+                            warn!("Failed to add downloaded blobs to cache: {err:?}");
+                        }
+                    }
+                    Poll::Ready(Err(err)) => {
+                        warn!("Forward fill task failed: {err}");
+                        indexes_to_remove.push(index);
+                    }
+                    Poll::Pending => {}
+                }
+            }
+        }
+    }
+
+    for index in indexes_to_remove {
+        tasks.remove(index);
+    }
+
+    Ok(())
 }

--- a/crates/networking/syncer/src/block_range/peer_manager.rs
+++ b/crates/networking/syncer/src/block_range/peer_manager.rs
@@ -1,0 +1,99 @@
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+use libp2p::PeerId;
+use ream_consensus::constants::SLOTS_PER_EPOCH;
+use ream_p2p::{network_state::NetworkState, peer::CachedPeer};
+use tracing::warn;
+
+#[derive(Debug, Clone)]
+pub enum PeerStatus {
+    Idle,
+    Downloading,
+}
+
+#[derive(Debug, Clone)]
+pub struct PeerInfo {
+    pub peer: CachedPeer,
+    pub peer_status: PeerStatus,
+}
+
+pub struct PeerManager {
+    network_state: Arc<NetworkState>,
+    peers: HashMap<PeerId, PeerInfo>,
+    banned_peers: HashMap<PeerId, Instant>,
+}
+
+impl PeerManager {
+    pub fn new(network_state: Arc<NetworkState>) -> Self {
+        Self {
+            network_state,
+            peers: HashMap::new(),
+            banned_peers: HashMap::new(),
+        }
+    }
+
+    pub fn update_peer_set(&mut self) {
+        let connected_peers = self.network_state.connected_peers();
+        for peer in &connected_peers {
+            if self.banned_peers.contains_key(&peer.peer_id) {
+                continue;
+            }
+
+            self.peers.entry(peer.peer_id).or_insert_with(|| PeerInfo {
+                peer: peer.clone(),
+                peer_status: PeerStatus::Idle,
+            });
+        }
+
+        // Remove disconnected peers
+        self.peers
+            .retain(|peer_id, _| connected_peers.iter().any(|peer| peer.peer_id == *peer_id));
+    }
+
+    /// Bans a peer
+    pub fn ban_peer(&mut self, peer_id: &PeerId) {
+        if let Some(peer_info) = self.peers.remove(peer_id) {
+            self.banned_peers
+                .insert(peer_info.peer.peer_id, Instant::now());
+        } else {
+            warn!("Attempted to ban a peer that is not in the peer set: {peer_id}");
+        }
+    }
+
+    /// Fetches an idle peer from the peer set.
+    ///
+    /// Will set the peer status to `Downloading` if an idle peer is found.
+    pub fn fetch_idle_peer(&mut self) -> Option<CachedPeer> {
+        for peer_info in self.peers.values_mut() {
+            if let PeerStatus::Idle = peer_info.peer_status {
+                peer_info.peer_status = PeerStatus::Downloading;
+                return Some(peer_info.peer.clone());
+            }
+        }
+        None
+    }
+
+    /// Marks a peer as idle after a download is complete.
+    pub fn mark_peer_as_idle(&mut self, peer_id: &PeerId) {
+        if let Some(peer_info) = self.peers.get_mut(peer_id) {
+            peer_info.peer_status = PeerStatus::Idle;
+        }
+    }
+
+    pub fn finalized_slot(&self) -> Option<u64> {
+        let mut frequencies = HashMap::new();
+
+        for peer in self.peers.values() {
+            if let Some(status) = &peer.peer.status {
+                *frequencies
+                    .entry(status.finalized_epoch * SLOTS_PER_EPOCH)
+                    .or_insert(0) += 1;
+            }
+        }
+
+        frequencies
+            .into_iter()
+            .max_by_key(|&(_, count)| count)
+            .map(|(slot, _)| slot)
+    }
+}

--- a/crates/networking/syncer/src/block_range/peer_range_downloader.rs
+++ b/crates/networking/syncer/src/block_range/peer_range_downloader.rs
@@ -1,0 +1,171 @@
+use alloy_primitives::B256;
+use libp2p::PeerId;
+use ream_consensus::{
+    blob_sidecar::{BlobIdentifier, BlobSidecar},
+    electra::beacon_block::SignedBeaconBlock,
+};
+use ream_executor::ReamExecutor;
+use ream_p2p::{
+    channel::{P2PCallbackResponse, P2PMessage, P2PRequest},
+    req_resp::messages::ResponseMessage,
+};
+use ssz::Encode;
+use tokio::{
+    sync::mpsc::{self, UnboundedSender},
+    task::JoinHandle,
+};
+use tracing::info;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Range {
+    pub start_slot: u64,
+    pub count: u64,
+}
+
+impl Range {
+    pub fn new(start_slot: u64, count: u64) -> Self {
+        Self { start_slot, count }
+    }
+}
+
+pub struct PeerRangeDownloader;
+
+impl PeerRangeDownloader {
+    pub fn start(
+        peer_id: PeerId,
+        p2p_sender: UnboundedSender<P2PMessage>,
+        executor: ReamExecutor,
+        range: Range,
+    ) -> JoinHandle<anyhow::Result<Vec<SignedBeaconBlock>>> {
+        executor.spawn(async move {
+            let mut beacon_blocks = vec![];
+            let (callback, mut rx) = mpsc::channel(100);
+            p2p_sender
+                .send(P2PMessage::Request(P2PRequest::BlockRange {
+                    peer_id,
+                    start: range.start_slot,
+                    count: range.count,
+                    callback,
+                }))
+                .expect("Failed to send block range request");
+
+            while let Some(response) = rx.recv().await {
+                match response {
+                    Ok(P2PCallbackResponse::ResponseMessage(message)) => {
+                        if let ResponseMessage::BeaconBlocksByRange(blocks) = *message {
+                            info!(
+                                "Received block response with slot {} length {}",
+                                blocks.message.slot,
+                                blocks.as_ssz_bytes().len()
+                            );
+                            beacon_blocks.push(blocks);
+                        }
+                    }
+                    Ok(P2PCallbackResponse::EndOfStream) => {
+                        info!("End of block range request stream received.");
+                        break;
+                    }
+                    Err(err) => {
+                        info!("Error receiving BeaconBlocks from block range request: {err:?}");
+                    }
+                }
+            }
+
+            beacon_blocks
+        })
+    }
+}
+
+pub struct PeerRootsDownloader;
+
+impl PeerRootsDownloader {
+    pub fn start(
+        peer_id: PeerId,
+        p2p_sender: UnboundedSender<P2PMessage>,
+        executor: ReamExecutor,
+        roots: Vec<B256>,
+    ) -> JoinHandle<anyhow::Result<Vec<SignedBeaconBlock>>> {
+        executor.spawn(async move {
+            let mut beacon_blocks = vec![];
+            let (callback, mut rx) = mpsc::channel(100);
+            p2p_sender
+                .send(P2PMessage::Request(P2PRequest::BlockRoots {
+                    peer_id,
+                    roots: roots.to_vec(),
+                    callback,
+                }))
+                .expect("Failed to send block roots request");
+
+            while let Some(response) = rx.recv().await {
+                match response {
+                    Ok(P2PCallbackResponse::ResponseMessage(message)) => {
+                        if let ResponseMessage::BeaconBlocksByRoot(blocks) = *message {
+                            info!(
+                                "Received block response with slot {} length {}",
+                                blocks.message.slot,
+                                blocks.as_ssz_bytes().len()
+                            );
+                            beacon_blocks.push(blocks);
+                        }
+                    }
+                    Ok(P2PCallbackResponse::EndOfStream) => {
+                        info!("End of block roots request stream received.");
+                        break;
+                    }
+                    Err(err) => {
+                        info!("Error receiving BeaconBlocks from block roots request: {err:?}");
+                    }
+                }
+            }
+
+            beacon_blocks
+        })
+    }
+}
+
+pub struct PeerBlobIdentifierDownloader;
+
+impl PeerBlobIdentifierDownloader {
+    pub fn start(
+        peer_id: PeerId,
+        p2p_sender: UnboundedSender<P2PMessage>,
+        executor: ReamExecutor,
+        blob_identifiers: Vec<BlobIdentifier>,
+    ) -> JoinHandle<anyhow::Result<Vec<BlobSidecar>>> {
+        executor.spawn(async move {
+            let mut blob_sidecars = vec![];
+            let (callback, mut rx) = mpsc::channel(100);
+            p2p_sender
+                .send(P2PMessage::Request(P2PRequest::BlobIdentifiers {
+                    peer_id,
+                    blob_identifiers: blob_identifiers.to_vec(),
+                    callback,
+                }))
+                .expect("Failed to send blob identifiers request");
+
+            while let Some(response) = rx.recv().await {
+                match response {
+                    Ok(P2PCallbackResponse::ResponseMessage(message)) => {
+                        if let ResponseMessage::BlobSidecarsByRoot(blob_sidecar) = *message {
+                            info!(
+                                "Received blob sidecar response with index {} length {}",
+                                blob_sidecar.index,
+                                blob_sidecar.as_ssz_bytes().len()
+                            );
+                            blob_sidecars.push(blob_sidecar);
+                        }
+                    }
+                    Ok(P2PCallbackResponse::EndOfStream) => {
+                        info!("End of blob roots request stream received.");
+                        break;
+                    }
+                    Err(err) => {
+                        info!("Error receiving blobs from blob roots request: {err:?}");
+                    }
+                }
+            }
+
+            blob_sidecars
+        })
+    }
+}

--- a/crates/rpc/src/handlers/identity.rs
+++ b/crates/rpc/src/handlers/identity.rs
@@ -28,12 +28,12 @@ impl Identity {
 
                 if let Some(ip4) = enr.ip4() {
                     if let Some(tcp4) = enr.tcp4() {
-                        addresses.push(format!("/ip4/{}/tcp/{}/p2p/{}", ip4, tcp4, peer_id));
+                        addresses.push(format!("/ip4/{ip4}/tcp/{tcp4}/p2p/{peer_id}"));
                     }
                 }
                 if let Some(ip6) = enr.ip6() {
                     if let Some(tcp6) = enr.tcp6() {
-                        addresses.push(format!("/ip6/{}/tcp/{}/p2p/{}", ip6, tcp6, peer_id));
+                        addresses.push(format!("/ip6/{ip6}/tcp/{tcp6}/p2p/{peer_id}"));
                     }
                 }
 
@@ -44,12 +44,12 @@ impl Identity {
 
                 if let Some(ip4) = enr.ip4() {
                     if let Some(udp4) = enr.udp4() {
-                        addresses.push(format!("/ip4/{}/udp/{}/p2p/{}", ip4, udp4, peer_id));
+                        addresses.push(format!("/ip4/{ip4}/udp/{udp4}/p2p/{peer_id}"));
                     }
                 }
                 if let Some(ip6) = enr.ip6() {
                     if let Some(udp6) = enr.udp6() {
-                        addresses.push(format!("/ip6/{}/udp/{}/p2p/{}", ip6, udp6, peer_id));
+                        addresses.push(format!("/ip6/{ip6}/udp/{udp6}/p2p/{peer_id}"));
                     }
                 }
 

--- a/crates/storage/src/tables/blobs_and_proofs.rs
+++ b/crates/storage/src/tables/blobs_and_proofs.rs
@@ -91,7 +91,7 @@ mod tests {
         let key = BlobIdentifier::default();
         let value = BlobAndProofV1::default();
 
-        table.insert(key.clone(), value.clone())?;
+        table.insert(key, value.clone())?;
 
         let result = table.get(key)?;
 

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -32,4 +32,5 @@ ream-bls.workspace = true
 ream-consensus.workspace = true
 ream-fork-choice.workspace = true
 ream-merkle.workspace = true
+ream-network-spec.workspace = true
 ream-storage.workspace = true

--- a/testing/ef-tests/src/macros/fork_choice.rs
+++ b/testing/ef-tests/src/macros/fork_choice.rs
@@ -15,6 +15,7 @@ macro_rules! test_fork_choice {
                     handlers::{on_attestation, on_attester_slashing, on_block, on_tick},
                     store::{get_forkchoice_store, Store},
                 };
+                use ream_network_spec::networks::initialize_test_network_spec;
                 use ream_storage::{
                     db::ReamDB,
                     tables::{Table, Field},
@@ -92,6 +93,7 @@ macro_rules! test_fork_choice {
 
                 #[tokio::test]
                 async fn test_fork_choice() -> anyhow::Result<()> {
+                    initialize_test_network_spec();
                     let base_path = format!(
                         "mainnet/tests/mainnet/electra/fork_choice/{}/pyspec_tests",
                         stringify!($path)
@@ -158,7 +160,7 @@ macro_rules! test_fork_choice {
                                         }
                                     }
 
-                                    assert_eq!(on_block(&mut store, &block, &mock_engine).await.is_ok(), blocks.valid.unwrap_or(true), "Unexpected result on on_block");
+                                    assert_eq!(on_block(&mut store, &block, &mock_engine, true).await.is_ok(), blocks.valid.unwrap_or(true), "Unexpected result on on_block");
                                 }
                                 ForkChoiceStep::Attestation(attestations) => {
                                     let attestation_path =


### PR DESCRIPTION
### What was wrong?

We can't sync forward from the initial checkpoint

### How was it fixed?

Implement a forward syncer which takes our connected peers, downloads blocks and blobs, and executes them till we get to the finalized point.


### What I will do in follow up PR's

Currently syncing blobs will eventually freeze due to peers never responding and we don't implement timing out requests yet, so I need to implement timing out P2P requests.

