### PR TITLE
fix: justifications_validators should vary with number of roots

### DIFF
--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -128,12 +128,11 @@ impl LeanState {
         }
 
         // Create a new Bitlist with all the flattened votes
-        let mut justifications_validators = BitList::with_capacity(
-            justifications.len() * VALIDATOR_REGISTRY_LIMIT as usize,
-        )
-        .map_err(|err| {
-            anyhow!("Failed to create BitList for justifications_validators: {err:?}")
-        })?;
+        let mut justifications_validators =
+            BitList::with_capacity(justifications.len() * VALIDATOR_REGISTRY_LIMIT as usize)
+                .map_err(|err| {
+                    anyhow!("Failed to create BitList for justifications_validators: {err:?}")
+                })?;
 
         flattened_justifications.iter().enumerate().try_for_each(
             |(index, justification)| -> anyhow::Result<()> {
@@ -592,24 +591,28 @@ mod test {
 
         // Test with a single root
         let root0 = B256::repeat_byte(0);
-        let bitlist0 =
-            BitList::<U4096>::with_capacity(VALIDATOR_REGISTRY_LIMIT as usize).unwrap();
+        let bitlist0 = BitList::<U4096>::with_capacity(VALIDATOR_REGISTRY_LIMIT as usize).unwrap();
 
         justifications.insert(root0, bitlist0);
 
         state.set_justifications(justifications.clone()).unwrap();
         assert_eq!(state.justifications_roots.len(), 1);
-        assert_eq!(state.justifications_validators.len(), VALIDATOR_REGISTRY_LIMIT as usize);
+        assert_eq!(
+            state.justifications_validators.len(),
+            VALIDATOR_REGISTRY_LIMIT as usize
+        );
 
         // Test with 2 roots
         let root1 = B256::repeat_byte(1);
-        let bitlist1 =
-            BitList::<U4096>::with_capacity(VALIDATOR_REGISTRY_LIMIT as usize).unwrap();
+        let bitlist1 = BitList::<U4096>::with_capacity(VALIDATOR_REGISTRY_LIMIT as usize).unwrap();
 
         justifications.insert(root1, bitlist1);
         state.set_justifications(justifications).unwrap();
         assert_eq!(state.justifications_roots.len(), 2);
-        assert_eq!(state.justifications_validators.len(), 2 * VALIDATOR_REGISTRY_LIMIT as usize);
+        assert_eq!(
+            state.justifications_validators.len(),
+            2 * VALIDATOR_REGISTRY_LIMIT as usize
+        );
     }
 
     #[test]


### PR DESCRIPTION
### What was wrong?

Observed by @syjn99:

> Just curious about `justifications_validators` field of LeanState: Why do we need to have the length of 1073741824 every time? I'm currently analyzing what's the main bottleneck for this PR: https://github.com/ReamLabs/ream/pull/786 and found that only calculating hash tree root of `state.justifications_validators` took 300>ms.
>
>> 2025-09-22T14:14:18.796463Z  WARN ream_chain_lean::lean_chain: Computing hash tree root of justifications_validators took 381.23575ms

### How was it fixed?

- The `BitList` was initialized with `MAX_HISTORICAL_BLOCK_HASHES *` but it should only be the number of existing roots
- Added a unit test to verify & guarantee this

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
