### PR TITLE
feat: add cli command to generate network key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5185,6 +5185,7 @@ dependencies = [
  "clap",
  "discv5",
  "hashbrown 0.15.3",
+ "libp2p-identity",
  "prometheus_exporter",
  "rand 0.9.2",
  "rand_chacha 0.9.0",

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -20,6 +20,7 @@ anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 discv5.workspace = true
 hashbrown.workspace = true
+libp2p-identity.workspace = true
 prometheus_exporter.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true

--- a/bin/ream/src/cli/generate_network_key.rs
+++ b/bin/ream/src/cli/generate_network_key.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct GenerateNetworkKeyConfig {
+    #[arg(long, help = "Output path for the generated network key")]
+    pub output_path: PathBuf,
+}

--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod account_manager;
 pub mod beacon_node;
 pub mod constants;
+pub mod generate_network_key;
 pub mod import_keystores;
 pub mod lean_node;
 pub mod validator_node;
@@ -13,8 +14,8 @@ use ream_node::version::FULL_VERSION;
 
 use crate::cli::{
     account_manager::AccountManagerConfig, beacon_node::BeaconNodeConfig,
-    lean_node::LeanNodeConfig, validator_node::ValidatorNodeConfig,
-    voluntary_exit::VoluntaryExitConfig,
+    generate_network_key::GenerateNetworkKeyConfig, lean_node::LeanNodeConfig,
+    validator_node::ValidatorNodeConfig, voluntary_exit::VoluntaryExitConfig,
 };
 
 #[derive(Debug, Parser)]
@@ -61,6 +62,10 @@ pub enum Commands {
     /// Perform voluntary exit for a validator
     #[command(name = "voluntary_exit")]
     VoluntaryExit(Box<VoluntaryExitConfig>),
+
+    /// Generate a network key for lean node
+    #[command(name = "generate_network_key")]
+    GenerateNetworkKey(Box<GenerateNetworkKeyConfig>),
 }
 
 #[cfg(test)]

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -1,5 +1,5 @@
 use std::{
-    env,
+    env, fs,
     net::SocketAddr,
     process,
     sync::Arc,
@@ -7,10 +7,12 @@ use std::{
 };
 
 use clap::Parser;
+use libp2p_identity::Keypair;
 use ream::cli::{
     Cli, Commands,
     account_manager::AccountManagerConfig,
     beacon_node::BeaconNodeConfig,
+    generate_network_key::GenerateNetworkKeyConfig,
     import_keystores::{load_keystore_directory, load_password_from_config, process_password},
     lean_node::LeanNodeConfig,
     validator_node::ValidatorNodeConfig,
@@ -101,6 +103,9 @@ fn main() {
         }
         Commands::VoluntaryExit(config) => {
             executor_clone.spawn(async move { run_voluntary_exit(*config).await });
+        }
+        Commands::GenerateNetworkKey(config) => {
+            executor_clone.spawn(async move { run_generate_network_key(*config).await });
         }
     }
 
@@ -472,4 +477,31 @@ fn get_current_epoch(genesis_time: u64) -> u64 {
             .as_secs()
             / beacon_network_spec().seconds_per_slot,
     )
+}
+
+/// Generates a new secp256k1 keypair and saves it to the specified path in protobuf encoding.
+///
+/// This allows the lean node to reuse the same network identity across restarts by loading
+/// the saved key with the --secret-key-path flag.
+pub async fn run_generate_network_key(config: GenerateNetworkKeyConfig) {
+    info!("Generating new secp256k1 network key...");
+
+    if let Some(parent) = config.output_path.parent() {
+        fs::create_dir_all(parent).expect("Failed to create parent directories");
+    }
+
+    fs::write(
+        &config.output_path,
+        Keypair::generate_secp256k1()
+            .to_protobuf_encoding()
+            .expect("Failed to encode keypair"),
+    )
+    .expect("Failed to write keypair to file");
+
+    info!(
+        "Network key generated successfully and saved to: {}",
+        config.output_path.display()
+    );
+
+    process::exit(0);
 }

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -11,5 +11,6 @@
     - [`ream validator_node`](./cli/ream/validator_node.md)
     - [`ream account_manager`](./cli/ream/account_manager.md)
     - [`ream voluntary_exit`](./cli/ream/voluntary_exit.md)
+    - [`ream generate_network_key`](./cli/ream/generate_network_key.md)
 - [Changelog](./Changelog.md) <!-- CLI_REFERENCE END -->
 

--- a/book/cli/SUMMARY.md
+++ b/book/cli/SUMMARY.md
@@ -4,4 +4,5 @@
   - [`ream validator_node`](./ream/validator_node.md)
   - [`ream account_manager`](./ream/account_manager.md)
   - [`ream voluntary_exit`](./ream/voluntary_exit.md)
+  - [`ream generate_network_key`](./ream/generate_network_key.md)
 

--- a/book/cli/ream.md
+++ b/book/cli/ream.md
@@ -9,12 +9,13 @@ $ ream --help
 Usage: ream [OPTIONS] <COMMAND>
 
 Commands:
-  lean_node        Start the lean node
-  beacon_node      Start the beacon node
-  validator_node   Start the validator node
-  account_manager  Manage validator accounts
-  voluntary_exit   Perform voluntary exit for a validator
-  help             Print this message or the help of the given subcommand(s)
+  lean_node             Start the lean node
+  beacon_node           Start the beacon node
+  validator_node        Start the validator node
+  account_manager       Manage validator accounts
+  voluntary_exit        Perform voluntary exit for a validator
+  generate_network_key  Generate a network key for lean node
+  help                  Print this message or the help of the given subcommand(s)
 
 Options:
       --data-dir <DATA_DIR>  The directory for storing application data. If used together with --ephemeral, new child directory will be created.

--- a/book/cli/ream/generate_network_key.md
+++ b/book/cli/ream/generate_network_key.md
@@ -1,0 +1,14 @@
+# ream generate_network_key
+
+Generate a network key for lean node
+
+```bash
+$ ream generate_network_key --help
+```
+```txt
+Usage: ream generate_network_key --output-path <OUTPUT_PATH>
+
+Options:
+      --output-path <OUTPUT_PATH>  Output path for the generated network key
+  -h, --help                       Print help
+```


### PR DESCRIPTION
### What was wrong?

Fixes #765 

### How was it fixed?

Added a cli command to generate a secp256k1 keypair.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
