### PR TITLE
Implement /eth/v2/beacon/pool/attester_slashings

### DIFF
--- a/crates/common/consensus/beacon/src/attester_slashing.rs
+++ b/crates/common/consensus/beacon/src/attester_slashing.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, Hash, TreeHash)]
 pub struct AttesterSlashing {
     pub attestation_1: IndexedAttestation,
     pub attestation_2: IndexedAttestation,

--- a/crates/common/consensus/misc/src/indexed_attestation.rs
+++ b/crates/common/consensus/misc/src/indexed_attestation.rs
@@ -6,7 +6,7 @@ use tree_hash_derive::TreeHash;
 
 use crate::attestation_data::AttestationData;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, Hash, TreeHash)]
 pub struct IndexedAttestation {
     #[serde(with = "quoted_u64_var_list")]
     pub attesting_indices: VariableList<u64, U131072>,

--- a/crates/common/operation_pool/src/lib.rs
+++ b/crates/common/operation_pool/src/lib.rs
@@ -107,7 +107,7 @@ impl OperationPool {
         });
     }
 
-    pub fn insert_attester_slashing(&mut self, slashing: AttesterSlashing) {
+    pub fn insert_attester_slashing(&self, slashing: AttesterSlashing) {
         self.attester_slashings.write().insert(slashing);
     }
 

--- a/crates/common/operation_pool/src/lib.rs
+++ b/crates/common/operation_pool/src/lib.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, map::HashSet};
 use parking_lot::RwLock;
 use ream_consensus_beacon::{
-    bls_to_execution_change::SignedBLSToExecutionChange, electra::beacon_state::BeaconState,
-    voluntary_exit::SignedVoluntaryExit,
+    attester_slashing::AttesterSlashing, bls_to_execution_change::SignedBLSToExecutionChange,
+    electra::beacon_state::BeaconState, voluntary_exit::SignedVoluntaryExit,
 };
 use tree_hash::TreeHash;
 
@@ -19,6 +19,7 @@ pub struct OperationPool {
     signed_voluntary_exits: RwLock<HashMap<u64, SignedVoluntaryExit>>,
     signed_bls_to_execution_changes: RwLock<HashMap<B256, SignedBLSToExecutionChange>>,
     proposer_preparations: RwLock<HashMap<u64, ProposerPreparation>>,
+    attester_slashings: RwLock<HashSet<AttesterSlashing>>,
 }
 
 impl OperationPool {
@@ -104,6 +105,14 @@ impl OperationPool {
             // They persist through the epoch of submission and for 2 more epochs after that
             current_epoch <= preparation.submission_epoch + 2
         });
+    }
+
+    pub fn insert_attester_slashing(&mut self, slashing: AttesterSlashing) {
+        self.attester_slashings.write().insert(slashing);
+    }
+
+    pub fn get_all_attester_slashings(&self) -> Vec<AttesterSlashing> {
+        self.attester_slashings.read().iter().cloned().collect()
     }
 }
 

--- a/crates/crypto/bls/src/signature.rs
+++ b/crates/crypto/bls/src/signature.rs
@@ -5,7 +5,7 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, typenum::U96};
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TreeHash, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Hash, TreeHash, Default)]
 pub struct BLSSignature {
     pub inner: FixedVector<u8, U96>,
 }

--- a/crates/rpc/beacon/src/handlers/pool.rs
+++ b/crates/rpc/beacon/src/handlers/pool.rs
@@ -4,7 +4,11 @@ use actix_web::{
     HttpResponse, Responder, get, post,
     web::{Data, Json},
 };
-use ream_api_types_beacon::{error::ApiError, id::ID, responses::DataResponse};
+use ream_api_types_beacon::{
+    error::ApiError,
+    id::ID,
+    responses::{DataResponse, DataVersionedResponse},
+};
 use ream_consensus_beacon::{
     bls_to_execution_change::SignedBLSToExecutionChange, voluntary_exit::SignedVoluntaryExit,
 };
@@ -97,4 +101,13 @@ pub async fn post_voluntary_exits(
     // TODO: publish voluntary exit to peers (gossipsub) - https://github.com/ReamLabs/ream/issues/556
 
     Ok(HttpResponse::Ok())
+}
+
+/// GET /eth/v2/beacon/pool/attester_slashings
+#[get("/beacon/pool/attester_slashings")]
+pub async fn get_pool_attester_slashings(
+    operation_pool: Data<Arc<OperationPool>>,
+) -> Result<impl Responder, ApiError> {
+    let attester_slashings = operation_pool.get_all_attester_slashings();
+    Ok(HttpResponse::Ok().json(DataVersionedResponse::new(attester_slashings)))
 }

--- a/crates/rpc/beacon/src/routes/beacon.rs
+++ b/crates/rpc/beacon/src/routes/beacon.rs
@@ -12,8 +12,8 @@ use crate::handlers::{
         get_light_client_bootstrap, get_light_client_finality_update, get_light_client_updates,
     },
     pool::{
-        get_bls_to_execution_changes, get_voluntary_exits, post_bls_to_execution_changes,
-        post_voluntary_exits,
+        get_bls_to_execution_changes, get_pool_attester_slashings, get_voluntary_exits,
+        post_bls_to_execution_changes, post_voluntary_exits,
     },
     state::{
         get_pending_consolidations, get_pending_deposits, get_pending_partial_withdrawals,
@@ -64,5 +64,6 @@ pub fn register_beacon_routes(cfg: &mut ServiceConfig) {
 
 pub fn register_beacon_routes_v2(cfg: &mut ServiceConfig) {
     cfg.service(get_block_attestations)
-        .service(get_block_from_id);
+        .service(get_block_from_id)
+        .service(get_pool_attester_slashings);
 }


### PR DESCRIPTION
### What was wrong?
Beacon V2 API endpoints for attester slashings - GET and POST

### How was it fixed?

https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolAttesterSlashingsV2
https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolAttesterSlashingsV2

### To-Do

Right now, the publish support on Gossip Pub Sub is not yet done. Once the implementation is completed, then publishing of attester slashing in the post should be added which is mentioned as a todo comment
 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
