### PR TITLE
feat: add peer rpc for lean

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,10 +5736,13 @@ name = "ream-rpc-lean"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "libp2p",
  "parking_lot",
  "ream-api-types-beacon",
  "ream-api-types-lean",
  "ream-chain-lean",
+ "ream-p2p",
+ "ream-rpc-beacon",
  "tokio",
  "tracing",
 ]

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -180,6 +180,8 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor) {
     .await
     .expect("Failed to create network service");
 
+    let peer_table = network_service.peer_table();
+
     let keystores = load_validator_registry(&config.validator_registry_path)
         .expect("Failed to load validator registry");
     let validator_service =
@@ -207,8 +209,8 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor) {
             panic!("Validator service exited with error: {err}");
         }
     });
-    let http_future =
-        executor.spawn(async move { start_lean_server(server_config, lean_chain_reader).await });
+    let http_future = executor
+        .spawn(async move { start_lean_server(server_config, lean_chain_reader, peer_table).await });
 
     tokio::select! {
         _ = chain_future => {

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -209,8 +209,9 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor) {
             panic!("Validator service exited with error: {err}");
         }
     });
-    let http_future = executor
-        .spawn(async move { start_lean_server(server_config, lean_chain_reader, peer_table).await });
+    let http_future = executor.spawn(async move {
+        start_lean_server(server_config, lean_chain_reader, peer_table).await
+    });
 
     tokio::select! {
         _ = chain_future => {

--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -16,7 +16,7 @@ use libp2p::{
     swarm::{Config, NetworkBehaviour, Swarm, SwarmEvent},
 };
 use libp2p_identity::{Keypair, PeerId};
-use parking_lot::RwLock as ParkingRwLock;
+use parking_lot::Mutex;
 use ream_chain_lean::{
     lean_chain::LeanChainReader, messages::LeanChainServiceMessage, p2p_request::LeanP2PRequest,
 };
@@ -79,7 +79,7 @@ pub struct LeanNetworkService {
     lean_chain: LeanChainReader,
     network_config: Arc<LeanNetworkConfig>,
     swarm: Swarm<ReamBehaviour>,
-    peer_table: Arc<ParkingRwLock<HashMap<PeerId, ConnectionState>>>,
+    peer_table: Arc<Mutex<HashMap<PeerId, ConnectionState>>>,
     chain_message_sender: UnboundedSender<LeanChainServiceMessage>,
     outbound_p2p_request: UnboundedReceiver<LeanP2PRequest>,
 }
@@ -152,7 +152,7 @@ impl LeanNetworkService {
             lean_chain,
             network_config: network_config.clone(),
             swarm,
-            peer_table: Arc::new(ParkingRwLock::new(HashMap::new())),
+            peer_table: Arc::new(Mutex::new(HashMap::new())),
             chain_message_sender,
             outbound_p2p_request,
         };
@@ -260,15 +260,17 @@ impl LeanNetworkService {
             }
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 self.peer_table
-                    .write()
+                    .lock()
                     .insert(peer_id, ConnectionState::Connected);
+
                 info!("Connected to peer: {peer_id:?}");
                 None
             }
             SwarmEvent::ConnectionClosed { peer_id, .. } => {
                 self.peer_table
-                    .write()
+                    .lock()
                     .insert(peer_id, ConnectionState::Disconnected);
+
                 info!("Disconnected from peer: {peer_id:?}");
                 Some(ReamNetworkEvent::PeerDisconnected(peer_id))
             }
@@ -346,13 +348,13 @@ impl LeanNetworkService {
             {
                 info!("Dialing peer: {peer_id:?}",);
                 self.peer_table
-                    .write()
+                    .lock()
                     .insert(peer_id, ConnectionState::Connecting);
             }
         }
     }
 
-    pub fn peer_table(&self) -> Arc<ParkingRwLock<HashMap<PeerId, ConnectionState>>> {
+    pub fn peer_table(&self) -> Arc<Mutex<HashMap<PeerId, ConnectionState>>> {
         self.peer_table.clone()
     }
 

--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -79,7 +79,7 @@ pub struct LeanNetworkService {
     lean_chain: LeanChainReader,
     network_config: Arc<LeanNetworkConfig>,
     swarm: Swarm<ReamBehaviour>,
-    peer_table: ParkingRwLock<HashMap<PeerId, ConnectionState>>,
+    peer_table: Arc<ParkingRwLock<HashMap<PeerId, ConnectionState>>>,
     chain_message_sender: UnboundedSender<LeanChainServiceMessage>,
     outbound_p2p_request: UnboundedReceiver<LeanP2PRequest>,
 }
@@ -152,7 +152,7 @@ impl LeanNetworkService {
             lean_chain,
             network_config: network_config.clone(),
             swarm,
-            peer_table: ParkingRwLock::new(HashMap::new()),
+            peer_table: Arc::new(ParkingRwLock::new(HashMap::new())),
             chain_message_sender,
             outbound_p2p_request,
         };
@@ -350,6 +350,10 @@ impl LeanNetworkService {
                     .insert(peer_id, ConnectionState::Connecting);
             }
         }
