### PR TITLE
feat: implement /eth/v1/validator/attestation_data

### DIFF
--- a/crates/common/beacon_api_types/src/error.rs
+++ b/crates/common/beacon_api_types/src/error.rs
@@ -23,6 +23,9 @@ pub enum ApiError {
 
     #[error("Too many validator IDs in request")]
     TooManyValidatorsIds,
+
+    #[error("Beacon node is currently syncing and not serving request on that endpoint")]
+    UnderSyncing,
 }
 
 impl ResponseError for ApiError {
@@ -39,6 +42,7 @@ impl ResponseError for ApiError {
             ApiError::InvalidParameter(_) => StatusCode::BAD_REQUEST,
             ApiError::ValidatorNotFound(_) => StatusCode::NOT_FOUND,
             ApiError::TooManyValidatorsIds => StatusCode::URI_TOO_LONG,
+            ApiError::UnderSyncing => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 }

--- a/crates/common/beacon_api_types/src/query.rs
+++ b/crates/common/beacon_api_types/src/query.rs
@@ -44,6 +44,12 @@ pub struct StatusQuery {
     pub status: Option<Vec<ValidatorStatus>>,
 }
 
+#[derive(Default, Debug, Deserialize)]
+pub struct AttestationQuery {
+    pub slot: u64,
+    pub committee_index: u64,
+}
+
 impl StatusQuery {
     pub fn has_status(&self) -> bool {
         match &self.status {

--- a/crates/common/fork_choice/src/store.rs
+++ b/crates/common/fork_choice/src/store.rs
@@ -802,6 +802,22 @@ impl Store {
 
         Ok(())
     }
+
+    pub fn is_syncing(&self) -> anyhow::Result<bool> {
+        let head = self.get_head()?;
+
+        let head_slot = match self.db.beacon_block_provider().get(head) {
+            Ok(Some(block)) => block.message.slot,
+            err => {
+                return Err(anyhow!("Failed to get head slot, error: {err:?}"));
+            }
+        };
+
+        // calculate sync_distance
+        let sync_distance = self.get_current_slot()?.saturating_sub(head_slot);
+
+        Ok(sync_distance > 1)
+    }
 }
 
 pub fn get_forkchoice_store(

--- a/crates/rpc/beacon/src/routes/validator.rs
+++ b/crates/rpc/beacon/src/routes/validator.rs
@@ -3,10 +3,12 @@ use actix_web::web::ServiceConfig;
 use crate::handlers::{
     duties::{get_attester_duties, get_proposer_duties},
     prepare_beacon_proposer::prepare_beacon_proposer,
+    validator::get_attestation_data,
 };
 
 pub fn register_validator_routes(config: &mut ServiceConfig) {
     config.service(get_proposer_duties);
     config.service(get_attester_duties);
     config.service(prepare_beacon_proposer);
+    config.service(get_attestation_data);
 }


### PR DESCRIPTION
### What was wrong?

 Missing attestation_data validator endpoint for the electra hardfork.

### How was it fixed?

- I have added some helper functions on the unrealized_checkpoint_table and justified_checkpoint_table to get the checkpoint details.
- Created a new request type for the API endpoint.
- Fetched data from the checkpoints table and highest block root from the slot index table. And returned the data object

### To-Do
- Logic Verification
 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
