### PR TITLE
chore: use `std::fmt::Display` for consistency

### DIFF
--- a/crates/common/api_types/beacon/src/id.rs
+++ b/crates/common/api_types/beacon/src/id.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-use std::{fmt::Display, str::FromStr};
+use std::str::FromStr;
 
 use alloy_primitives::{B256, hex};
 use ream_bls::PublicKey;
@@ -53,8 +52,8 @@ impl<'de> Deserialize<'de> for ID {
     }
 }
 
-impl fmt::Display for ID {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for ID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ID::Finalized => write!(f, "finalized"),
             ID::Genesis => write!(f, "genesis"),
@@ -104,7 +103,7 @@ impl<'de> Deserialize<'de> for ValidatorID {
     }
 }
 
-impl Display for ValidatorID {
+impl std::fmt::Display for ValidatorID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ValidatorID::Index(i) => write!(f, "{i}"),

--- a/crates/common/validator/beacon/src/beacon_api_client/event.rs
+++ b/crates/common/validator/beacon/src/beacon_api_client/event.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, str::FromStr};
+use std::str::FromStr;
 
 use alloy_rpc_types_beacon::events::{
     AttestationEvent, BlobSidecarEvent, BlockEvent, BlsToExecutionChangeEvent, ChainReorgEvent,
@@ -46,7 +46,7 @@ impl FromStr for EventTopic {
     }
 }
 
-impl Display for EventTopic {
+impl std::fmt::Display for EventTopic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/crates/networking/syncer/src/block_range/block_cache.rs
+++ b/crates/networking/syncer/src/block_range/block_cache.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Display,
-};
+use std::collections::{HashMap, HashSet};
 
 use alloy_primitives::B256;
 use anyhow::{bail, ensure};
@@ -256,7 +253,7 @@ pub enum DataToFetch {
     Finished,
 }
 
-impl Display for DataToFetch {
+impl std::fmt::Display for DataToFetch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DataToFetch::BlockRange(range) => write!(f, "BlockRange({range:?})"),


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

The node would not run in `no_std` environment, so use `std::fmt::Display` instead of `core::fmt::Display.`
Also did some cosmetics for all over the codebase.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Use `std::fmt::Display`

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
