### PR TITLE
feat(lean): `get_block` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5741,6 +5741,7 @@ dependencies = [
  "ream-api-types-beacon",
  "ream-api-types-lean",
  "ream-chain-lean",
+ "ream-consensus-lean",
  "ream-p2p",
  "ream-rpc-beacon",
  "tokio",

--- a/crates/common/api_types/lean/src/block_id.rs
+++ b/crates/common/api_types/lean/src/block_id.rs
@@ -1,0 +1,65 @@
+use std::str::FromStr;
+
+use alloy_primitives::{B256, hex};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlockID {
+    Finalized,
+    Genesis,
+    Head,
+    Justified,
+    Slot(u64),
+    /// expected to be a 0x-prefixed hex string.
+    Root(B256),
+}
+
+impl Serialize for BlockID {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for BlockID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "finalized" => Ok(BlockID::Finalized),
+            "genesis" => Ok(BlockID::Genesis),
+            "head" => Ok(BlockID::Head),
+            "justified" => Ok(BlockID::Justified),
+            _ => {
+                if s.starts_with("0x") {
+                    B256::from_str(&s)
+                        .map(BlockID::Root)
+                        .map_err(|_| serde::de::Error::custom(format!("Invalid hex root: {s}")))
+                } else if s.chars().all(|c| c.is_ascii_digit()) {
+                    s.parse::<u64>()
+                        .map(BlockID::Slot)
+                        .map_err(|_| serde::de::Error::custom(format!("Invalid slot number: {s}")))
+                } else {
+                    Err(serde::de::Error::custom(format!("Invalid state ID: {s}")))
+                }
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for BlockID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlockID::Finalized => write!(f, "finalized"),
+            BlockID::Genesis => write!(f, "genesis"),
+            BlockID::Head => write!(f, "head"),
+            BlockID::Justified => write!(f, "justified"),
+            BlockID::Slot(slot) => write!(f, "{slot}"),
+            BlockID::Root(root) => write!(f, "0x{}", hex::encode(root)),
+        }
+    }
+}

--- a/crates/common/api_types/lean/src/lib.rs
+++ b/crates/common/api_types/lean/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod block_id;
 pub mod head;

--- a/crates/common/chain/lean/src/lean_chain.rs
+++ b/crates/common/chain/lean/src/lean_chain.rs
@@ -223,4 +223,11 @@ impl LeanChain {
     pub fn get_block_by_root(&self, root: B256) -> Option<Block> {
         self.chain.get(&root).cloned()
     }
+
+    pub fn get_block_by_slot(&self, slot: u64) -> Option<Block> {
+        self.chain
+            .values()
+            .find(|block| block.slot == slot)
+            .cloned()
+    }
 }

--- a/crates/common/chain/lean/src/lean_chain.rs
+++ b/crates/common/chain/lean/src/lean_chain.rs
@@ -220,5 +220,7 @@ impl LeanChain {
         })
     }
 
-    // TODO: Add necessary methods for receive.
+    pub fn get_block_by_root(&self, root: B256) -> Option<Block> {
+        self.chain.get(&root).cloned()
+    }
 }

--- a/crates/rpc/lean/Cargo.toml
+++ b/crates/rpc/lean/Cargo.toml
@@ -20,5 +20,6 @@ tracing.workspace = true
 ream-api-types-beacon.workspace = true
 ream-api-types-lean.workspace = true
 ream-chain-lean.workspace = true
+ream-consensus-lean.workspace = true
 ream-p2p.workspace = true
 ream-rpc-beacon.workspace = true

--- a/crates/rpc/lean/src/handlers/block.rs
+++ b/crates/rpc/lean/src/handlers/block.rs
@@ -1,0 +1,38 @@
+use actix_web::{
+    HttpResponse, Responder, get,
+    web::{Data, Path},
+};
+use ream_api_types_beacon::error::ApiError;
+use ream_api_types_lean::block_id::BlockID;
+use ream_chain_lean::lean_chain::LeanChainReader;
+
+// GET /lean/v0/blocks/{block_id}
+#[get("/blocks/{block_id}")]
+pub async fn get_block(
+    block_id: Path<BlockID>,
+    lean_chain: Data<LeanChainReader>,
+) -> Result<impl Responder, ApiError> {
+    // Obtain read guard first from the reader.
+    let lean_chain = lean_chain.read().await;
+
+    Ok(HttpResponse::Ok().json(
+        match block_id.into_inner() {
+            BlockID::Finalized => {
+                lean_chain.get_block_by_root(lean_chain.latest_finalized_hash().ok_or(
+                    ApiError::InternalError(format!("Failed to get latest finalized hash")),
+                )?)
+            }
+            BlockID::Genesis => lean_chain.get_block_by_root(lean_chain.genesis_hash),
+            BlockID::Head => lean_chain.get_block_by_root(lean_chain.head),
+            BlockID::Justified => {
+                lean_chain.get_block_by_root(lean_chain.latest_justified_hash().ok_or(
+                    ApiError::InternalError(format!("Failed to get latest justified hash")),
+                )?)
+            }
+            // TODO: Implement fetching block by slot
+            BlockID::Slot(_slot) => None,
+            BlockID::Root(root) => lean_chain.get_block_by_root(root),
+        }
+        .ok_or_else(|| ApiError::NotFound(format!("Block not found")))?,
+    ))
+}

