### PR TITLE
feat: remove mutating LeanChain from Validator, add exclusive writer multi reader primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,6 +5229,7 @@ dependencies = [
  "ream-rpc-beacon",
  "ream-rpc-lean",
  "ream-storage",
+ "ream-sync",
  "ream-validator-beacon",
  "ream-validator-lean",
  "tokio",
@@ -5331,6 +5332,7 @@ dependencies = [
  "ream-metrics",
  "ream-network-spec",
  "ream-pqc",
+ "ream-sync",
  "serde",
  "ssz_types",
  "tokio",
@@ -5654,6 +5656,7 @@ dependencies = [
  "ream-executor",
  "ream-light-client",
  "ream-network-spec",
+ "ream-sync",
  "ream-validator-beacon",
  "serde",
  "serde_yaml",
@@ -5785,6 +5788,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ream-sync"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "ream-syncer"
 version = "0.1.0"
 dependencies = [
@@ -5850,6 +5860,7 @@ dependencies = [
  "ream-consensus-lean",
  "ream-consensus-misc",
  "ream-network-spec",
+ "ream-sync",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/common/node",
     "crates/common/operation_pool",
     "crates/common/polynomial_commitments",
+    "crates/common/sync",
     "crates/common/validator/beacon",
     "crates/common/validator/lean",
     "crates/crypto/bls",
@@ -147,6 +148,7 @@ ream-pqc = { path = "crates/crypto/pqc" }
 ream-rpc-beacon = { path = "crates/rpc/beacon" }
 ream-rpc-lean = { path = "crates/rpc/lean" }
 ream-storage = { path = "crates/storage" }
+ream-sync = { path = "crates/common/sync" }
 ream-syncer = { path = "crates/networking/syncer" }
 ream-validator-beacon = { path = "crates/common/validator/beacon" }
 ream-validator-lean = { path = "crates/common/validator/lean" }

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -48,5 +48,6 @@ ream-p2p.workspace = true
 ream-rpc-beacon.workspace = true
 ream-rpc-lean.workspace = true
 ream-storage.workspace = true
+ream-sync.workspace = true
 ream-validator-beacon.workspace = true
 ream-validator-lean.workspace = true

--- a/crates/common/chain/lean/Cargo.toml
+++ b/crates/common/chain/lean/Cargo.toml
@@ -24,3 +24,4 @@ ream-consensus-misc.workspace = true
 ream-metrics.workspace = true
 ream-network-spec.workspace = true
 ream-pqc.workspace = true
+ream-sync.workspace = true

--- a/crates/common/chain/lean/src/lib.rs
+++ b/crates/common/chain/lean/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod clock;
 pub mod genesis;
 pub mod lean_chain;
+pub mod messages;
 pub mod service;
 pub mod slot;

--- a/crates/common/chain/lean/src/messages.rs
+++ b/crates/common/chain/lean/src/messages.rs
@@ -1,0 +1,33 @@
+use ream_consensus_lean::{VoteItem, block::Block};
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+
+#[derive(Debug)]
+pub enum LeanChainServiceMessage {
+    ProduceBlock(ProduceBlockMessage),
+    QueueItem(QueueItem),
+}
+
+impl LeanChainServiceMessage {
+    pub fn produce_block(slot: u64, response: oneshot::Sender<Block>) -> Self {
+        LeanChainServiceMessage::ProduceBlock(ProduceBlockMessage::new(slot, response))
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum QueueItem {
+    Block(Block),
+    Vote(VoteItem),
+}
+
+#[derive(Debug)]
+pub struct ProduceBlockMessage {
+    pub slot: u64,
+    pub response: oneshot::Sender<Block>,
+}
+
+impl ProduceBlockMessage {
+    pub fn new(slot: u64, response: oneshot::Sender<Block>) -> Self {
+        ProduceBlockMessage { slot, response }
+    }
+}

--- a/crates/common/consensus/lean/src/lib.rs
+++ b/crates/common/consensus/lean/src/lib.rs
@@ -23,12 +23,6 @@ pub enum VoteItem {
     Unsigned(Vote),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum QueueItem {
-    BlockItem(Block),
-    VoteItem(VoteItem),
-}
-
 /// We allow justification of slots either <= 5 or a perfect square or oblong after
 /// the latest finalized slot. This gives us a backoff technique and ensures
 /// finality keeps progressing even under high latency

--- a/crates/common/sync/Cargo.toml
+++ b/crates/common/sync/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ream-sync"
+description = "This crate is for rust synchronization primitives"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+tokio.workspace = true

--- a/crates/common/sync/src/lib.rs
+++ b/crates/common/sync/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod rwlock;

--- a/crates/common/sync/src/rwlock.rs
+++ b/crates/common/sync/src/rwlock.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+#[derive(Clone)]
+pub struct Reader<T>(Arc<RwLock<T>>);
+
+pub struct Writer<T>(Arc<RwLock<T>>);
+
+impl<T> Writer<T> {
+    pub fn new(value: T) -> (Self, Reader<T>) {
+        let arc = Arc::new(RwLock::new(value));
+        (Self(arc.clone()), Reader(arc))
+    }
+
+    pub async fn read(&self) -> RwLockReadGuard<'_, T> {
+        self.0.read().await
+    }
+
+    pub async fn write(&self) -> RwLockWriteGuard<'_, T> {
+        self.0.write().await
+    }
+
+    pub fn reader(&self) -> Reader<T> {
+        Reader(self.0.clone())
+    }
+}
+
+impl<T> Reader<T> {
+    pub async fn read(&self) -> RwLockReadGuard<'_, T> {
+        self.0.read().await
+    }
+}

--- a/crates/common/validator/lean/Cargo.toml
+++ b/crates/common/validator/lean/Cargo.toml
@@ -19,3 +19,4 @@ ream-chain-lean.workspace = true
 ream-consensus-lean.workspace = true
 ream-consensus-misc.workspace = true
 ream-network-spec.workspace = true
+ream-sync.workspace = true

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -48,4 +48,5 @@ ream-discv5.workspace = true
 ream-executor.workspace = true
 ream-light-client.workspace = true
 ream-network-spec.workspace = true
+ream-sync.workspace = true
 ream-validator-beacon.workspace = true

--- a/crates/rpc/lean/src/lib.rs
+++ b/crates/rpc/lean/src/lib.rs
@@ -1,9 +1,6 @@
-use std::sync::Arc;
-
 use actix_web::{App, HttpServer, middleware, web::Data};
 use config::LeanRpcServerConfig;
-use ream_chain_lean::lean_chain::LeanChain;
-use tokio::sync::RwLock;
+use ream_chain_lean::lean_chain::LeanChainReader;
 use tracing::info;
 
 use crate::routes::register_routers;
@@ -15,7 +12,7 @@ pub mod routes;
 /// Start the Lean API server.
 pub async fn start_lean_server(
     server_config: LeanRpcServerConfig,
-    lean_chain: Arc<RwLock<LeanChain>>,
+    lean_chain: LeanChainReader,
 ) -> std::io::Result<()> {
     info!(
         "starting HTTP server on {:?}",


### PR DESCRIPTION
### What was wrong?

fixes https://github.com/ReamLabs/ream/issues/728

The validator was modifying the LeanChain directly, which is quite a bit of a overreach for it. Also there was comments in the Validator saying it would directly access P2P.

I don't think 
- the Validator should be able to modify the LeanChain
- the validator shouldn't be able to directly interact with P2P

### How was it fixed?

Add `Writer`/`Reader` primitives so that different parts of the codebase can access the `LeanChain`, but not modify it if they aren't supposed to. Like the `Validator` it is the `LeanChainServices`'s job to modify the LeanChain, it is the `Validator`'s job to propose and vote on new blocks.

I modified the code so only the `LeanChainService` can modify the LeanChain, but we can have global readers of the LeanChain
