### PR TITLE
refactor: recursive async function issue in `handle_item`

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -143,7 +143,8 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor) {
 
     // TODO 1: Load keystores from the config.
     // TODO 2: Add RPC service for lean node.
-    let chain_service = LeanChainService::new(lean_chain.clone(), chain_receiver).await;
+    let chain_service =
+        LeanChainService::new(lean_chain.clone(), chain_receiver, chain_sender.clone()).await;
     let network_service = LeanNetworkService::new(
         Arc::new(LeanNetworkConfig {
             gossipsub_config: LeanGossipsubConfig::default(),


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Yesterday, there was a new [Rust nightly release](https://rust-analyzer.github.io/thisweek/2025/08/11/changelog-298.html#an-update-on-the-next-trait-solver). This introduced a new solver, which catches bad Rust patterns more accurately.

My last PR (#679) has an anti-pattern (e.g., using `Box::pin` to make it run). It makes our CI (`cargo udeps`) fail since #694. See [the action result](https://github.com/ReamLabs/ream/actions/runs/16900171783/job/47878222193?pr=694).

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

This PR refactors `LeanChainService` methods by avoiding recursive asynchronous function calls using`mpsc`. (Decoupling the call cycle). Therefore, our `udeps` is much happier right now :)

I also added to log `source_slot` in each vote as this shows the chain finalization much clear.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
