### PR TITLE
feat: implementation of /eth/v1/validator/sync_committee_selections

### DIFF
--- a/crates/common/consensus/beacon/src/lib.rs
+++ b/crates/common/consensus/beacon/src/lib.rs
@@ -23,6 +23,7 @@ pub mod predicates;
 pub mod proposer_slashing;
 pub mod single_attestation;
 pub mod sync_aggregate;
+pub mod sync_committe_selection;
 pub mod sync_committee;
 pub mod voluntary_exit;
 pub mod withdrawal;

--- a/crates/common/consensus/beacon/src/sync_committe_selection.rs
+++ b/crates/common/consensus/beacon/src/sync_committe_selection.rs
@@ -1,0 +1,12 @@
+use ream_bls::BLSSignature;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use tree_hash_derive::TreeHash;
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+pub struct SyncCommitteeSelection {
+    validatior_index: u64,
+    slot: u64,
+    subcommittee_index: u64,
+    selection_proof: BLSSignature,
+}

--- a/crates/rpc/beacon/src/handlers/validator.rs
+++ b/crates/rpc/beacon/src/handlers/validator.rs
@@ -13,7 +13,9 @@ use ream_api_types_beacon::{
 };
 use ream_api_types_common::{error::ApiError, id::ID};
 use ream_bls::PublicKey;
-use ream_consensus_beacon::electra::beacon_state::BeaconState;
+use ream_consensus_beacon::{
+    electra::beacon_state::BeaconState, sync_committe_selection::SyncCommitteeSelection,
+};
 use ream_consensus_misc::{
     attestation_data::AttestationData, constants::beacon::SLOTS_PER_EPOCH, validator::Validator,
 };
@@ -484,4 +486,12 @@ pub async fn get_attestation_data(
         source: source_checkpoint,
         target: target_checkpoint,
     })))
+}
+
+/// For the initial stage, this endpoint returns a 501 as DVT support is not planned.
+#[post("/validator/sync_committee_selections")]
+pub async fn post_sync_committee_selections(
+    _selections: Json<SyncCommitteeSelection>,
+) -> Result<impl Responder, ApiError> {
+    Ok(HttpResponse::NotImplemented())
 }


### PR DESCRIPTION
### What was wrong?

fixes: #239 

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Since the DVT support is not planned for the upcoming release, the endpoint is supposed to return `501` as suggested in the beacon endpoints specs


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
