### PR TITLE
chore: remove `actix-web` dependency in `api_types/beacon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,7 +5233,6 @@ dependencies = [
 name = "ream-api-types-beacon"
 version = "0.1.0"
 dependencies = [
- "actix-web",
  "alloy-primitives",
  "anyhow",
  "ethereum_serde_utils",

--- a/crates/common/api_types/beacon/Cargo.toml
+++ b/crates/common/api_types/beacon/Cargo.toml
@@ -10,7 +10,6 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-actix-web.workspace = true
 alloy-primitives.workspace = true
 anyhow.workspace = true
 ethereum_serde_utils.workspace = true


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

`cargo udeps` fails: https://github.com/ReamLabs/ream/actions/runs/17431884721/job/49491965211

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Delete `actix-web` dependency in `api_types/beacon` crate.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
