### PR TITLE
feat: bash script to run lean nodes

### DIFF
--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -182,6 +182,7 @@ impl LeanNetworkService {
         ));
         multi_addr.push(Protocol::QuicV1);
         info!("Listening on {multi_addr:?}");
+        println!("local_peer_id={:?}", lean_network_service.local_peer_id());
 
         lean_network_service
             .swarm

--- a/lean_run.sh
+++ b/lean_run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+read -p "Enter number of nodes: " n
+
+if ! [[ "$n" =~ ^[0-9]+$ ]] || [ "$n" -lt 1 ]; then
+  echo "Please enter a positive integer"
+  exit 1
+fi
+
+# Open first node in a new terminal window
+osascript <<EOF
+tell application "Terminal"
+    activate
+    do script "cd $(pwd) && cargo run --release -- --data-dir db lean_node \
+      --network ephemery \
+      --validator-registry-path ./bin/ream/assets/lean/validator_registry.yml | tee db_first_node.log; exec \$SHELL"
+end tell
+EOF
+
+echo "Waiting for first node to generate peer id..."
+sleep 5
+
+# Extract local_peer_id from logs and strip PeerId wrapper
+peer_id=$(grep -m1 --color=never -oE 'local_peer_id=[^ ]+' db_first_node.log | cut -d= -f2)
+peer_id=${peer_id//\"/}       # remove quotes
+peer_id=${peer_id//PeerId(/}  # remove PeerId(
+peer_id=${peer_id//)/}        # remove trailing )
+
+echo "First node peer_id: $peer_id"
+
+# Launch remaining nodes in new tabs
+base_socket_port=9000
+base_http_port=5052
+
+for ((i=2; i<=n; i++)); do
+  data_dir="db$i"
+  socket_port=$((base_socket_port + i - 2))
+  http_port=$((base_http_port + i - 2))
+  log_file="db${i}_node.log"
+
+  osascript <<EOF
+tell application "Terminal"
+    activate
+    tell application "System Events" to keystroke "t" using command down
+    delay 0.2
+    do script "cd $(pwd) && cargo run --release -- --data-dir $data_dir lean_node \
+      --network ephemery \
+      --validator-registry-path ./bin/ream/assets/lean/validator_registry.yml \
+      --socket-port $socket_port \
+      --http-port $http_port \
+      --bootnodes /ip4/127.0.0.1/udp/9000/quic-v1/p2p/$peer_id | tee $log_file; exec \$SHELL" in front window
+end tell
+EOF
+done
+
+echo "✅ All $n nodes launched (first in window, rest in tabs)."


### PR DESCRIPTION
## What was wrong?

After https://github.com/ReamLabs/ream/issues/778 I realized its a bit of a headache to run multiple lean nodes because we have to change the `data-dir` `socket-port` and `http-port` for each. So I created this bash script to run `n` nodes one after the other.
In case we already have a convinient way to do this that I'm unaware of, let me know and I'll close this PR.

## How was it fixed?

The script runs `n` nodes. Currenly it makes all the nodes connect to the first one(by using --bootnodes flag). Ideally, all nodes should connect to all previous nodes. But we can change that later, should not be a big deal.
Also this script is modelled for a macOS machine, have not had the chance to test in other OS.
This creates separate log files for each node, I think those need to be prettified(not sure how so will do a bit of research) or if its an overkill I can remove that.
P.S. it may need executable permission to run. Something like `chmod +x lean_run.sh` depending on your settings.

The reason I've added a `println` is because the script is unable to read `info!` logs(let me know if there is a way). It needs to detect the `local_peer_id` in order to pass it to the next node.