### PR TITLE
feat: add support CLI flag for reusing the network identity

### DIFF
--- a/bin/ream/src/cli/lean_node.rs
+++ b/bin/ream/src/cli/lean_node.rs
@@ -32,6 +32,9 @@ pub struct LeanNodeConfig {
     #[arg(long, help = "The path to the validator registry")]
     pub validator_registry_path: PathBuf,
 
+    #[arg(long, help = "The path to the protobuf encoded secp256k1 libp2p key")]
+    pub secret_key_path: Option<PathBuf>,
+
     #[arg(long, help = "Set P2P socket address", default_value_t = DEFAULT_SOCKET_ADDRESS)]
     pub socket_address: IpAddr,
 

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -171,6 +171,7 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor) {
             gossipsub_config,
             socket_address: config.socket_address,
             socket_port: config.socket_port,
+            secret_key_path: config.secret_key_path,
         }),
         lean_chain_reader.clone(),
         executor.clone(),


### PR DESCRIPTION
### What was wrong?

Fixes: https://github.com/ReamLabs/ream/issues/754

### How was it fixed?

adds a cli flag for reusing the network identity
