### PR TITLE
feat: gossipsub validate and forward: voluntary_exit

### DIFF
--- a/crates/networking/manager/src/gossipsub/validate/mod.rs
+++ b/crates/networking/manager/src/gossipsub/validate/mod.rs
@@ -3,3 +3,4 @@ pub mod blob_sidecar;
 pub mod bls_to_execution_change;
 pub mod result;
 pub mod sync_committee;
+pub mod voluntary_exit;

--- a/crates/networking/manager/src/gossipsub/validate/voluntary_exit.rs
+++ b/crates/networking/manager/src/gossipsub/validate/voluntary_exit.rs
@@ -1,0 +1,52 @@
+use anyhow::anyhow;
+use ream_beacon_chain::beacon_chain::BeaconChain;
+use ream_consensus_beacon::{
+    electra::beacon_state::BeaconState, voluntary_exit::SignedVoluntaryExit,
+};
+use ream_storage::{cache::CachedDB, tables::Table};
+
+use super::result::ValidationResult;
+
+pub async fn validate_voluntary_exit(
+    voluntary_exit: &SignedVoluntaryExit,
+    beacon_chain: &BeaconChain,
+    cached_db: &CachedDB,
+) -> anyhow::Result<ValidationResult> {
+    let store = beacon_chain.store.lock().await;
+
+    let head_root = store.get_head()?;
+    let state: BeaconState = store
+        .db
+        .beacon_state_provider()
+        .get(head_root)?
+        .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
+
+    // [IGNORE] The voluntary exit is the first valid voluntary exit received for the validator with
+    // index signed_voluntary_exit.message.validator_index
+    if cached_db
+        .seen_voluntary_exit
+        .read()
+        .await
+        .contains(&voluntary_exit.message.validator_index)
+    {
+        let index = voluntary_exit.message.validator_index;
+        return Ok(ValidationResult::Ignore(format!(
+            "The voluntary_exit is not the first valid voluntary exit received for the validator with index: {index}"
+        )));
+    }
+
+    // [REJECT] All of the conditions within process_voluntary_exit pass validation.
+    if let Err(err) = state.validate_voluntary_exit(voluntary_exit) {
+        return Ok(ValidationResult::Reject(format!(
+            "All of the conditions within validate_voluntary_exit pass validation fail: {err}"
+        )));
+    }
+
+    cached_db
+        .seen_voluntary_exit
+        .write()
+        .await
+        .put(voluntary_exit.message.validator_index, ());
+
+    Ok(ValidationResult::Accept)
+}

--- a/crates/networking/p2p/src/gossipsub/message.rs
+++ b/crates/networking/p2p/src/gossipsub/message.rs
@@ -3,7 +3,7 @@ use ream_consensus_beacon::{
     attester_slashing::AttesterSlashing, blob_sidecar::BlobSidecar,
     bls_to_execution_change::SignedBLSToExecutionChange, electra::beacon_block::SignedBeaconBlock,
     proposer_slashing::ProposerSlashing, single_attestation::SingleAttestation,
-    voluntary_exit::VoluntaryExit,
+    voluntary_exit::SignedVoluntaryExit,
 };
 use ream_consensus_misc::constants::genesis_validators_root;
 use ream_light_client::{
@@ -34,7 +34,7 @@ pub enum GossipsubMessage {
     SyncCommitteeContributionAndProof(Box<SignedContributionAndProof>),
     LightClientFinalityUpdate(Box<LightClientFinalityUpdate>),
     LightClientOptimisticUpdate(Box<LightClientOptimisticUpdate>),
-    VoluntaryExit(Box<VoluntaryExit>),
+    VoluntaryExit(Box<SignedVoluntaryExit>),
 }
 
 impl GossipsubMessage {
@@ -86,7 +86,7 @@ impl GossipsubMessage {
                 Box::new(LightClientOptimisticUpdate::from_ssz_bytes(data)?),
             )),
             GossipTopicKind::VoluntaryExit => Ok(Self::VoluntaryExit(Box::new(
-                VoluntaryExit::from_ssz_bytes(data)?,
+                SignedVoluntaryExit::from_ssz_bytes(data)?,
             ))),
         }
     }

--- a/crates/storage/src/cache.rs
+++ b/crates/storage/src/cache.rs
@@ -42,6 +42,7 @@ pub struct CachedDB {
     pub seen_attestations: RwLock<LruCache<AtestationKey, ()>>,
     pub seen_bls_to_execution_change: RwLock<LruCache<AddressValidaterIndexIdentifier, ()>>,
     pub seen_sync_messages: RwLock<LruCache<SyncCommitteeKey, ()>>,
+    pub seen_voluntary_exit: RwLock<LruCache<u64, ()>>,
 }
 
 impl CachedDB {
@@ -60,6 +61,10 @@ impl CachedDB {
             seen_bls_to_execution_change: LruCache::new(NonZeroUsize::new(LRU_CACHE_SIZE).unwrap())
                 .into(),
             seen_sync_messages: LruCache::new(NonZeroUsize::new(LRU_CACHE_SIZE).unwrap()).into(),
+            seen_voluntary_exit: LruCache::new(
+                NonZeroUsize::new(LRU_CACHE_SIZE).expect("Invalid cache size"),
+            )
+            .into(),
         }
     }
 }


### PR DESCRIPTION
### What was wrong?

Fixes #591 
### How was it fixed?

Adds validation for `voluntary_exit` as per https://ethereum.github.io/consensus-specs/specs/phase0/p2p-interface/#voluntary_exit and forwards to the network if all validations pass.
### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
