### PR TITLE
fix: use `LeanChainReader` for lean http server param

### DIFF
--- a/crates/rpc/lean/src/handlers/head.rs
+++ b/crates/rpc/lean/src/handlers/head.rs
@@ -1,16 +1,11 @@
-use std::sync::Arc;
-
 use actix_web::{HttpResponse, Responder, get, web::Data};
 use ream_api_types_beacon::error::ApiError;
 use ream_api_types_lean::head::Head;
-use ream_chain_lean::lean_chain::LeanChain;
-use tokio::sync::RwLock;
+use ream_chain_lean::lean_chain::LeanChainReader;
 
 // GET /lean/v0/head
 #[get("/head")]
-pub async fn get_head(
-    lean_chain: Data<Arc<RwLock<LeanChain>>>,
-) -> Result<impl Responder, ApiError> {
+pub async fn get_head(lean_chain: Data<LeanChainReader>) -> Result<impl Responder, ApiError> {
     Ok(HttpResponse::Ok().json(Head {
         head: lean_chain.read().await.head,
     }))


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

```bash
$ curl 127.0.0.1:5052/lean/v0/head
```

This API request would fail because of the data type of the function parameter in `get_head`.

```
Requested application data is not configured correctly. View/enable debug logs for more details
```

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Use `LeanChainReader`.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
