### PR TITLE
feat(lean): add ephemery option for dev purpose

### DIFF
--- a/bin/ream/src/cli/lean_node.rs
+++ b/bin/ream/src/cli/lean_node.rs
@@ -13,7 +13,7 @@ pub struct LeanNodeConfig {
 
     #[arg(
       long,
-      help = "Provide a path to a YAML config file",
+      help = "Provide a path to a YAML config file, or use 'ephemery' for the Ephemery network",
       value_parser = lean_network_parser
   )]
     pub network: Arc<LeanNetworkSpec>,

--- a/book/cli/ream/lean_node.md
+++ b/book/cli/ream/lean_node.md
@@ -10,7 +10,7 @@ Usage: ream lean_node [OPTIONS] --network <NETWORK>
 
 Options:
   -v, --verbosity <VERBOSITY>        Verbosity level [default: 3]
-      --network <NETWORK>            Provide a path to a YAML config file
+      --network <NETWORK>            Provide a path to a YAML config file, or use 'ephemery' for the Ephemery network
       --http-address <HTTP_ADDRESS>  Set HTTP address [default: 127.0.0.1]
       --http-port <HTTP_PORT>        Set HTTP Port [default: 5052]
       --http-allow-origin

--- a/crates/common/network_spec/src/cli.rs
+++ b/crates/common/network_spec/src/cli.rs
@@ -15,8 +15,11 @@ pub fn beacon_network_parser(network_string: &str) -> Result<Arc<BeaconNetworkSp
     }
 }
 
-pub fn lean_network_parser(path: &str) -> Result<Arc<LeanNetworkSpec>, String> {
-    read_network_spec(path)
+pub fn lean_network_parser(network_string: &str) -> Result<Arc<LeanNetworkSpec>, String> {
+    match network_string {
+        "ephemery" => Ok(LeanNetworkSpec::ephemery()),
+        path => read_network_spec(path),
+    }
 }
 
 fn read_network_spec<T: DeserializeOwned>(path: &str) -> Result<Arc<T>, String> {

--- a/crates/common/network_spec/src/networks/lean.rs
+++ b/crates/common/network_spec/src/networks/lean.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, OnceLock};
+use std::{
+    sync::{Arc, OnceLock},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use serde::Deserialize;
 
@@ -11,6 +14,23 @@ pub struct LeanNetworkSpec {
     pub genesis_time: u64,
     pub seconds_per_slot: u64,
     pub num_validators: u64,
+}
+
+impl LeanNetworkSpec {
+    /// Creates a new instance of `LeanNetworkSpec` for the Ephemery network
+    /// that starts 3 seconds after the current system time,
+    pub fn ephemery() -> Arc<Self> {
+        let current_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System time is before UNIX epoch")
+            .as_secs();
+
+        Arc::new(Self {
+            genesis_time: current_timestamp + 3,
+            seconds_per_slot: 4,
+            num_validators: 4,
+        })
+    }
 }
 
 /// MUST be called only once at the start of the application to initialize static


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

#679 introduces some hacky code for setting `genesis_time`.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

This PR adds `ephemery` option explicitly so that user can spin up local network with following command:

```
$ cargo run --release lean_node --network ephemery
```

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
