### PR TITLE
feat: use simple 1/3 slot wait

### DIFF
--- a/crates/common/validator/beacon/src/validator.rs
+++ b/crates/common/validator/beacon/src/validator.rs
@@ -28,7 +28,7 @@ use ream_executor::ReamExecutor;
 use ream_keystore::keystore::Keystore;
 use ream_network_spec::networks::beacon_network_spec;
 use reqwest::Url;
-use tokio::time::{Instant, MissedTickBehavior, interval_at};
+use tokio::time::{Instant, MissedTickBehavior, interval_at, sleep};
 use tracing::{error, info, warn};
 use tree_hash::TreeHash;
 
@@ -505,6 +505,11 @@ impl ValidatorService {
         validator_index: u64,
         committee_index: u64,
     ) -> anyhow::Result<()> {
+        sleep(Duration::from_secs(
+            beacon_network_spec().seconds_per_slot / 3,
+        ))
+        .await;
+
         let Some(keystore) = self.validator_index_to_keystore.get(&validator_index) else {
             bail!("Keystore not found for validator: {validator_index}");
         };


### PR DESCRIPTION
### What was wrong?

Fixes: #623 

### How was it fixed?

We wanted to implement a wait before making attestations which waits for either:
1. A valid block to be proposed to the Beacon node or
2. Passing of 1/3rd of the slot 

For now we only wait 1/3rd of the slot. We will later optimize it to use the events stream to get the head event and wait for valid block as in #640. However setting up the event stream properly will take time so we are moving forward with a simple sleep function that will work.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
