### PR TITLE
Feature/shariqnaiyer/attestation wait

### DIFF
--- a/crates/common/validator/src/validator.rs
+++ b/crates/common/validator/src/validator.rs
@@ -542,9 +542,6 @@ impl ValidatorService {
             return;
         }
 
-        let seconds_per_slot = network_spec().seconds_per_slot;
-        let timeout_duration = Duration::from_secs(seconds_per_slot / 3);
-
         let mut slot_receiver = self.slot_sender.subscribe();
 
         tokio::select! {
@@ -553,7 +550,7 @@ impl ValidatorService {
                     info!("Received slot {received_slot}, proceeding with attestation");
                 }
             }
-            _ = tokio::time::sleep(timeout_duration) => {
+            _ = tokio::time::sleep(Duration::from_secs(network_spec().seconds_per_slot / 3)) => {
                 info!("One third of slot {slot} has passed, proceeding with attestation");
             }
         }


### PR DESCRIPTION
### What was wrong?

Fixes: #623 

### How was it fixed?

We wanted to implement a wait before making attestations which waits for either:
1. A valid block to be proposed to the Beacon node or
2. Passing of 1/3rd of the slot 

(2) is easy as we just implement a tokio::time::sleep()
For (1) we had to first subscribe to the Beacon API events stream on the 'head' topic, we then process each head topic by extracting the slot and keeping track of the highest slot for which a valid block has been seen. We also relay this to the waiting function using a channel.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
