### PR TITLE
feat: add is_proposer from the lean spec

### DIFF
--- a/crates/common/validator/lean/src/lib.rs
+++ b/crates/common/validator/lean/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod service;
+pub mod validator;

--- a/crates/common/validator/lean/src/validator.rs
+++ b/crates/common/validator/lean/src/validator.rs
@@ -1,0 +1,6 @@
+use ream_chain_lean::slot::get_current_slot;
+use ream_consensus_lean::state::LeanState;
+
+pub fn is_proposer(state: &LeanState, validator_index: u64) -> anyhow::Result<bool> {
+    Ok(get_current_slot() % state.config.num_validators == validator_index)
+}


### PR DESCRIPTION
### What was wrong?

Implement is_proposer based on the proposed validator spec.

https://github.com/unnawut/leanSpec/blob/pqdevnet0-md/docs/client/validator.md

### How was it fixed?

Translated the function to rust

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
