### PR TITLE
chore: align lean specification with e9bb80

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -154,11 +154,11 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor) {
     let topics: Vec<LeanGossipTopic> = vec![
         LeanGossipTopic {
             fork: fork.clone(),
-            kind: LeanGossipTopicKind::LeanBlock,
+            kind: LeanGossipTopicKind::Block,
         },
         LeanGossipTopic {
             fork,
-            kind: LeanGossipTopicKind::LeanVote,
+            kind: LeanGossipTopicKind::Vote,
         },
     ];
 

--- a/crates/common/chain/lean/src/genesis.rs
+++ b/crates/common/chain/lean/src/genesis.rs
@@ -13,15 +13,19 @@ fn genesis_block(state_root: B256) -> Block {
     }
 }
 
-fn genesis_state(num_validators: u64) -> LeanState {
-    LeanState::new(num_validators)
+fn genesis_state(num_validators: u64, genesis_time: u64) -> LeanState {
+    LeanState::new(num_validators, genesis_time)
 }
 
 /// Setup the genesis block and state for the Lean chain.
 ///
 /// Reference: https://github.com/ethereum/research/blob/d225a6775a9b184b5c1fd6c830cc58a375d9535f/3sf-mini/test_p2p.py#L119-L131
 pub fn setup_genesis() -> (Block, LeanState) {
-    let mut genesis_state = genesis_state(lean_network_spec().num_validators);
+    let (num_validators, genesis_time) = {
+        let network_spec = lean_network_spec();
+        (network_spec.num_validators, network_spec.genesis_time)
+    };
+    let mut genesis_state = genesis_state(num_validators, genesis_time);
     genesis_state
         .historical_block_hashes
         .push(B256::ZERO)

--- a/crates/common/chain/lean/src/genesis.rs
+++ b/crates/common/chain/lean/src/genesis.rs
@@ -1,15 +1,19 @@
 use alloy_primitives::B256;
-use ream_consensus_lean::{block::Block, state::LeanState};
+use ream_consensus_lean::{
+    block::{Block, BlockBody},
+    state::LeanState,
+};
 use ream_network_spec::networks::lean_network_spec;
-use ssz_types::VariableList;
 use tree_hash::TreeHash;
 
 fn genesis_block(state_root: B256) -> Block {
     Block {
         slot: 1,
-        parent: B256::ZERO,
-        votes: VariableList::empty(),
+        // Round-robin proposer selection for genesis
+        proposer_index: 1,
+        parent_root: B256::ZERO,
         state_root,
+        body: BlockBody::default(),
     }
 }
 

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -134,7 +134,7 @@ impl LeanChainService {
                 let block_hash = block.tree_hash_root();
                 info!(
                     "Received block at slot {} with hash {block_hash:?} from parent {:?}",
-                    block.slot, block.parent
+                    block.slot, block.parent_root
                 );
                 self.handle_block(block).await
             }
@@ -170,11 +170,11 @@ impl LeanChainService {
             return Ok(());
         }
 
-        match lean_chain.post_states.get(&block.parent) {
+        match lean_chain.post_states.get(&block.parent_root) {
             Some(parent_state) => {
                 let state = process_block(parent_state, &block)?;
 
-                for vote in &block.votes {
+                for vote in &block.body.votes {
                     if !lean_chain.known_votes.contains(vote) {
                         lean_chain.known_votes.push(vote.clone());
                     }
@@ -199,7 +199,7 @@ impl LeanChainService {
                 // If we have not yet seen the block's parent, ignore for now,
                 // process later once we actually see the parent
                 self.dependencies
-                    .entry(block.parent)
+                    .entry(block.parent_root)
                     .or_default()
                     .push(QueueItem::Block(block));
             }

--- a/crates/common/consensus/lean/src/block.rs
+++ b/crates/common/consensus/lean/src/block.rs
@@ -7,12 +7,20 @@ use tree_hash_derive::TreeHash;
 
 use crate::vote::Vote;
 
+/// Represents a signed block in the Lean chain.
+///
+/// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#signedblock)
+/// for detailed protocol information.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct SignedBlock {
     pub message: Block,
     pub signature: PQSignature,
 }
 
+/// Represents a block in the Lean chain.
+///
+/// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#block)
+/// for detailed protocol information.
 #[derive(
     Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash,
 )]
@@ -26,6 +34,10 @@ pub struct Block {
     pub body: BlockBody,
 }
 
+/// Represents the body of a block in the Lean chain.
+///
+/// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#blockbody)
+/// for detailed protocol information.
 #[derive(
     Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash,
 )]

--- a/crates/common/consensus/lean/src/block.rs
+++ b/crates/common/consensus/lean/src/block.rs
@@ -9,7 +9,7 @@ use crate::vote::Vote;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct SignedBlock {
-    pub data: Block,
+    pub message: Block,
     pub signature: PQSignature,
 }
 
@@ -18,9 +18,17 @@ pub struct SignedBlock {
 )]
 pub struct Block {
     pub slot: u64,
+    pub proposer_index: u64,
     // Diverged from Python implementation: Disallow `None` (uses `B256::ZERO` instead)
-    pub parent: B256,
-    pub votes: VariableList<Vote, U4096>,
+    pub parent_root: B256,
     // Diverged from Python implementation: Disallow `None` (uses `B256::ZERO` instead)
     pub state_root: B256,
+    pub body: BlockBody,
+}
+
+#[derive(
+    Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash,
+)]
+pub struct BlockBody {
+    pub votes: VariableList<Vote, U4096>,
 }

