### PR TITLE
feat: add POST /eth/v1/beacon/pool/sync_committees endpoint to Beacon APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5723,6 +5723,7 @@ dependencies = [
  "ream-operation-pool",
  "ream-p2p",
  "ream-storage",
+ "ream-validator-beacon",
  "serde",
  "serde_json",
  "ssz_types",

--- a/crates/rpc/beacon/Cargo.toml
+++ b/crates/rpc/beacon/Cargo.toml
@@ -41,3 +41,4 @@ ream-node.workspace = true
 ream-operation-pool.workspace = true
 ream-p2p.workspace = true
 ream-storage.workspace = true
+ream-validator-beacon.workspace = true

--- a/crates/rpc/beacon/src/routes/beacon.rs
+++ b/crates/rpc/beacon/src/routes/beacon.rs
@@ -14,7 +14,7 @@ use crate::handlers::{
     },
     pool::{
         get_bls_to_execution_changes, get_pool_attester_slashings, get_voluntary_exits,
-        post_bls_to_execution_changes, post_voluntary_exits,
+        post_bls_to_execution_changes, post_sync_committees, post_voluntary_exits,
     },
     state::{
         get_pending_consolidations, get_pending_deposits, get_pending_partial_withdrawals,
@@ -54,6 +54,7 @@ pub fn register_beacon_routes(cfg: &mut ServiceConfig) {
         .service(post_validator_balances_from_state)
         .service(get_bls_to_execution_changes)
         .service(post_bls_to_execution_changes)
+        .service(post_sync_committees)
         .service(get_voluntary_exits)
         .service(post_voluntary_exits)
         .service(get_light_client_bootstrap)


### PR DESCRIPTION
### What was wrong?

Fixes #215 

### How was it fixed?
implemented [/eth/v1/beacon/pool/sync_committees of BeaconAPI](https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolSyncCommitteeSignatures)
 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