--- a/crates/rpc/lean/src/handlers/block.rs
+++ b/crates/rpc/lean/src/handlers/block.rs
@@ -29,8 +29,7 @@ pub async fn get_block(
                     ApiError::InternalError(format!("Failed to get latest justified hash")),
                 )?)
             }
-            // TODO: Implement fetching block by slot
-            BlockID::Slot(_slot) => None,
+            BlockID::Slot(slot) => lean_chain.get_block_by_slot(slot),
             BlockID::Root(root) => lean_chain.get_block_by_root(root),
         }
         .ok_or_else(|| ApiError::NotFound(format!("Block not found")))?,

--- a/crates/rpc/lean/src/handlers/mod.rs
+++ b/crates/rpc/lean/src/handlers/mod.rs
@@ -1,2 +1,3 @@
+pub mod block;
 pub mod head;
 pub mod peer;

--- a/crates/rpc/lean/src/routes/lean.rs
+++ b/crates/rpc/lean/src/routes/lean.rs
@@ -1,8 +1,8 @@
 use actix_web::web::ServiceConfig;
 
-use crate::handlers::head::get_head;
+use crate::handlers::{block::get_block, head::get_head};
 
 /// Creates and returns all `/lean` routes.
 pub fn register_lean_routes(cfg: &mut ServiceConfig) {
-    cfg.service(get_head);
+    cfg.service(get_head).service(get_block);
 }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

I'm building a PQ devnet visualizer, and fetching a block is MUST-HAVE feature for each client. This PR adds the endpoint that was added for my testing purpose.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Add new endpoint: `/lean/v0/blocks/{block_id}`. `block_id` is almost same as the one of the beacon's, but I just copy-pasted it in the crate for lean.

### Example

```bash
$  curl 127.0.0.1:5052/lean/v0/blocks/head | jq
```

```json
{
  "slot": 33,
  "proposer_index": 1,
  "parent_root": "0xe75b087f8e2111735c6d489e095716fd08acace51d944f990f3bf110843c4f55",
  "state_root": "0xdfed078e262fa643c894a21dc3d19d98791ac78ba1647eec135ba30156c4eb01",
  "body": {
    "votes": [
      {
        "validator_id": 0,
        "slot": 32,
        "head": {
          "root": "0xe75b087f8e2111735c6d489e095716fd08acace51d944f990f3bf110843c4f55",
          "slot": 32
        },
        "target": {
          "root": "0xd4a3ba9dd02e638cae398f7450e9df49351734c21ce1737313ce3ff9272c8116",
          "slot": 31
        },
        "source": {
          "root": "0xe031a6d76151fedb7da9ea01c43861aeb286c8b34576bff3d71ec0e9a868479e",
          "slot": 30
        }
      },
      {
        "validator_id": 1,
        "slot": 32,
        "head": {
          "root": "0xe75b087f8e2111735c6d489e095716fd08acace51d944f990f3bf110843c4f55",
          "slot": 32
        },
        "target": {
          "root": "0xd4a3ba9dd02e638cae398f7450e9df49351734c21ce1737313ce3ff9272c8116",
          "slot": 31
        },
        "source": {
          "root": "0xe031a6d76151fedb7da9ea01c43861aeb286c8b34576bff3d71ec0e9a868479e",
          "slot": 30
        }
      },
      {
        "validator_id": 2,
        "slot": 32,
        "head": {
          "root": "0xe75b087f8e2111735c6d489e095716fd08acace51d944f990f3bf110843c4f55",
          "slot": 32
        },
        "target": {
          "root": "0xd4a3ba9dd02e638cae398f7450e9df49351734c21ce1737313ce3ff9272c8116",
          "slot": 31
        },
        "source": {
          "root": "0xe031a6d76151fedb7da9ea01c43861aeb286c8b34576bff3d71ec0e9a868479e",
          "slot": 30
        }
      },
      {
        "validator_id": 3,
        "slot": 32,
        "head": {
          "root": "0xe75b087f8e2111735c6d489e095716fd08acace51d944f990f3bf110843c4f55",
          "slot": 32
        },
        "target": {
          "root": "0xd4a3ba9dd02e638cae398f7450e9df49351734c21ce1737313ce3ff9272c8116",
          "slot": 31
        },
        "source": {
          "root": "0xe031a6d76151fedb7da9ea01c43861aeb286c8b34576bff3d71ec0e9a868479e",
          "slot": 30
        }
      }
    ]
  }
}
```

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