--- a/crates/common/consensus/lean/src/checkpoint.rs
+++ b/crates/common/consensus/lean/src/checkpoint.rs
@@ -3,6 +3,10 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
+/// Represents a checkpoint in the Lean chain.
+///
+/// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#checkpoint)
+/// for detailed protocol information.
 #[derive(
     Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash,
 )]

--- a/crates/common/consensus/lean/src/config.rs
+++ b/crates/common/consensus/lean/src/config.rs
@@ -5,4 +5,5 @@ use tree_hash_derive::TreeHash;
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct Config {
     pub num_validators: u64,
+    pub genesis_time: u64,
 }

--- a/crates/common/consensus/lean/src/config.rs
+++ b/crates/common/consensus/lean/src/config.rs
@@ -2,6 +2,10 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
+/// Configuration for the Lean chain.
+///
+/// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#config)
+/// for detailed protocol information.
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct Config {
     pub num_validators: u64,

--- a/crates/common/consensus/lean/src/vote.rs
+++ b/crates/common/consensus/lean/src/vote.rs
@@ -5,12 +5,20 @@ use tree_hash_derive::TreeHash;
 
 use crate::checkpoint::Checkpoint;
 
+/// Represents a signed vote in the Lean chain.
+///
+/// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#signedvote)
+/// for detailed protocol information.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct SignedVote {
     pub data: Vote,
     pub signature: PQSignature,
 }
 
+/// Represents a vote in the Lean chain.
+///
+/// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#vote)
+/// for detailed protocol information.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct Vote {
     pub validator_id: u64,

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -93,8 +93,8 @@ impl ValidatorService {
                                     "Validator {} built block: slot={}, parent={:?}, votes={}, state_root={:?}",
                                     keystore.id,
                                     new_block.slot,
-                                    new_block.parent,
-                                    new_block.votes.len(),
+                                    new_block.parent_root,
+                                    new_block.body.votes.len(),
                                     new_block.state_root
                                 );
 

