### PR TITLE
chore: add missing fields(slot, latest_block_header) in `LeanState`

### DIFF
--- a/crates/common/consensus/lean/src/block.rs
+++ b/crates/common/consensus/lean/src/block.rs
@@ -34,6 +34,21 @@ pub struct Block {
     pub body: BlockBody,
 }
 
+/// Represents a block header in the Lean chain.
+///
+/// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#blockheader)
+/// for detailed protocol information.
+#[derive(
+    Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash,
+)]
+pub struct BlockHeader {
+    pub slot: u64,
+    pub proposer_index: u64,
+    pub parent_root: B256,
+    pub state_root: B256,
+    pub body_root: B256,
+}
+
 /// Represents the body of a block in the Lean chain.
 ///
 /// See the [Lean specification](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#blockbody)

--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -9,7 +9,7 @@ use ssz_types::{
 };
 use tree_hash_derive::TreeHash;
 
-use crate::{checkpoint::Checkpoint, config::Config};
+use crate::{block::BlockHeader, checkpoint::Checkpoint, config::Config};
 
 /// Represents the state of the Lean chain.
 ///
@@ -18,6 +18,8 @@ use crate::{checkpoint::Checkpoint, config::Config};
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct LeanState {
     pub config: Config,
+    pub slot: u64,
+    pub latest_block_header: BlockHeader,
 
     pub latest_justified: Checkpoint,
     pub latest_finalized: Checkpoint,
@@ -36,6 +38,8 @@ impl LeanState {
                 num_validators,
                 genesis_time,
             },
+            slot: 0,
+            latest_block_header: BlockHeader::default(),
 
             latest_justified: Checkpoint::default(),
             latest_finalized: Checkpoint::default(),


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

`LeanState` doesn't have `slot` and `latest_block_header` right now.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Make consistent with the [spec](https://github.com/leanEthereum/leanSpec/blob/main/docs/client/containers.md#state).

`BlockHeader` will be added after https://github.com/leanEthereum/leanSpec/pull/15 is merged.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
