### PR TITLE
chore: bump rust version to 1.88 & make linter happy

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         curl -L https://risczero.com/install | bash
         /home/runner/.risc0/bin/rzup install
-        /home/runner/.risc0/bin/rzup install rust 1.85.0
+        /home/runner/.risc0/bin/rzup install rust 1.88.0
         rustup default risc0
         
     - name: Build Risc0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ keywords = [
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ReamLabs/ream"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -6,6 +6,7 @@
   - [P2P Networking](./developer/p2p/README.md)
 - [CLI Reference](./cli/cli.md) <!-- CLI_REFERENCE START -->
   - [`ream`](./cli/ream.md)
+    - [`ream lean_node`](./cli/ream/lean_node.md)
     - [`ream beacon_node`](./cli/ream/beacon_node.md)
     - [`ream validator_node`](./cli/ream/validator_node.md)
     - [`ream account_manager`](./cli/ream/account_manager.md)

--- a/book/cli/SUMMARY.md
+++ b/book/cli/SUMMARY.md
@@ -1,4 +1,5 @@
 - [`ream`](./ream.md)
+  - [`ream lean_node`](./ream/lean_node.md)
   - [`ream beacon_node`](./ream/beacon_node.md)
   - [`ream validator_node`](./ream/validator_node.md)
   - [`ream account_manager`](./ream/account_manager.md)

--- a/book/cli/ream.md
+++ b/book/cli/ream.md
@@ -9,6 +9,7 @@ $ ream --help
 Usage: ream <COMMAND>
 
 Commands:
+  lean_node        Start the lean node
   beacon_node      Start the beacon node
   validator_node   Start the validator node
   account_manager  Manage validator accounts

--- a/book/cli/ream/lean_node.md
+++ b/book/cli/ream/lean_node.md
@@ -1,0 +1,14 @@
+# ream lean_node
+
+Start the lean node
+
+```bash
+$ ream lean_node --help
+```
+```txt
+Usage: ream lean_node [OPTIONS]
+
+Options:
+  -v, --verbosity <VERBOSITY>  Verbosity level [default: 3]
+  -h, --help                   Print help
+```

--- a/crates/common/checkpoint_sync/src/lib.rs
+++ b/crates/common/checkpoint_sync/src/lib.rs
@@ -35,6 +35,7 @@ use weak_subjectivity::{WeakSubjectivityState, verify_state_from_weak_subjectivi
 ///     "data" : T
 /// })
 /// }
+#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 struct OptionalBeaconVersionedResponse<T> {
     pub version: Option<String>,

--- a/crates/common/checkpoint_sync/src/lib.rs
+++ b/crates/common/checkpoint_sync/src/lib.rs
@@ -18,31 +18,9 @@ use reqwest::{
     header::{ACCEPT, HeaderValue},
 };
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use ssz::Decode;
 use tracing::{info, warn};
 use weak_subjectivity::{WeakSubjectivityState, verify_state_from_weak_subjectivity_checkpoint};
-
-/// A OptionalBeaconVersionedResponse data struct that can be used to wrap data type
-/// used for json rpc responses
-///
-/// # Example
-/// {
-///  "data": json!({
-///     "version": Some("electra")
-///     "execution_optimistic" : Some("false"),
-///     "finalized" : None,
-///     "data" : T
-/// })
-/// }
-#[allow(dead_code)]
-#[derive(Debug, Serialize, Deserialize)]
-struct OptionalBeaconVersionedResponse<T> {
-    pub version: Option<String>,
-    pub execution_optimistic: Option<Value>,
-    pub finalized: Option<Value>,
-    pub data: T,
-}
 
 /// Entry point for checkpoint sync.
 pub async fn initialize_db_from_checkpoint(

--- a/crates/common/consensus/beacon/src/electra/beacon_state.rs
+++ b/crates/common/consensus/beacon/src/electra/beacon_state.rs
@@ -1628,7 +1628,7 @@ impl BeaconState {
     pub fn process_historical_summaries_update(&mut self) -> anyhow::Result<()> {
         // Set historical block root accumulator.
         let next_epoch = self.get_current_epoch() + 1;
-        if next_epoch % (SLOTS_PER_HISTORICAL_ROOT / SLOTS_PER_EPOCH) == 0 {
+        if next_epoch.is_multiple_of(SLOTS_PER_HISTORICAL_ROOT / SLOTS_PER_EPOCH) {
             let historical_summary = HistoricalSummary {
                 block_summary_root: self.block_roots.tree_hash_root(),
                 state_summary_root: self.state_roots.tree_hash_root(),
@@ -1964,7 +1964,7 @@ impl BeaconState {
         let next_epoch = self.get_current_epoch() + 1;
 
         // Reset eth1 data votes
-        if next_epoch % EPOCHS_PER_ETH1_VOTING_PERIOD == 0 {
+        if next_epoch.is_multiple_of(EPOCHS_PER_ETH1_VOTING_PERIOD) {
             self.eth1_data_votes = VariableList::default();
         }
 
@@ -2547,7 +2547,7 @@ impl BeaconState {
 
     pub fn process_sync_committee_updates(&mut self) -> anyhow::Result<()> {
         let next_epoch = self.get_current_epoch() + 1;
-        if next_epoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0 {
+        if next_epoch.is_multiple_of(EPOCHS_PER_SYNC_COMMITTEE_PERIOD) {
             self.current_sync_committee = self.next_sync_committee.clone();
             self.next_sync_committee = Arc::new(self.get_next_sync_committee()?);
         }
@@ -2587,7 +2587,7 @@ impl BeaconState {
         while self.slot < slot {
             self.process_slot()?;
             // Process epoch on the start slot of the next epoch
-            if (self.slot + 1) % SLOTS_PER_EPOCH == 0 {
+            if (self.slot + 1).is_multiple_of(SLOTS_PER_EPOCH) {
                 self.process_epoch()?;
             }
 

--- a/crates/common/consensus/misc/src/misc.rs
+++ b/crates/common/consensus/misc/src/misc.rs
@@ -99,7 +99,7 @@ pub fn compute_committee(
 }
 
 pub fn is_shuffling_stable(slot: u64) -> bool {
-    slot % SLOTS_PER_EPOCH != 0
+    !slot.is_multiple_of(SLOTS_PER_EPOCH)
 }
 
 /// Return the epoch number at ``slot``.

--- a/crates/common/fork_choice/src/store.rs
+++ b/crates/common/fork_choice/src/store.rs
@@ -718,33 +718,33 @@ impl Store {
         }
 
         // Fallback to trying engine api
-        if let Some(execution_engine) = execution_engine {
-            if blobs_and_proofs.contains(&None) {
-                let indexed_blob_versioned_hashes = blobs_and_proofs
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(index, blob_and_proof)| {
-                        if blob_and_proof.is_none() {
-                            Some((
-                                index,
-                                blob_kzg_commitments[index].calculate_versioned_hash(),
-                            ))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                let (indices, blob_versioned_hashes): (Vec<_>, Vec<_>) =
-                    indexed_blob_versioned_hashes.into_iter().unzip();
-                let execution_blobs_and_proofs = execution_engine
-                    .engine_get_blobs_v1(blob_versioned_hashes)
-                    .await?;
-                for (index, blob_and_proof) in indices
-                    .into_iter()
-                    .zip(execution_blobs_and_proofs.into_iter())
-                {
-                    blobs_and_proofs[index] = blob_and_proof;
-                }
+        if let Some(execution_engine) = execution_engine
+            && blobs_and_proofs.contains(&None)
+        {
+            let indexed_blob_versioned_hashes = blobs_and_proofs
+                .iter()
+                .enumerate()
+                .filter_map(|(index, blob_and_proof)| {
+                    if blob_and_proof.is_none() {
+                        Some((
+                            index,
+                            blob_kzg_commitments[index].calculate_versioned_hash(),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            let (indices, blob_versioned_hashes): (Vec<_>, Vec<_>) =
+                indexed_blob_versioned_hashes.into_iter().unzip();
+            let execution_blobs_and_proofs = execution_engine
+                .engine_get_blobs_v1(blob_versioned_hashes)
+                .await?;
+            for (index, blob_and_proof) in indices
+                .into_iter()
+                .zip(execution_blobs_and_proofs.into_iter())
+            {
+                blobs_and_proofs[index] = blob_and_proof;
             }
         }
 

--- a/crates/common/validator/beacon/src/attestation.rs
+++ b/crates/common/validator/beacon/src/attestation.rs
@@ -32,13 +32,13 @@ pub fn is_aggregator(
     committee_index: u64,
     slot_signature: BLSSignature,
 ) -> anyhow::Result<bool> {
-    Ok(hash_signature_prefix_to_u64(&slot_signature) as usize
-        % max(
+    Ok(
+        (hash_signature_prefix_to_u64(&slot_signature) as usize).is_multiple_of(max(
             1,
             state.get_beacon_committee(slot, committee_index)?.len()
                 / TARGET_AGGREGATORS_PER_COMMITTEE as usize,
-        )
-        == 0)
+        )),
+    )
 }
 
 /// Compute the correct subnet for an attestation for Phase 0.

--- a/crates/common/validator/beacon/src/sync_committee.rs
+++ b/crates/common/validator/beacon/src/sync_committee.rs
@@ -156,12 +156,10 @@ pub fn get_sync_committee_selection_proof(
 }
 
 pub fn is_sync_committee_aggregator(signature: &BLSSignature) -> bool {
-    hash_signature_prefix_to_u64(signature)
-        % max(
-            1,
-            SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT / TARGET_AGGREGATORS_PER_COMMITTEE,
-        )
-        == 0
+    hash_signature_prefix_to_u64(signature).is_multiple_of(max(
+        1,
+        SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT / TARGET_AGGREGATORS_PER_COMMITTEE,
+    ))
 }
 
 pub fn get_sync_committee_message(

--- a/crates/common/validator/beacon/src/validator.rs
+++ b/crates/common/validator/beacon/src/validator.rs
@@ -135,18 +135,18 @@ impl ValidatorService {
             tokio::select! {
                 _ = interval.tick() => {
                     intervals += 1;
-                    if intervals % (INTERVALS_PER_SLOT * SLOTS_PER_EPOCH) == 0 {
+                    if intervals.is_multiple_of(INTERVALS_PER_SLOT * SLOTS_PER_EPOCH) {
                         epoch += 1;
                         self.on_epoch(epoch).await;
                     }
-                    if intervals % INTERVALS_PER_SLOT == 0 {
+                    if intervals.is_multiple_of(INTERVALS_PER_SLOT) {
                         slot += 1;
                         self.on_slot(slot).await;
                     }
                     if intervals % INTERVALS_PER_SLOT == 2 {
                         self.on_slot_aggregator(slot).await;
                     }
-                    if (intervals+1) % (INTERVALS_PER_SLOT * SLOTS_PER_EPOCH) == 0 {
+                    if (intervals + 1).is_multiple_of(INTERVALS_PER_SLOT * SLOTS_PER_EPOCH) {
                         self.on_epoch_end(epoch).await;
                     }
                 }

--- a/crates/networking/manager/src/gossipsub/validate/blob_sidecar.rs
+++ b/crates/networking/manager/src/gossipsub/validate/blob_sidecar.rs
@@ -102,7 +102,7 @@ pub async fn validate_blob_sidecar(
 
     // [REJECT] The sidecar's blob is valid as verified by
     if !verify_blob_kzg_proof_batch(
-        &[blob_sidecar.blob.clone()],
+        std::slice::from_ref(&blob_sidecar.blob),
         &[blob_sidecar.kzg_commitment],
         &[blob_sidecar.kzg_proof],
     )? {

--- a/crates/networking/p2p/src/req_resp/handler.rs
+++ b/crates/networking/p2p/src/req_resp/handler.rs
@@ -531,15 +531,14 @@ impl ConnectionHandler for ReqRespConnectionHandler {
             });
         }
 
-        if let ConnectionState::ShuttingDown = self.connection_state {
-            if self.inbound_streams.is_empty()
-                && self.outbound_streams.is_empty()
-                && self.pending_outbound_streams.is_empty()
-                && self.behaviour_events.is_empty()
-            {
-                self.connection_state = ConnectionState::Closed;
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(HandlerEvent::Close));
-            }
+        if let ConnectionState::ShuttingDown = self.connection_state
+            && self.inbound_streams.is_empty()
+            && self.outbound_streams.is_empty()
+            && self.pending_outbound_streams.is_empty()
+            && self.behaviour_events.is_empty()
+        {
+            self.connection_state = ConnectionState::Closed;
+            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(HandlerEvent::Close));
         }
 
         Poll::Pending

--- a/crates/networking/p2p/src/req_resp/outbound_protocol.rs
+++ b/crates/networking/p2p/src/req_resp/outbound_protocol.rs
@@ -143,12 +143,12 @@ impl Decoder for OutboundSSZSnappyCodec {
             src.advance(B32::len_bytes());
         }
 
-        if let Some(context_bytes) = self.context_bytes {
-            if context_bytes != network_spec().fork_digest(genesis_validators_root()) {
-                return Ok(Some(RespMessage::Error(ReqRespError::InvalidData(
-                    "Invalid context bytes, we only support Electra".to_string(),
-                ))));
-            }
+        if let Some(context_bytes) = self.context_bytes
+            && context_bytes != network_spec().fork_digest(genesis_validators_root())
+        {
+            return Ok(Some(RespMessage::Error(ReqRespError::InvalidData(
+                "Invalid context bytes, we only support Electra".to_string(),
+            ))));
         }
 
         let length = match self.length {

--- a/crates/rpc/beacon/src/handlers/identity.rs
+++ b/crates/rpc/beacon/src/handlers/identity.rs
@@ -27,15 +27,15 @@ impl Identity {
             p2p_address: {
                 let mut addresses = Vec::new();
 
-                if let Some(ip4) = enr.ip4() {
-                    if let Some(tcp4) = enr.tcp4() {
-                        addresses.push(format!("/ip4/{ip4}/tcp/{tcp4}/p2p/{peer_id}"));
-                    }
+                if let Some(ip4) = enr.ip4()
+                    && let Some(tcp4) = enr.tcp4()
+                {
+                    addresses.push(format!("/ip4/{ip4}/tcp/{tcp4}/p2p/{peer_id}"));
                 }
-                if let Some(ip6) = enr.ip6() {
-                    if let Some(tcp6) = enr.tcp6() {
-                        addresses.push(format!("/ip6/{ip6}/tcp/{tcp6}/p2p/{peer_id}"));
-                    }
+                if let Some(ip6) = enr.ip6()
+                    && let Some(tcp6) = enr.tcp6()
+                {
+                    addresses.push(format!("/ip6/{ip6}/tcp/{tcp6}/p2p/{peer_id}"));
                 }
 
                 addresses
@@ -43,15 +43,15 @@ impl Identity {
             discovery_address: {
                 let mut addresses = Vec::new();
 
-                if let Some(ip4) = enr.ip4() {
-                    if let Some(udp4) = enr.udp4() {
-                        addresses.push(format!("/ip4/{ip4}/udp/{udp4}/p2p/{peer_id}"));
-                    }
+                if let Some(ip4) = enr.ip4()
+                    && let Some(udp4) = enr.udp4()
+                {
+                    addresses.push(format!("/ip4/{ip4}/udp/{udp4}/p2p/{peer_id}"));
                 }
-                if let Some(ip6) = enr.ip6() {
-                    if let Some(udp6) = enr.udp6() {
-                        addresses.push(format!("/ip6/{ip6}/udp/{udp6}/p2p/{peer_id}"));
-                    }
+                if let Some(ip6) = enr.ip6()
+                    && let Some(udp6) = enr.udp6()
+                {
+                    addresses.push(format!("/ip6/{ip6}/udp/{udp6}/p2p/{peer_id}"));
                 }
 
                 addresses

--- a/crates/rpc/beacon/src/handlers/validator.rs
+++ b/crates/rpc/beacon/src/handlers/validator.rs
@@ -127,10 +127,10 @@ pub async fn get_validators_from_state(
     id_query: Query<IdQuery>,
     status_query: Query<StatusQuery>,
 ) -> Result<impl Responder, ApiError> {
-    if let Some(validator_ids) = &id_query.id {
-        if validator_ids.len() >= MAX_VALIDATOR_COUNT {
-            return Err(ApiError::TooManyValidatorsIds);
-        }
+    if let Some(validator_ids) = &id_query.id
+        && validator_ids.len() >= MAX_VALIDATOR_COUNT
+    {
+        return Err(ApiError::TooManyValidatorsIds);
     }
 
     let state = get_state_from_id(state_id.into_inner(), &db).await?;


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Rust `1.88.0` is now stable. ([changelog](https://releases.rs/docs/1.88.0/)) I wanted to use let-chain because it makes the code cleaner.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Bump Rust version to `1.88.0` and fix linting issue when I run `make lint`.

Also I forgot to update our book 😂, this PR also introduces a new command `lean_node` in our book.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
