### PR TITLE
feat: dont allow dialing own peer id

### DIFF
--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -358,15 +358,16 @@ impl LeanNetworkService {
     async fn connect_to_peers(&mut self, peers: Vec<Multiaddr>) {
         trace!("Discovered peers: {peers:?}");
         for peer in peers {
-            if let Err(err) = self.swarm.dial(peer.clone()) {
-                warn!("Failed to dial peer: {err:?}");
-                continue;
-            }
-
             if let Some(Protocol::P2p(peer_id)) = peer
                 .iter()
                 .find(|protocol| matches!(protocol, Protocol::P2p(_)))
+                && peer_id != self.local_peer_id()
             {
+                if let Err(err) = self.swarm.dial(peer.clone()) {
+                    warn!("Failed to dial peer: {err:?}");
+                    continue;
+                }
+
                 info!("Dialing peer: {peer_id:?}",);
                 self.peer_table
                     .lock()


### PR DESCRIPTION
### What was wrong?

Fixes #790

### How was it fixed?
Does not allow dialing to its own peer using a check

Tested with this:
this test is not added to the codebase since it felt rather trivial.

```
    #[tokio::test]
    #[traced_test]
    async fn test_no_self_conenction() -> anyhow::Result<()> {
        let socket_port1 = 9000;

        let (mut node1, mut node1_addr) = setup_lean_node(socket_port1).await?;

        let node1_peer_id = node1.local_peer_id();

        node1_addr.push(Protocol::Udp(socket_port1));
        node1_addr.push(Protocol::QuicV1);
        node1_addr.push(Protocol::P2p(node1_peer_id));

        let node1_handle = tokio::spawn(async move {
            let bootnodes = Bootnodes::Multiaddr(vec![node1_addr]);

            node1.start(bootnodes).await.unwrap();
        });

        tokio::time::sleep(Duration::from_millis(100)).await;

        node1_handle.abort();

        assert!(!logs_contain(&format!(
            "Dialing peer: PeerId(\"{node1_peer_id}\")"
        )));

        Ok(())
    }

```
