### PR TITLE
fix(account_manager): panicking bug for wrong lifetime setup & log the key_gen time

### DIFF
--- a/bin/ream/src/cli/account_manager.rs
+++ b/bin/ream/src/cli/account_manager.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 const MIN_CHUNK_SIZE: u64 = 4;
 const MIN_LIFETIME: u64 = 18;
 const DEFAULT_ACTIVATION_EPOCH: usize = 0;
-const DEFAULT_NUM_ACTIVE_EPOCHS: usize = 1 << 28;
+const DEFAULT_NUM_ACTIVE_EPOCHS: usize = 1 << 18;
 
 #[derive(Debug, Parser)]
 pub struct AccountManagerConfig {
@@ -13,7 +13,7 @@ pub struct AccountManagerConfig {
     pub verbosity: u8,
 
     /// Account lifetime in 2 ** lifetime slots
-    #[arg(short, long, default_value_t = 28)]
+    #[arg(short, long, default_value_t = 18)]
     pub lifetime: u64,
 
     /// Chunk size for messages
@@ -37,7 +37,7 @@ impl Default for AccountManagerConfig {
     fn default() -> Self {
         Self {
             verbosity: 3,
-            lifetime: 28,
+            lifetime: 18,
             chunk_size: 5,
             seed_phrase: None,
             activation_epoch: DEFAULT_ACTIVATION_EPOCH,

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -53,7 +53,7 @@ use ream_validator_beacon::{
     voluntary_exit::process_voluntary_exit,
 };
 use ream_validator_lean::service::ValidatorService as LeanValidatorService;
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time::Instant};
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
@@ -376,11 +376,17 @@ pub async fn run_account_manager(mut config: AccountManagerConfig) {
     );
 
     let seed_phrase = config.get_seed_phrase();
+
+    // Measure key generation time
+    let start_time = Instant::now();
     let (_public_key, _private_key) = ream_account_manager::generate_keys(
         &seed_phrase,
         config.activation_epoch,
         config.num_active_epochs,
     );
+    let duration = start_time.elapsed();
+    info!("Key generation complete, took {:?}", duration);
+
     info!("Account manager completed successfully");
 }
 

--- a/book/cli/ream/account_manager.md
+++ b/book/cli/ream/account_manager.md
@@ -10,10 +10,10 @@ Usage: ream account_manager [OPTIONS]
 
 Options:
   -v, --verbosity <VERBOSITY>                  Verbosity level [default: 3]
-  -l, --lifetime <LIFETIME>                    Account lifetime in 2 ** lifetime slots [default: 28]
+  -l, --lifetime <LIFETIME>                    Account lifetime in 2 ** lifetime slots [default: 18]
   -c, --chunk-size <CHUNK_SIZE>                Chunk size for messages [default: 5]
   -s, --seed-phrase <SEED_PHRASE>              Seed phrase for key generation
       --activation-epoch <ACTIVATION_EPOCH>    Activation epoch for the validator [default: 0]
-      --num-active-epochs <NUM_ACTIVE_EPOCHS>  Number of active epochs [default: 268435456]
+      --num-active-epochs <NUM_ACTIVE_EPOCHS>  Number of active epochs [default: 262144]
   -h, --help                                   Print help
 ```

--- a/crates/common/account_manager/src/lib.rs
+++ b/crates/common/account_manager/src/lib.rs
@@ -9,19 +9,15 @@ pub fn generate_keys(
     activation_epoch: usize,
     num_active_epochs: usize,
 ) -> (PublicKey, PrivateKey) {
-    info!("Generating lean consensus validator keys.....");
+    info!(
+        "Generating lean consensus validator keys  with activation_epoch={activation_epoch}, num_active_epochs={num_active_epochs}....."
+    );
 
     // Hash the seed phrase to get a 32-byte seed
     let mut hasher = Sha256::new();
     hasher.update(seed_phrase.as_bytes());
     let seed = hasher.finalize().into();
     info!("Seed: {seed:?}");
-
-    info!(
-        "Generating hash-based signature key pair with activation_epoch={activation_epoch}, num_active_epochs={num_active_epochs}"
-    );
-
-    info!("Key generation complete");
 
     PrivateKey::generate(
         &mut <ChaCha20Rng as SeedableRng>::from_seed(seed),


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

```
cargo run --release account_manager
```

Above command is panicking, with wrong logs.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

- Make default lifetime as `18`. I'm not sure where `28` came from, but I think our codebase is using `SIGWinternitzLifetime18W4` right now, I made it lower.
- Better logging, including with the time measurement.

- Note: `SIGWinternitzLifetime18W4` should be replaced with other IE scheme. We won't use basic `WinternitzEncoding` because it doesn't have the best performance regarding signature size and signing time.
  - Also see the current version of `leanSpec`: https://github.com/leanEthereum/leanSpec/blob/e9bb80cb5fef3b6a1a2aae009a37cf86f002e431/src/lean_spec/subspecs/xmss/constants.py#L37-L52

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
