### PR TITLE
feat: add quic support for lean

### DIFF
--- a/bin/ream/src/cli/lean_node.rs
+++ b/bin/ream/src/cli/lean_node.rs
@@ -43,4 +43,7 @@ pub struct LeanNodeConfig {
 
     #[arg(long, default_value_t = DEFAULT_HTTP_ALLOW_ORIGIN)]
     pub http_allow_origin: bool,
+
+    #[arg(long, help = "Enable QUIC")]
+    pub enable_quic: bool,
 }

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -135,6 +135,7 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor) {
         }),
         lean_chain.clone(),
         executor.clone(),
+        config.enable_quic,
     )
     .await
     .expect("Failed to create network service");

--- a/book/cli/ream/lean_node.md
+++ b/book/cli/ream/lean_node.md
@@ -25,6 +25,8 @@ Options:
           Set HTTP Port [default: 5052]
       --http-allow-origin
 
+      --enable-quic
+          Enable QUIC
   -h, --help
           Print help
 ```

--- a/crates/networking/p2p/src/network/beacon.rs
+++ b/crates/networking/p2p/src/network/beacon.rs
@@ -166,7 +166,7 @@ impl Network {
             }
         };
 
-        let transport = build_transport(Keypair::from(local_key.clone()))
+        let transport = build_transport(Keypair::from(local_key.clone()), false)
             .map_err(|err| anyhow!("Failed to build transport: {err:?}"))?;
 
         let swarm = {

--- a/crates/networking/p2p/src/network/lean.rs
+++ b/crates/networking/p2p/src/network/lean.rs
@@ -75,6 +75,7 @@ impl LeanNetworkService {
         network_config: Arc<LeanNetworkConfig>,
         lean_chain: Arc<RwLock<LeanChain>>,
         executor: ReamExecutor,
+        enable_quic: bool,
     ) -> anyhow::Result<Self> {
         let connection_limits = {
             let limits = ConnectionLimits::default()
@@ -117,7 +118,7 @@ impl LeanNetworkService {
             }
         };
 
-        let transport = build_transport(local_key.clone())
+        let transport = build_transport(local_key.clone(), enable_quic)
             .map_err(|err| anyhow!("Failed to build transport: {err:?}"))?;
 
         let swarm = {
@@ -146,9 +147,17 @@ impl LeanNetworkService {
         };
 
         let mut multi_addr: Multiaddr = lean_network_service.network_config.socket_address.into();
-        multi_addr.push(Protocol::Tcp(
-            lean_network_service.network_config.socket_port,
-        ));
+        if enable_quic {
+            multi_addr.push(Protocol::Udp(
+                lean_network_service.network_config.socket_port,
+            ));
+            multi_addr.push(Protocol::QuicV1);
+        } else {
+            multi_addr.push(Protocol::Tcp(
+                lean_network_service.network_config.socket_port,
+            ));
+        }
+        info!("Listening on {multi_addr:?}");
 
         lean_network_service
             .swarm
@@ -199,12 +208,8 @@ impl LeanNetworkService {
                 info!("Disconnected from peer: {peer_id:?}");
                 Some(ReamNetworkEvent::PeerDisconnected(peer_id))
             }
-            SwarmEvent::IncomingConnection {
-                local_addr,
-                send_back_addr,
-                ..
-            } => {
-                info!("Incoming connection from {send_back_addr:?} to {local_addr:?}");
+            SwarmEvent::IncomingConnection { local_addr, .. } => {
+                info!("Incoming connection from {local_addr:?}");
                 None
             }
             SwarmEvent::Dialing { peer_id, .. } => {
@@ -238,11 +243,15 @@ impl LeanNetworkService {
             }
         }
     }
+
+    pub fn local_peer_id(&self) -> PeerId {
+        *self.swarm.local_peer_id()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, time::Duration};
+    use std::{net::Ipv4Addr, sync::Once, time::Duration};
 
     use libp2p::{Multiaddr, multiaddr::Protocol};
     use ream_chain_lean::lean_chain::LeanChain;
@@ -252,40 +261,144 @@ mod tests {
     use super::*;
     use crate::bootnodes::Bootnodes;
 
+    static INIT: Once = Once::new();
+
+    fn ensure_network_spec_init() {
+        INIT.call_once(|| {
+            set_lean_network_spec(LeanNetworkSpec::default().into());
+        });
+    }
+
+    pub async fn setup_lean_node(
+        quic: bool,
+        socket_port: u16,
+    ) -> anyhow::Result<(LeanNetworkService, Multiaddr)> {
+        ensure_network_spec_init();
+
+        let lean_chain = Arc::new(RwLock::new(LeanChain::default()));
+        let executor = ReamExecutor::new();
+        let config = Arc::new(LeanNetworkConfig {
+            gossipsub_config: LeanGossipsubConfig::default(),
+            socket_address: Ipv4Addr::new(127, 0, 0, 1).into(),
+            socket_port,
+        });
+        let node =
+            LeanNetworkService::new(config.clone(), lean_chain, executor.unwrap(), quic).await?;
+        let multi_addr: Multiaddr = config.socket_address.into();
+        Ok((node, multi_addr))
+    }
+
+    // Test to check connection between 2 TCP lean nodes
     #[tokio::test]
     #[traced_test]
-    async fn test_two_lean_nodes_connection() -> anyhow::Result<()> {
-        set_lean_network_spec(LeanNetworkSpec::default().into());
+    async fn test_two_tcp_lean_nodes_connection() -> anyhow::Result<()> {
+        let socket_port1 = 9000;
+        let socket_port2 = 9001;
 
-        let lean_chain1 = Arc::new(RwLock::new(LeanChain::default()));
-        let lean_chain2 = Arc::new(RwLock::new(LeanChain::default()));
+        let (mut node1, mut node1_addr) = setup_lean_node(false, socket_port1).await?;
+        let (mut node2, _) = setup_lean_node(false, socket_port2).await?;
 
-        let executor1 = ReamExecutor::new();
-        let executor2 = ReamExecutor::new();
+        let node1_peer_id = node1.local_peer_id();
+        let node2_peer_id = node2.local_peer_id();
 
-        let config1 = Arc::new(LeanNetworkConfig {
-            gossipsub_config: LeanGossipsubConfig::default(),
-            socket_address: Ipv4Addr::new(127, 0, 0, 1).into(),
-            socket_port: 9000,
+        node1_addr.push(Protocol::Tcp(socket_port1));
+        node1_addr.push(Protocol::P2p(node1_peer_id));
+
+        let node1_handle = tokio::spawn(async move {
+            let bootnodes = Bootnodes::Default;
+
+            node1.start(bootnodes).await.unwrap();
         });
 
-        let config2 = Arc::new(LeanNetworkConfig {
-            gossipsub_config: LeanGossipsubConfig::default(),
-            socket_address: Ipv4Addr::new(127, 0, 0, 1).into(),
-            socket_port: 9001,
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let node2_handle = tokio::spawn(async move {
+            let bootnodes = Bootnodes::Multiaddr(vec![node1_addr]);
+
+            node2.start(bootnodes).await.unwrap();
         });
 
-        let mut node1 =
-            LeanNetworkService::new(config1.clone(), lean_chain1, executor1.unwrap()).await?;
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
-        let mut node2 =
-            LeanNetworkService::new(config2.clone(), lean_chain2, executor2.unwrap()).await?;
+        node1_handle.abort();
+        node2_handle.abort();
 
-        let node1_peer_id = *node1.swarm.local_peer_id();
-        let node2_peer_id = *node2.swarm.local_peer_id();
+        assert!(logs_contain(&format!(
+            "Dialing peer: PeerId(\"{node1_peer_id}\")"
+        )));
+        assert!(logs_contain(&format!(
+            "Connected to peer: PeerId(\"{node1_peer_id}\")"
+        )));
+        assert!(logs_contain(&format!(
+            "Connected to peer: PeerId(\"{node2_peer_id}\")"
+        )));
 
-        let mut node1_addr: Multiaddr = config1.socket_address.into();
-        node1_addr.push(Protocol::Tcp(config1.socket_port));
+        Ok(())
+    }
+
+    // Test to check connection between 2 QUIC lean nodes
+    #[tokio::test]
+    #[traced_test]
+    async fn test_two_quic_lean_nodes_connection() -> anyhow::Result<()> {
+        let socket_port1 = 9002;
+        let socket_port2 = 9003;
+
+        let (mut node1, mut node1_addr) = setup_lean_node(true, socket_port1).await?;
+        let (mut node2, _) = setup_lean_node(true, socket_port2).await?;
+
+        let node1_peer_id = node1.local_peer_id();
+        let node2_peer_id = node2.local_peer_id();
+
+        node1_addr.push(Protocol::Udp(socket_port1));
+        node1_addr.push(Protocol::QuicV1);
+        node1_addr.push(Protocol::P2p(node1_peer_id));
+
+        let node1_handle = tokio::spawn(async move {
+            let bootnodes = Bootnodes::Default;
+
+            node1.start(bootnodes).await.unwrap();
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let node2_handle = tokio::spawn(async move {
+            let bootnodes = Bootnodes::Multiaddr(vec![node1_addr]);
+
+            node2.start(bootnodes).await.unwrap();
+        });
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        node1_handle.abort();
+        node2_handle.abort();
+
+        assert!(logs_contain(&format!(
+            "Dialing peer: PeerId(\"{node1_peer_id}\")"
+        )));
+        assert!(logs_contain(&format!(
+            "Connected to peer: PeerId(\"{node1_peer_id}\")"
+        )));
+        assert!(logs_contain(&format!(
+            "Connected to peer: PeerId(\"{node2_peer_id}\")"
+        )));
+
+        Ok(())
+    }
+
+    // Test to check connection between 1 TCP lean node and 1 QUIC lean node
+    #[tokio::test]
+    #[traced_test]
+    async fn test_quic_tcp_lean_nodes_connection() -> anyhow::Result<()> {
+        let socket_port1 = 9004;
+        let socket_port2 = 9005;
+
+        let (mut node1, mut node1_addr) = setup_lean_node(false, socket_port1).await?;
+        let (mut node2, _) = setup_lean_node(true, socket_port2).await?;
+
+        let node1_peer_id = node1.local_peer_id();
+        let node2_peer_id = node2.local_peer_id();
+
+        node1_addr.push(Protocol::Tcp(socket_port1));
         node1_addr.push(Protocol::P2p(node1_peer_id));
 
         let node1_handle = tokio::spawn(async move {


### PR DESCRIPTION
### What was wrong?

Fixes #697 

### How was it fixed?

- Adds `Quic` support for the `lean_node`
- Nodes can now start in Quic mode by passing `--enable-quic`. If not, by default it runs in TCP mode.
- Nodes can dial and connect with both TCP/QUIC nodes.
- Tests are added for the following cases:
  - `tcp lean node <-> tcp lean node` : 
  - `quic lean node <-> quic lean node`
  - `tcp lean node <-> quic lean node`


### How to run

To run in quic node:
```
cargo run --release lean_node --network ephemery --enable-quic
```

Example of tcp address:
```
/ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmLsfh4CHNEKYx42NGLcVJn5zxpSjnqJ7PsCrUrU6ugAvu
```

Example of quic address:
```
/ip4/127.0.0.1/udp/9003/quic-v1/p2p/16Uiu2HAmLsfh4CHNEKYx42NGLcVJn5zxpSjnqJ7PsCrUrU6ugAvu
```