### PR TITLE
feat: implementation of /eth/v1/beacon/pool/proposer_slashings

### DIFF
--- a/crates/common/consensus/beacon/src/electra/beacon_state.rs
+++ b/crates/common/consensus/beacon/src/electra/beacon_state.rs
@@ -1570,7 +1570,8 @@ impl BeaconState {
         Ok(sync_committee_indices)
     }
 
-    /// check if the given proposer slashing is valid and returns the index of proposer to be slashed
+    /// check if the given proposer slashing is valid and returns the index of proposer to
+    /// slashed
     pub fn validate_proposer_slashing(
         &self,
         proposer_slashing: &ProposerSlashing,

--- a/crates/common/consensus/beacon/src/electra/beacon_state.rs
+++ b/crates/common/consensus/beacon/src/electra/beacon_state.rs
@@ -1570,6 +1570,7 @@ impl BeaconState {
         Ok(sync_committee_indices)
     }
 
+    /// check if the given proposer slashing is valid and returns the index of proposer to be slashed
     pub fn validate_proposer_slashing(
         &self,
         proposer_slashing: &ProposerSlashing,
@@ -1623,6 +1624,7 @@ impl BeaconState {
 
         Ok(proposer_index)
     }
+
     pub fn process_proposer_slashing(
         &mut self,
         proposer_slashing: &ProposerSlashing,

--- a/crates/common/consensus/beacon/src/electra/beacon_state.rs
+++ b/crates/common/consensus/beacon/src/electra/beacon_state.rs
@@ -1570,10 +1570,10 @@ impl BeaconState {
         Ok(sync_committee_indices)
     }
 
-    pub fn process_proposer_slashing(
-        &mut self,
+    pub fn validate_proposer_slashing(
+        &self,
         proposer_slashing: &ProposerSlashing,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<u64> {
         let header_1 = &proposer_slashing.signed_header_1.message;
         let header_2 = &proposer_slashing.signed_header_2.message;
 
@@ -1621,6 +1621,13 @@ impl BeaconState {
             );
         }
 
+        Ok(proposer_index)
+    }
+    pub fn process_proposer_slashing(
+        &mut self,
+        proposer_slashing: &ProposerSlashing,
+    ) -> anyhow::Result<()> {
+        let proposer_index = self.validate_proposer_slashing(proposer_slashing)?;
         // Slash the validator
         self.slash_validator(proposer_index, None)
     }

--- a/crates/common/consensus/beacon/src/proposer_slashing.rs
+++ b/crates/common/consensus/beacon/src/proposer_slashing.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Hash)]
 pub struct ProposerSlashing {
     pub signed_header_1: SignedBeaconBlockHeader,
     pub signed_header_2: SignedBeaconBlockHeader,

--- a/crates/common/consensus/misc/src/beacon_block_header.rs
+++ b/crates/common/consensus/misc/src/beacon_block_header.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Hash)]
 pub struct SignedBeaconBlockHeader {
     pub message: BeaconBlockHeader,
     pub signature: BLSSignature,
 }
 
 #[derive(
-    Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash,
+    Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Hash,
 )]
 pub struct BeaconBlockHeader {
     #[serde(with = "serde_utils::quoted_u64")]

--- a/crates/common/operation_pool/src/lib.rs
+++ b/crates/common/operation_pool/src/lib.rs
@@ -4,7 +4,8 @@ use alloy_primitives::{Address, B256, map::HashSet};
 use parking_lot::RwLock;
 use ream_consensus_beacon::{
     attester_slashing::AttesterSlashing, bls_to_execution_change::SignedBLSToExecutionChange,
-    electra::beacon_state::BeaconState, voluntary_exit::SignedVoluntaryExit,
+    electra::beacon_state::BeaconState, proposer_slashing::ProposerSlashing,
+    voluntary_exit::SignedVoluntaryExit,
 };
 use tree_hash::TreeHash;
 
@@ -20,6 +21,7 @@ pub struct OperationPool {
     signed_bls_to_execution_changes: RwLock<HashMap<B256, SignedBLSToExecutionChange>>,
     proposer_preparations: RwLock<HashMap<u64, ProposerPreparation>>,
     attester_slashings: RwLock<HashSet<AttesterSlashing>>,
+    proposer_slashings: RwLock<HashSet<ProposerSlashing>>,
 }
 
 impl OperationPool {
@@ -113,6 +115,14 @@ impl OperationPool {
 
     pub fn get_all_attester_slashings(&self) -> Vec<AttesterSlashing> {
         self.attester_slashings.read().iter().cloned().collect()
+    }
+
+    pub fn get_all_proposer_slahsings(&self) -> Vec<ProposerSlashing> {
+        self.proposer_slashings.read().iter().cloned().collect()
+    }
+
+    pub fn insert_proposer_slashing(&self, slashing: ProposerSlashing) {
+        self.proposer_slashings.write().insert(slashing);
     }
 }
 

--- a/crates/rpc/beacon/src/handlers/pool.rs
+++ b/crates/rpc/beacon/src/handlers/pool.rs
@@ -190,7 +190,7 @@ pub async fn get_proposer_slashings(
 }
 
 /// POST /eth/v2/beacon/pool/proposer_slashing
-#[post("/beacon/poo/proposer_slashings")]
+#[post("/beacon/pool/proposer_slashings")]
 pub async fn post_proposer_slashings(
     db: Data<ReamDB>,
     operation_pool: Data<Arc<OperationPool>>,
@@ -217,6 +217,7 @@ pub async fn post_proposer_slashings(
                 "Invalid proposer slashing, it will never pass validation so it's rejected: {err:?}"
             ))
         })?;
