### PR TITLE
fix: calculate the BlockRoot not the SignedBlockRoot

### DIFF
--- a/crates/common/consensus/src/electra/beacon_block.rs
+++ b/crates/common/consensus/src/electra/beacon_block.rs
@@ -18,7 +18,7 @@ use crate::{
     polynomial_commitments::kzg_proof::KZGProof,
 };
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct SignedBeaconBlock {
     pub message: BeaconBlock,
     pub signature: BLSSignature,

--- a/crates/rpc/src/handlers/light_client.rs
+++ b/crates/rpc/src/handlers/light_client.rs
@@ -126,7 +126,7 @@ pub async fn get_light_client_updates(
                 block.message.parent_root
             )))?;
 
-        let attested_block_root = attested_block.tree_hash_root();
+        let attested_block_root = attested_block.message.tree_hash_root();
         let attested_state = db
             .beacon_state_provider()
             .get(attested_block_root)
@@ -223,7 +223,7 @@ pub async fn get_light_client_finality_update(
         })?
         .ok_or_else(|| ApiError::NotFound("Light client finality update unavailable".into()))?;
 
-    let attested_block_root = attested_block.tree_hash_root();
+    let attested_block_root = attested_block.message.tree_hash_root();
     let attested_state = db
         .beacon_state_provider()
         .get(attested_block_root)

--- a/crates/storage/src/tables/beacon_block.rs
+++ b/crates/storage/src/tables/beacon_block.rs
@@ -37,7 +37,7 @@ impl Table for BeaconBlockTable {
 
     fn insert(&self, key: Self::Key, value: Self::Value) -> Result<(), StoreError> {
         // insert entry to slot_index table
-        let block_root = value.tree_hash_root();
+        let block_root = value.message.tree_hash_root();
         let slot_index_table = SlotIndexTable {
             db: self.db.clone(),
         };


### PR DESCRIPTION
### What was wrong?

We are calculating the SignedBlockRoot instead of BlockRoot in several places. Once of the places is in our indexes. The impact of this is if we execute a block and restart the clients, we won't be able to find the latest state
### How was it fixed?

Remove the `TreeHash` derive on SignedBeaconBlock, and update our code to calculate the BlockRoot as it was meant to.
