### PR TITLE
feat: disconnect peer if disconnected from swarm

### DIFF
--- a/crates/networking/manager/src/gossipsub/handle.rs
+++ b/crates/networking/manager/src/gossipsub/handle.rs
@@ -143,7 +143,7 @@ pub async fn handle_gossipsub_message(
                 }
             }
             GossipsubMessage::BeaconAttestation((single_attestation, subnet_id)) => {
-                info!(
+                trace!(
                     "Beacon Attestation received over gossipsub: root: {}",
                     single_attestation.tree_hash_root()
                 );
@@ -172,7 +172,7 @@ pub async fn handle_gossipsub_message(
                         }
                     },
                     Err(err) => {
-                        error!("Could not validate attestation: {err}");
+                        trace!("Could not validate attestation: {err}");
                     }
                 }
             }

--- a/crates/networking/p2p/src/network_state.rs
+++ b/crates/networking/p2p/src/network_state.rs
@@ -29,8 +29,8 @@ impl NetworkState {
         direction: Direction,
         enr: Option<Enr>,
     ) {
-        let mut peer_table = self.peer_table.write();
-        peer_table
+        self.peer_table
+            .write()
             .entry(peer_id)
             .and_modify(|cached_peer| {
                 if let Some(address_ref) = &address {
@@ -43,6 +43,15 @@ impl NetworkState {
                 }
             })
             .or_insert(CachedPeer::new(peer_id, address, state, direction, enr));
+    }
+
+    pub fn update_peer_state(&self, peer_id: PeerId, state: ConnectionState) {
+        self.peer_table
+            .write()
+            .entry(peer_id)
+            .and_modify(|cached_peer| {
+                cached_peer.state = state;
+            });
     }
 
     pub fn write_meta_data_to_disk(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
### What was wrong?

peers would still be connected if disconnected to the swarm

### How was it fixed?

disconnected peer if its disconnected from the swarm