--- a/crates/networking/p2p/src/gossipsub/lean/configurations.rs
+++ b/crates/networking/p2p/src/gossipsub/lean/configurations.rs
@@ -27,7 +27,7 @@ impl Default for LeanGossipsubConfig {
             .mesh_n_low(6)
             .mesh_n_high(12)
             .gossip_lazy(6)
-            .history_length(12)
+            .history_length(6)
             .history_gossip(3)
             .max_messages_per_rpc(Some(500))
             .duplicate_cache_time(Duration::from_secs(

--- a/crates/networking/p2p/src/gossipsub/lean/message.rs
+++ b/crates/networking/p2p/src/gossipsub/lean/message.rs
@@ -14,10 +14,10 @@ pub enum LeanGossipsubMessage {
 impl LeanGossipsubMessage {
     pub fn decode(topic: &TopicHash, data: &[u8]) -> Result<Self, GossipsubError> {
         match LeanGossipTopic::from_topic_hash(topic)?.kind {
-            LeanGossipTopicKind::LeanBlock => {
+            LeanGossipTopicKind::Block => {
                 Ok(Self::Block(Box::new(SignedBlock::from_ssz_bytes(data)?)))
             }
-            LeanGossipTopicKind::LeanVote => {
+            LeanGossipTopicKind::Vote => {
                 Ok(Self::Vote(Box::new(SignedVote::from_ssz_bytes(data)?)))
             }
         }

--- a/crates/networking/p2p/src/gossipsub/lean/topics.rs
+++ b/crates/networking/p2p/src/gossipsub/lean/topics.rs
@@ -6,8 +6,8 @@ use crate::gossipsub::error::GossipsubError;
 
 pub const TOPIC_PREFIX: &str = "leanconsensus";
 pub const ENCODING_POSTFIX: &str = "ssz_snappy";
-pub const LEAN_BLOCK_TOPIC: &str = "lean_block";
-pub const LEAN_VOTE_TOPIC: &str = "lean_vote";
+pub const LEAN_BLOCK_TOPIC: &str = "block";
+pub const LEAN_VOTE_TOPIC: &str = "vote";
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct LeanGossipTopic {
@@ -30,8 +30,8 @@ impl LeanGossipTopic {
 
         let fork = topic_parts[1].to_string();
         let kind = match topic_parts[2] {
-            LEAN_BLOCK_TOPIC => LeanGossipTopicKind::LeanBlock,
-            LEAN_VOTE_TOPIC => LeanGossipTopicKind::LeanVote,
+            LEAN_BLOCK_TOPIC => LeanGossipTopicKind::Block,
+            LEAN_VOTE_TOPIC => LeanGossipTopicKind::Vote,
             other => {
                 return Err(GossipsubError::InvalidTopic(format!(
                     "Invalid topic: {other:?}"
@@ -71,8 +71,8 @@ impl From<LeanGossipTopic> for String {
 impl From<LeanGossipTopic> for TopicHash {
     fn from(val: LeanGossipTopic) -> Self {
         let kind_str = match &val.kind {
-            LeanBlock => LEAN_BLOCK_TOPIC,
-            LeanVote => LEAN_VOTE_TOPIC,
+            Block => LEAN_BLOCK_TOPIC,
+            Vote => LEAN_VOTE_TOPIC,
         };
         TopicHash::from_raw(format!(
             "/{}/{}/{}/{}",
@@ -86,15 +86,15 @@ impl From<LeanGossipTopic> for TopicHash {
 
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
 pub enum LeanGossipTopicKind {
-    LeanBlock,
-    LeanVote,
+    Block,
+    Vote,
 }
 
 impl std::fmt::Display for LeanGossipTopicKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LeanGossipTopicKind::LeanBlock => write!(f, "{LEAN_BLOCK_TOPIC}"),
-            LeanGossipTopicKind::LeanVote => write!(f, "{LEAN_VOTE_TOPIC}"),
+            LeanGossipTopicKind::Block => write!(f, "{LEAN_BLOCK_TOPIC}"),
+            LeanGossipTopicKind::Vote => write!(f, "{LEAN_VOTE_TOPIC}"),
         }
     }
 }

--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -206,7 +206,7 @@ impl LeanNetworkService {
                                         .gossipsub_config
                                         .topics
                                         .iter()
-                                        .find(|block_topic| matches!(block_topic.kind, LeanGossipTopicKind::LeanBlock))
+                                        .find(|block_topic| matches!(block_topic.kind, LeanGossipTopicKind::Block))
                                         .map(|block_topic| IdentTopic::from(block_topic.clone()))
                                         .expect("LeanBlock topic configured"),
                                     block.as_ssz_bytes(),
@@ -231,7 +231,7 @@ impl LeanNetworkService {
                                         .gossipsub_config
                                         .topics
                                         .iter()
-                                        .find(|vote_topic| matches!(vote_topic.kind, LeanGossipTopicKind::LeanVote))
+                                        .find(|vote_topic| matches!(vote_topic.kind, LeanGossipTopicKind::Vote))
                                         .map(|vote_topic| IdentTopic::from(vote_topic.clone()))
                                         .expect("LeanVote topic configured"),
                                     bytes,

--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -302,12 +302,12 @@ impl LeanNetworkService {
                     if let Err(err) =
                         self.chain_message_sender
                             .send(LeanChainServiceMessage::QueueItem(QueueItem::Block(
-                                (signed_block).data.clone(),
+                                (signed_block).message.clone(),
                             )))
                     {
                         warn!(
                             "failed to send block for slot {} item to chain: {err:?}",
-                            signed_block.data.slot
+                            signed_block.message.slot
                         );
                     }
                 }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Fixes #744, and also matches with current [lean specification](https://github.com/leanEthereum/leanSpec/tree/e9bb80cb5fef3b6a1a2aae009a37cf86f002e431/docs/client) (commit hash: [e9bb80cb5fef3b6a1a2aae009a37cf86f002e431](https://github.com/leanEthereum/leanSpec/commit/e9bb80cb5fef3b6a1a2aae009a37cf86f002e431)).

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

- Did some double-check with current lean spec.
- Changed `history_length` (= `mcache_len`) to `6`.
- Added docstrings with the specification link.

### Note

I'm **quite sure** [the networking part](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/networking.md) would need some changes:

1. Use fork digest instead of `devnet{N}`: Agreed with @KolbyML's [comment](https://github.com/leanEthereum/leanSpec/pull/8#discussion_r2296812658).
2. Add topic for calculating `message-id`: Making it consistent with [altair spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/p2p-interface.md#topics-and-messages).

But I didn't include it in this PR.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
