### PR TITLE
chore: bump rust version to 1.89

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         curl -L https://risczero.com/install | bash
         /home/runner/.risc0/bin/rzup install
-        /home/runner/.risc0/bin/rzup install rust 1.88.0
+        /home/runner/.risc0/bin/rzup install rust 1.89.0
         rustup default risc0
         
     - name: Build Risc0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ keywords = [
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ReamLabs/ream"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 version = "0.1.0"
 
 [workspace.dependencies]


### PR DESCRIPTION
### What was wrong?

Rust 1.89 is out.

### How was it fixed?

Changed 1.88 to 1.89 wherever necessary.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