+    }
+
+    pub fn peer_table(&self) -> Arc<ParkingRwLock<HashMap<PeerId, ConnectionState>>> {
+        self.peer_table.clone()
     }
 
     pub fn local_peer_id(&self) -> PeerId {

--- a/crates/rpc/beacon/src/handlers/peers.rs
+++ b/crates/rpc/beacon/src/handlers/peers.rs
@@ -56,7 +56,7 @@ pub async fn get_peer_count(
     Ok(HttpResponse::Ok().json(DataResponse::new(peer_count)))
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Default, Debug, Clone, Serialize)]
 pub struct PeerCount {
     #[serde(with = "serde_utils::quoted_u64")]
     pub disconnected: u64,

--- a/crates/rpc/beacon/src/handlers/peers.rs
+++ b/crates/rpc/beacon/src/handlers/peers.rs
@@ -59,13 +59,13 @@ pub async fn get_peer_count(
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct PeerCount {
     #[serde(with = "serde_utils::quoted_u64")]
-    disconnected: u64,
+    pub disconnected: u64,
     #[serde(with = "serde_utils::quoted_u64")]
-    connecting: u64,
+    pub connecting: u64,
     #[serde(with = "serde_utils::quoted_u64")]
-    connected: u64,
+    pub connected: u64,
     #[serde(with = "serde_utils::quoted_u64")]
-    disconnecting: u64,
+    pub disconnecting: u64,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/crates/rpc/lean/Cargo.toml
+++ b/crates/rpc/lean/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 
 [dependencies]
 actix-web.workspace = true
+libp2p.workspace = true
 parking_lot.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -19,3 +20,5 @@ tracing.workspace = true
 ream-api-types-beacon.workspace = true
 ream-api-types-lean.workspace = true
 ream-chain-lean.workspace = true
+ream-p2p.workspace = true
+ream-rpc-beacon.workspace = true

--- a/crates/rpc/lean/src/handlers/mod.rs
+++ b/crates/rpc/lean/src/handlers/mod.rs
@@ -1,1 +1,2 @@
 pub mod head;
+pub mod peer;

--- a/crates/rpc/lean/src/handlers/peer.rs
+++ b/crates/rpc/lean/src/handlers/peer.rs
@@ -2,42 +2,34 @@ use std::{collections::HashMap, sync::Arc};
 
 use actix_web::{HttpResponse, Responder, get, web::Data};
 use libp2p::PeerId;
-use parking_lot::RwLock;
+use parking_lot::Mutex;
 use ream_api_types_beacon::error::ApiError;
-use ream_p2p::peer::ConnectionState;
+use ream_p2p::network::peer::ConnectionState;
 use ream_rpc_beacon::handlers::peers::PeerCount;
 
 // /lean/v0/node/peers
 #[get("/node/peers")]
 pub async fn list_peers(
-    peer_table: Data<Arc<RwLock<HashMap<PeerId, ConnectionState>>>>,
+    peer_table: Data<Arc<Mutex<HashMap<PeerId, ConnectionState>>>>,
 ) -> Result<impl Responder, ApiError> {
-    Ok(HttpResponse::Ok().json(peer_table.read().clone()))
+    Ok(HttpResponse::Ok().json(peer_table.lock().clone()))
 }
 
-// /lean/v0/node/peers
+// /lean/v0/node/peer_count
 #[get("/node/peer_count")]
 pub async fn get_peer_count(
-    peer_table: Data<Arc<RwLock<HashMap<PeerId, ConnectionState>>>>,
+    peer_table: Data<Arc<Mutex<HashMap<PeerId, ConnectionState>>>>,
 ) -> Result<impl Responder, ApiError> {
-    let mut connected = 0;
-    let mut connecting = 0;
-    let mut disconnected = 0;
-    let mut disconnecting = 0;
+    let mut peer_count = PeerCount::default();
 
-    for connection_state in peer_table.read().values() {
+    for connection_state in peer_table.lock().values() {
         match connection_state {
-            ConnectionState::Connected => connected += 1,
-            ConnectionState::Connecting => connecting += 1,
-            ConnectionState::Disconnected => disconnected += 1,
-            ConnectionState::Disconnecting => disconnecting += 1,
+            ConnectionState::Connected => peer_count.connected += 1,
+            ConnectionState::Connecting => peer_count.connecting += 1,
+            ConnectionState::Disconnected => peer_count.disconnected += 1,
+            ConnectionState::Disconnecting => peer_count.disconnecting += 1,
         }
     }
 
-    Ok(HttpResponse::Ok().json(&PeerCount {
-        connected,
-        connecting,
-        disconnected,
-        disconnecting,
-    }))
+    Ok(HttpResponse::Ok().json(&peer_count))
 }

--- a/crates/rpc/lean/src/handlers/peer.rs
+++ b/crates/rpc/lean/src/handlers/peer.rs
@@ -1,0 +1,43 @@
+use std::{collections::HashMap, sync::Arc};
+
+use actix_web::{HttpResponse, Responder, get, web::Data};
+use libp2p::PeerId;
+use parking_lot::RwLock;
+use ream_api_types_beacon::error::ApiError;
+use ream_p2p::peer::ConnectionState;
+use ream_rpc_beacon::handlers::peers::PeerCount;
+
+// /lean/v0/node/peers
+#[get("/node/peers")]
+pub async fn list_peers(
+    peer_table: Data<Arc<RwLock<HashMap<PeerId, ConnectionState>>>>,
+) -> Result<impl Responder, ApiError> {
+    Ok(HttpResponse::Ok().json(peer_table.read().clone()))
+}
+
+// /lean/v0/node/peers
+#[get("/node/peer_count")]
+pub async fn get_peer_count(
+    peer_table: Data<Arc<RwLock<HashMap<PeerId, ConnectionState>>>>,
+) -> Result<impl Responder, ApiError> {
+    let mut connected = 0;
+    let mut connecting = 0;
+    let mut disconnected = 0;
+    let mut disconnecting = 0;
+
+    for connection_state in peer_table.read().values() {
+        match connection_state {
+            ConnectionState::Connected => connected += 1,
+            ConnectionState::Connecting => connecting += 1,
+            ConnectionState::Disconnected => disconnected += 1,
+            ConnectionState::Disconnecting => disconnecting += 1,
+        }
+    }
+
+    Ok(HttpResponse::Ok().json(&PeerCount {
+        connected,
+        connecting,
+        disconnected,
+        disconnecting,
+    }))
+}

--- a/crates/rpc/lean/src/lib.rs
+++ b/crates/rpc/lean/src/lib.rs
@@ -2,13 +2,14 @@ pub mod config;
 pub mod handlers;
 pub mod routes;
 
+use std::{collections::HashMap, sync::Arc};
+
 use actix_web::{App, HttpServer, middleware, web::Data};
 use config::LeanRpcServerConfig;
 use libp2p::PeerId;
-use parking_lot::RwLock as ParkingRwLock;
-use ream_chain_lean::lean_chain::LeanChain;
-use ream_p2p::peer::ConnectionState;
-use tokio::sync::RwLock;
+use parking_lot::Mutex;
+use ream_chain_lean::lean_chain::LeanChainReader;
+use ream_p2p::network::peer::ConnectionState;
 use tracing::info;
 
 use crate::routes::register_routers;
@@ -17,7 +18,7 @@ use crate::routes::register_routers;
 pub async fn start_lean_server(
     server_config: LeanRpcServerConfig,
     lean_chain: LeanChainReader,
-    peer_table: Arc<ParkingRwLock<HashMap<PeerId, ConnectionState>>>,
+    peer_table: Arc<Mutex<HashMap<PeerId, ConnectionState>>>,
 ) -> std::io::Result<()> {
     info!(
         "starting HTTP server on {:?}",

--- a/crates/rpc/lean/src/routes/mod.rs
+++ b/crates/rpc/lean/src/routes/mod.rs
@@ -1,8 +1,13 @@
 pub mod lean;
+pub mod node;
 use actix_web::web::{ServiceConfig, scope};
 
 pub fn get_v0_routes(config: &mut ServiceConfig) {
-    config.service(scope("/lean/v0").configure(lean::register_lean_routes));
+    config.service(
+        scope("/lean/v0")
+            .configure(lean::register_lean_routes)
+            .configure(node::register_node_routes),
+    );
 }
 
 pub fn register_routers(config: &mut ServiceConfig) {

--- a/crates/rpc/lean/src/routes/node.rs
+++ b/crates/rpc/lean/src/routes/node.rs
@@ -1,0 +1,8 @@
+use actix_web::web::ServiceConfig;
+
+use crate::handlers::peer::{get_peer_count, list_peers};
+
+/// Creates and returns all `/node` routes.
+pub fn register_node_routes(cfg: &mut ServiceConfig) {
+    cfg.service(get_peer_count).service(list_peers);
+}


### PR DESCRIPTION
### What was wrong?

Fixes #714 
### How was it fixed?

- Adds RPC support for fetching peer data for `lean_node`
- Currently 2 endpoints have been added:
  - `/lean/v0/node/peers`: to get list of all peers
  - `/lean/v0/node/peer_count`: to get connection state
- Tried and tested with local nodes
