### PR TITLE
docs: make Ream Book more prevalent in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)][tg-url]
 
 
+**[Install](https://ream.rs/installation.html)**
+| [User Docs](https://ream.rs)
+
 ## What is Ream
 
 Ream aims to be modular, contributor-friendly, and blazingly fast implementation of the Lean Consensus specification.
@@ -22,6 +25,10 @@ Building the first Lean consenus client which is
 - Contributor Friendly
 - Blazingly Fast
 - Extendible
+
+## For Users
+
+See the [Ream documentation](https://ream.rs) for instructions on how to install and run Ream.
 
 ## Getting Help
 


### PR DESCRIPTION
### What was wrong?

It could be more clear where users should look to learn more about Ream and set it up

### How was it fixed?

Updating the Read me
