### PR TITLE
feat(lean): implement block headers API

### DIFF
--- a/crates/common/consensus/lean/src/block.rs
+++ b/crates/common/consensus/lean/src/block.rs
@@ -3,6 +3,7 @@ use ream_post_quantum_crypto::PQSignature;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{VariableList, typenum::U4096};
+use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
 use crate::vote::Vote;
@@ -47,6 +48,18 @@ pub struct BlockHeader {
     pub parent_root: B256,
     pub state_root: B256,
     pub body_root: B256,
+}
+
+impl From<Block> for BlockHeader {
+    fn from(block: Block) -> Self {
+        BlockHeader {
+            slot: block.slot,
+            proposer_index: block.proposer_index,
+            parent_root: block.parent_root,
+            state_root: block.state_root,
+            body_root: block.body.tree_hash_root(),
+        }
+    }
 }
 
 /// Represents the body of a block in the Lean chain.

--- a/crates/rpc/lean/src/handlers/block.rs
+++ b/crates/rpc/lean/src/handlers/block.rs
@@ -4,6 +4,7 @@ use actix_web::{
 };
 use ream_api_types_common::{error::ApiError, id::ID};
 use ream_chain_lean::lean_chain::LeanChainReader;
+use ream_consensus_lean::block::Block;
 
 // GET /lean/v0/blocks/{block_id}
 #[get("/blocks/{block_id}")]
@@ -11,26 +12,31 @@ pub async fn get_block(
     block_id: Path<ID>,
     lean_chain: Data<LeanChainReader>,
 ) -> Result<impl Responder, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        get_block_by_id(block_id.into_inner(), lean_chain)
+            .await?
+            .ok_or_else(|| ApiError::NotFound("Block not found".to_string()))?,
+    ))
+}
+
+// Retrieve a block from the lean chain by its block ID.
+pub async fn get_block_by_id(
+    block_id: ID,
+    lean_chain: Data<LeanChainReader>,
+) -> Result<Option<Block>, ApiError> {
     // Obtain read guard first from the reader.
     let lean_chain = lean_chain.read().await;
 
-    Ok(HttpResponse::Ok().json(
-        match block_id.into_inner() {
-            ID::Finalized => {
-                lean_chain.get_block_by_root(lean_chain.latest_finalized_hash().ok_or(
-                    ApiError::InternalError("Failed to get latest finalized hash".to_string()),
-                )?)
-            }
-            ID::Genesis => lean_chain.get_block_by_root(lean_chain.genesis_hash),
-            ID::Head => lean_chain.get_block_by_root(lean_chain.head),
-            ID::Justified => {
-                lean_chain.get_block_by_root(lean_chain.latest_justified_hash().ok_or(
-                    ApiError::InternalError("Failed to get latest justified hash".to_string()),
-                )?)
-            }
-            ID::Slot(slot) => lean_chain.get_block_by_slot(slot),
-            ID::Root(root) => lean_chain.get_block_by_root(root),
-        }
-        .ok_or_else(|| ApiError::NotFound("Block not found".to_string()))?,
-    ))
+    Ok(match block_id {
+        ID::Finalized => lean_chain.get_block_by_root(lean_chain.latest_finalized_hash().ok_or(
+            ApiError::InternalError("Failed to get latest finalized hash".to_string()),
+        )?),
+        ID::Genesis => lean_chain.get_block_by_root(lean_chain.genesis_hash),
+        ID::Head => lean_chain.get_block_by_root(lean_chain.head),
+        ID::Justified => lean_chain.get_block_by_root(lean_chain.latest_justified_hash().ok_or(
+            ApiError::InternalError("Failed to get latest justified hash".to_string()),
+        )?),
+        ID::Slot(slot) => lean_chain.get_block_by_slot(slot),
+        ID::Root(root) => lean_chain.get_block_by_root(root),
+    })
 }

--- a/crates/rpc/lean/src/handlers/block_header.rs
+++ b/crates/rpc/lean/src/handlers/block_header.rs
@@ -1,0 +1,22 @@
+use actix_web::{
+    HttpResponse, Responder, get,
+    web::{Data, Path},
+};
+use ream_api_types_common::{error::ApiError, id::ID};
+use ream_chain_lean::lean_chain::LeanChainReader;
+use ream_consensus_lean::block::BlockHeader;
+
+use super::block::get_block_by_id;
+
+// GET /lean/v0/headers/{block_id}
+#[get("/headers/{block_id}")]
+pub async fn get_block_header(
+    block_id: Path<ID>,
+    lean_chain: Data<LeanChainReader>,
+) -> Result<impl Responder, ApiError> {
+    Ok(HttpResponse::Ok().json(BlockHeader::from(
+        get_block_by_id(block_id.into_inner(), lean_chain)
+            .await?
+            .ok_or_else(|| ApiError::NotFound("Block not found".to_string()))?,
+    )))
+}

--- a/crates/rpc/lean/src/handlers/mod.rs
+++ b/crates/rpc/lean/src/handlers/mod.rs
@@ -1,3 +1,4 @@
 pub mod block;
+pub mod block_header;
 pub mod head;
 pub mod peer;

--- a/crates/rpc/lean/src/routes/lean.rs
+++ b/crates/rpc/lean/src/routes/lean.rs
@@ -1,8 +1,10 @@
 use actix_web::web::ServiceConfig;
 
-use crate::handlers::{block::get_block, head::get_head};
+use crate::handlers::{block::get_block, block_header::get_block_header, head::get_head};
 
 /// Creates and returns all `/lean` routes.
 pub fn register_lean_routes(cfg: &mut ServiceConfig) {
-    cfg.service(get_head).service(get_block);
+    cfg.service(get_head)
+        .service(get_block)
+        .service(get_block_header);
 }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

This endpoint might be needed: `/lean/v0/headers/{block_id}` (for building an explorer)

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

- Reuse logic of `get_block` (#761)

### Example

```bash
$ curl 127.0.0.1:5052/lean/v0/headers/head | jq
```

```json
{
  "slot": 2,
  "proposer_index": 2,
  "parent_root": "0x575909f88a025cc7287ddb3af83826f144e055690b7b6ade4f6487d89b36617c",
  "state_root": "0xf95dbb1b477f46ae232442f4fa6491aebb0de06e391edf3c458589185909cda4",
  "body_root": "0xdba9671bac9513c9482f1416a53aabd2c6ce90d5a5f865ce5a55c775325c9136"
}
```



### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