+
     network_manager.p2p_sender.send_gossip(GossipMessage {
         topic: {
             GossipTopic {

--- a/crates/rpc/beacon/src/handlers/pool.rs
+++ b/crates/rpc/beacon/src/handlers/pool.rs
@@ -130,7 +130,7 @@ pub async fn post_voluntary_exits(
 
 /// GET /eth/v2/beacon/pool/attester_slashings
 #[get("/beacon/pool/attester_slashings")]
-pub async fn get_pool_attester_slashings(
+pub async fn get_attester_slashings(
     operation_pool: Data<Arc<OperationPool>>,
 ) -> Result<impl Responder, ApiError> {
     Ok(HttpResponse::Ok().json(DataVersionedResponse::new(
@@ -140,7 +140,7 @@ pub async fn get_pool_attester_slashings(
 
 /// POST /eth/v2/beacon/pool/attester_slashings
 #[post("/beacon/pool/attester_slashings")]
-pub async fn post_pool_attester_slashings(
+pub async fn post_attester_slashings(
     db: Data<ReamDB>,
     operation_pool: Data<Arc<OperationPool>>,
     network_manager: Data<Arc<NetworkManagerService>>,

--- a/crates/rpc/beacon/src/handlers/pool.rs
+++ b/crates/rpc/beacon/src/handlers/pool.rs
@@ -210,8 +210,13 @@ pub async fn post_proposer_slashings(
         ))?;
     let beacon_state = get_state_from_id(ID::Slot(highest_slot), &db).await?;
 
-    // TODO: Validate proposer slashing
-
+    beacon_state
+        .validate_proposer_slashing(&proposer_slashing)
+        .map_err(|err| {
+            ApiError::BadRequest(format!(
+                "Invalid proposer slashing, it will never pass validation so it's rejected: {err:?}"
+            ))
+        })?;
     network_manager.p2p_sender.send_gossip(GossipMessage {
         topic: {
             GossipTopic {

--- a/crates/rpc/beacon/src/handlers/pool.rs
+++ b/crates/rpc/beacon/src/handlers/pool.rs
@@ -8,7 +8,7 @@ use ream_api_types_beacon::responses::{DataResponse, DataVersionedResponse};
 use ream_api_types_common::{error::ApiError, id::ID};
 use ream_consensus_beacon::{
     attester_slashing::AttesterSlashing, bls_to_execution_change::SignedBLSToExecutionChange,
-    voluntary_exit::SignedVoluntaryExit,
+    proposer_slashing::ProposerSlashing, voluntary_exit::SignedVoluntaryExit,
 };
 use ream_network_manager::service::NetworkManagerService;
 use ream_operation_pool::OperationPool;
@@ -177,4 +177,14 @@ pub async fn post_attester_slashings(
     operation_pool.insert_attester_slashing(attester_slashing);
 
     Ok(HttpResponse::Ok())
+}
+
+/// GET /eth/v2/beacon/pool/proposer_slashings
+#[get("/beacon/pool/prposer_slashings")]
+pub async fn get_proposer_slashings(
+    operation_pool: Data<Arc<OperationPool>>,
+) -> Result<impl Responder, ApiError> {
+    Ok(HttpResponse::Ok().json(DataVersionedResponse::new(
+        operation_pool.get_all_proposer_slahsings(),
+    )))
 }

--- a/crates/rpc/beacon/src/routes/beacon.rs
+++ b/crates/rpc/beacon/src/routes/beacon.rs
@@ -13,8 +13,8 @@ use crate::handlers::{
         get_light_client_optimistic_update, get_light_client_updates,
     },
     pool::{
-        get_bls_to_execution_changes, get_pool_attester_slashings, get_voluntary_exits,
-        post_bls_to_execution_changes, post_voluntary_exits,
+        get_attester_slashings, get_bls_to_execution_changes, get_voluntary_exits,
+        post_attester_slashings, post_bls_to_execution_changes, post_voluntary_exits,
     },
     state::{
         get_pending_consolidations, get_pending_deposits, get_pending_partial_withdrawals,
@@ -67,5 +67,6 @@ pub fn register_beacon_routes(cfg: &mut ServiceConfig) {
 pub fn register_beacon_routes_v2(cfg: &mut ServiceConfig) {
     cfg.service(get_block_attestations)
         .service(get_block_from_id)
-        .service(get_pool_attester_slashings);
+        .service(get_attester_slashings)
+        .service(post_attester_slashings);
 }

--- a/crates/rpc/beacon/src/routes/beacon.rs
+++ b/crates/rpc/beacon/src/routes/beacon.rs
@@ -13,8 +13,9 @@ use crate::handlers::{
         get_light_client_optimistic_update, get_light_client_updates,
     },
     pool::{
-        get_attester_slashings, get_bls_to_execution_changes, get_voluntary_exits,
-        post_attester_slashings, post_bls_to_execution_changes, post_voluntary_exits,
+        get_attester_slashings, get_bls_to_execution_changes, get_proposer_slashings,
+        get_voluntary_exits, post_attester_slashings, post_bls_to_execution_changes,
+        post_voluntary_exits,
     },
     state::{
         get_pending_consolidations, get_pending_deposits, get_pending_partial_withdrawals,
@@ -61,7 +62,8 @@ pub fn register_beacon_routes(cfg: &mut ServiceConfig) {
         .service(get_light_client_finality_update)
         .service(get_light_client_optimistic_update)
         .service(get_blind_block)
-        .service(post_validator_liveness);
+        .service(post_validator_liveness)
+        .service(get_proposer_slashings);
 }
 
 pub fn register_beacon_routes_v2(cfg: &mut ServiceConfig) {

--- a/crates/rpc/beacon/src/routes/beacon.rs
+++ b/crates/rpc/beacon/src/routes/beacon.rs
@@ -15,7 +15,7 @@ use crate::handlers::{
     pool::{
         get_attester_slashings, get_bls_to_execution_changes, get_proposer_slashings,
         get_voluntary_exits, post_attester_slashings, post_bls_to_execution_changes,
-        post_voluntary_exits,
+        post_proposer_slashings, post_voluntary_exits,
     },
     state::{
         get_pending_consolidations, get_pending_deposits, get_pending_partial_withdrawals,
@@ -63,7 +63,8 @@ pub fn register_beacon_routes(cfg: &mut ServiceConfig) {
         .service(get_light_client_optimistic_update)
         .service(get_blind_block)
         .service(post_validator_liveness)
-        .service(get_proposer_slashings);
+        .service(get_proposer_slashings)
+        .service(post_proposer_slashings);
 }
 
 pub fn register_beacon_routes_v2(cfg: &mut ServiceConfig) {


### PR DESCRIPTION
### What was wrong?
 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Fixes: #214 

### How was it fixed?
- Created a new hashset on the op_pool to store the proposer slashings
- GET and POST methods to insert and retrieve them
- Validation against the latest beacon state.

 <!-- List the approach you used, and/or changes made to the codebase  -->

NOTE: Also included a commit which has some code missing from another API endpoint that I worked on `attester_slashings`.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
