### PR TITLE
chore: improve logging & apply verbosity 

### DIFF
--- a/bin/ream/src/cli/account_manager.rs
+++ b/bin/ream/src/cli/account_manager.rs
@@ -5,10 +5,6 @@ const DEFAULT_NUM_ACTIVE_EPOCHS: u32 = 1 << 18;
 
 #[derive(Debug, Parser, Default)]
 pub struct AccountManagerConfig {
-    /// Verbosity level
-    #[arg(short, long, default_value_t = 3)]
-    pub verbosity: u8,
-
     /// Account lifetime in 2 ** lifetime slots
     #[arg(short, long, default_value_t = 18, value_parser = clap::value_parser!(u32).range(18..))]
     pub lifetime: u32,

--- a/bin/ream/src/cli/beacon_node.rs
+++ b/bin/ream/src/cli/beacon_node.rs
@@ -15,10 +15,6 @@ use crate::cli::constants::{
 
 #[derive(Debug, Parser)]
 pub struct BeaconNodeConfig {
-    /// Verbosity level
-    #[arg(short, long, default_value_t = 3)]
-    pub verbosity: u8,
-
     #[arg(
       long,
       help = "Choose mainnet, holesky, sepolia, hoodi, dev or provide a path to a YAML config file",

--- a/bin/ream/src/cli/lean_node.rs
+++ b/bin/ream/src/cli/lean_node.rs
@@ -11,10 +11,6 @@ use crate::cli::constants::{
 
 #[derive(Debug, Parser)]
 pub struct LeanNodeConfig {
-    /// Verbosity level
-    #[arg(short, long, default_value_t = 3)]
-    pub verbosity: u8,
-
     #[arg(
       long,
       help = "Provide a path to a YAML config file, or use 'ephemery' for the Ephemery network",

--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod generate_private_key;
 pub mod import_keystores;
 pub mod lean_node;
 pub mod validator_node;
+pub mod verbosity;
 pub mod voluntary_exit;
 
 use std::path::PathBuf;
@@ -15,12 +16,16 @@ use ream_node::version::FULL_VERSION;
 use crate::cli::{
     account_manager::AccountManagerConfig, beacon_node::BeaconNodeConfig,
     generate_private_key::GeneratePrivateKeyConfig, lean_node::LeanNodeConfig,
-    validator_node::ValidatorNodeConfig, voluntary_exit::VoluntaryExitConfig,
+    validator_node::ValidatorNodeConfig, verbosity::Verbosity, voluntary_exit::VoluntaryExitConfig,
 };
 
 #[derive(Debug, Parser)]
 #[command(author, version = FULL_VERSION, about, long_about = None)]
 pub struct Cli {
+    /// Verbosity level (1=error, 2=warn, 3=info, 4=debug, 5=trace)
+    #[arg(short, long, default_value = "3")]
+    pub verbosity: Verbosity,
+
     #[command(subcommand)]
     pub command: Commands,
 
@@ -86,8 +91,6 @@ mod tests {
         let cli = Cli::parse_from([
             "program",
             "lean_node",
-            "--verbosity",
-            "2",
             "--network",
             "./assets/lean/sample_spec.yml",
             "--validator-registry-path",
@@ -96,7 +99,7 @@ mod tests {
 
         match cli.command {
             Commands::LeanNode(config) => {
-                assert_eq!(config.verbosity, 2);
+                // assert_eq!(config.network, "./assets/lean/sample_spec.yml");
             }
             _ => unreachable!("This test should only validate the lean node cli"),
         }
@@ -107,8 +110,6 @@ mod tests {
         let cli = Cli::parse_from([
             "program",
             "beacon_node",
-            "--verbosity",
-            "2",
             "--socket-address",
             "127.0.0.1",
             "--socket-port",
@@ -120,7 +121,6 @@ mod tests {
         match cli.command {
             Commands::BeaconNode(config) => {
                 assert_eq!(config.network.network, Network::Mainnet);
-                assert_eq!(config.verbosity, 2);
                 assert_eq!(
                     config.socket_address,
                     IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
@@ -137,8 +137,6 @@ mod tests {
         let cli = Cli::parse_from([
             "program",
             "validator_node",
-            "--verbosity",
-            "2",
             "--beacon-api-endpoint",
             "http://localhost:5052",
             "--request-timeout",
@@ -153,7 +151,6 @@ mod tests {
 
         match cli.command {
             Commands::ValidatorNode(config) => {
-                assert_eq!(config.verbosity, 2);
                 assert_eq!(
                     config.beacon_api_endpoint,
                     Url::parse(DEFAULT_BEACON_API_ENDPOINT).expect("Invalid URL")
@@ -169,8 +166,6 @@ mod tests {
         let cli = Cli::parse_from([
             "program",
             "account_manager",
-            "--verbosity",
-            "2",
             "--lifetime",
             "30",
             "--chunk-size",
@@ -183,7 +178,6 @@ mod tests {
 
         match cli.command {
             Commands::AccountManager(config) => {
-                assert_eq!(config.verbosity, 2);
                 assert_eq!(config.lifetime, 30);
                 assert_eq!(config.chunk_size, 10);
                 assert_eq!(config.activation_epoch, 100);

--- a/bin/ream/src/cli/validator_node.rs
+++ b/bin/ream/src/cli/validator_node.rs
@@ -12,10 +12,6 @@ use crate::cli::constants::{
 
 #[derive(Debug, Parser)]
 pub struct ValidatorNodeConfig {
-    /// Verbosity level
-    #[arg(short, long, default_value_t = 3)]
-    pub verbosity: u8,
-
     #[arg(long, help = "Set HTTP url of the beacon api endpoint", default_value = DEFAULT_BEACON_API_ENDPOINT)]
     pub beacon_api_endpoint: Url,
 

--- a/bin/ream/src/cli/verbosity.rs
+++ b/bin/ream/src/cli/verbosity.rs
@@ -1,0 +1,28 @@
+#[derive(Debug, Clone, Copy)]
+pub struct Verbosity(pub u8);
+
+impl Verbosity {
+    pub fn directive(&self) -> &str {
+        match self.0 - 1 {
+            0 => "error",
+            1 => "warn",
+            2 => "info",
+            3 => "debug",
+            _ => "trace",
+        }
+    }
+}
+
+impl std::str::FromStr for Verbosity {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<u8>().map(Verbosity)
+    }
+}
+
+impl std::fmt::Display for Verbosity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/bin/ream/src/cli/voluntary_exit.rs
+++ b/bin/ream/src/cli/voluntary_exit.rs
@@ -11,10 +11,6 @@ use crate::cli::{
 
 #[derive(Debug, Parser)]
 pub struct VoluntaryExitConfig {
-    /// Verbosity level
-    #[arg(short, long, default_value_t = 3)]
-    pub verbosity: u8,
-
     #[arg(long, help = "Set HTTP url of the beacon api endpoint", default_value = DEFAULT_BEACON_API_ENDPOINT)]
     pub beacon_api_endpoint: Url,
 

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -209,7 +209,6 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
             socket_port: config.socket_port,
             private_key_path: config.private_key_path,
         }),
-        lean_chain_reader.clone(),
         executor.clone(),
         chain_sender.clone(),
         outbound_p2p_receiver,

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -75,16 +75,19 @@ pub const APP_NAME: &str = "ream";
 /// appropriate node type (beacon node, validator node, or account manager) based on the command
 /// line arguments. Handles graceful shutdown on Ctrl-C.
 fn main() {
-    // Set the default log level to `info` if not set
+    let cli = Cli::parse();
+
+    // Set the default log level based on verbosity flag or RUST_LOG env var
     let rust_log = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default();
     let env_filter = match rust_log.is_empty() {
-        true => EnvFilter::builder().parse_lossy("info,actix_server=warn,discv5=error"),
+        true => EnvFilter::builder().parse_lossy(format!(
+            "{},actix_server=warn,discv5=error",
+            cli.verbosity.directive()
+        )),
         false => EnvFilter::builder().parse_lossy(rust_log),
     };
 
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
-
-    let cli = Cli::parse();
 
     let executor = ReamExecutor::new().expect("unable to create executor");
     let executor_clone = executor.clone();

--- a/book/cli/ream.md
+++ b/book/cli/ream.md
@@ -18,9 +18,10 @@ Commands:
   help                  Print this message or the help of the given subcommand(s)
 
 Options:
-      --data-dir <DATA_DIR>  The directory for storing application data. If used together with --ephemeral, new child directory will be created.
-  -e, --ephemeral            Use new data directory, located in OS temporary directory. If used together with --data-dir, new directory will be created there instead.
-      --purge-db             Purges the database.
-  -h, --help                 Print help
-  -V, --version              Print version
+  -v, --verbosity <VERBOSITY>  Verbosity level (1=error, 2=warn, 3=info, 4=debug, 5=trace) [default: 3]
+      --data-dir <DATA_DIR>    The directory for storing application data. If used together with --ephemeral, new child directory will be created.
+  -e, --ephemeral              Use new data directory, located in OS temporary directory. If used together with --data-dir, new directory will be created there instead.
+      --purge-db               Purges the database.
+  -h, --help                   Print help
+  -V, --version                Print version
 ```

--- a/book/cli/ream/account_manager.md
+++ b/book/cli/ream/account_manager.md
@@ -9,8 +9,6 @@ $ ream account_manager --help
 Usage: ream account_manager [OPTIONS]
 
 Options:
-  -v, --verbosity <VERBOSITY>
-          Verbosity level [default: 3]
   -l, --lifetime <LIFETIME>
           Account lifetime in 2 ** lifetime slots [default: 18]
   -c, --chunk-size <CHUNK_SIZE>

--- a/book/cli/ream/beacon_node.md
+++ b/book/cli/ream/beacon_node.md
@@ -9,8 +9,6 @@ $ ream beacon_node --help
 Usage: ream beacon_node [OPTIONS]
 
 Options:
-  -v, --verbosity <VERBOSITY>
-          Verbosity level [default: 3]
       --network <NETWORK>
           Choose mainnet, holesky, sepolia, hoodi, dev or provide a path to a YAML config file [default: mainnet]
       --http-address <HTTP_ADDRESS>

--- a/book/cli/ream/lean_node.md
+++ b/book/cli/ream/lean_node.md
@@ -9,8 +9,6 @@ $ ream lean_node --help
 Usage: ream lean_node [OPTIONS] --network <NETWORK> --validator-registry-path <VALIDATOR_REGISTRY_PATH>
 
 Options:
-  -v, --verbosity <VERBOSITY>
-          Verbosity level [default: 3]
       --network <NETWORK>
           Provide a path to a YAML config file, or use 'ephemery' for the Ephemery network
       --bootnodes <BOOTNODES>

--- a/book/cli/ream/validator_node.md
+++ b/book/cli/ream/validator_node.md
@@ -9,8 +9,6 @@ $ ream validator_node --help
 Usage: ream validator_node [OPTIONS] --import-keystores <IMPORT_KEYSTORES> --suggested-fee-recipient <SUGGESTED_FEE_RECIPIENT>
 
 Options:
-  -v, --verbosity <VERBOSITY>
-          Verbosity level [default: 3]
       --beacon-api-endpoint <BEACON_API_ENDPOINT>
           Set HTTP url of the beacon api endpoint [default: http://localhost:5052]
       --request-timeout <REQUEST_TIMEOUT>

--- a/book/cli/ream/voluntary_exit.md
+++ b/book/cli/ream/voluntary_exit.md
@@ -9,8 +9,6 @@ $ ream voluntary_exit --help
 Usage: ream voluntary_exit [OPTIONS] --import-keystores <IMPORT_KEYSTORES> --validator-index <VALIDATOR_INDEX>
 
 Options:
-  -v, --verbosity <VERBOSITY>
-          Verbosity level [default: 3]
       --beacon-api-endpoint <BEACON_API_ENDPOINT>
           Set HTTP url of the beacon api endpoint [default: http://localhost:5052]
       --request-timeout <REQUEST_TIMEOUT>

--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -305,8 +305,11 @@ impl LeanState {
                 .ok_or(anyhow!("Source slot not found in justified_slots"))?
             {
                 info!(
-                    "Skipping vote. Source slot not justified: validator_id={}, source={:?}, target={:?}",
-                    signed_vote.validator_id, vote.source, vote.target
+                    reason = "Source slot not justified",
+                    source_slot = vote.source.slot,
+                    target_slot = vote.target.slot,
+                    "Skipping vote by Validator {}",
+                    signed_vote.validator_id,
                 );
                 continue;
             }
@@ -321,8 +324,11 @@ impl LeanState {
                 .ok_or(anyhow!("Target slot not found in justified_slots"))?
             {
                 info!(
-                    "Skipping vote. Target slot already justified: validator_id={}, source={:?}, target={:?}",
-                    signed_vote.validator_id, vote.source, vote.target
+                    reason = "Target slot already justified",
+                    source_slot = vote.source.slot,
+                    target_slot = vote.target.slot,
+                    "Skipping vote by Validator {}",
+                    signed_vote.validator_id,
                 );
                 continue;
             }
@@ -334,8 +340,11 @@ impl LeanState {
                     .ok_or(anyhow!("Source slot not found in historical_block_hashes"))?
             {
                 info!(
-                    "Skipping vote. Source block not in historical block hashes: validator_id={}, source={:?}, target={:?}",
-                    signed_vote.validator_id, vote.source, vote.target
+                    reason = "Source block not in historical block hashes",
+                    source_slot = vote.source.slot,
+                    target_slot = vote.target.slot,
+                    "Skipping vote by Validator {}",
+                    signed_vote.validator_id,
                 );
                 continue;
             }
@@ -347,24 +356,33 @@ impl LeanState {
                     .ok_or(anyhow!("Target slot not found in historical_block_hashes"))?
             {
                 info!(
-                    "Skipping vote. Target block not in historical block hashes: validator_id={}, source={:?}, target={:?}",
-                    signed_vote.validator_id, vote.source, vote.target
+                    reason = "Target block not in historical block hashes",
+                    source_slot = vote.source.slot,
+                    target_slot = vote.target.slot,
+                    "Skipping vote by Validator {}",
+                    signed_vote.validator_id,
                 );
                 continue;
             }
 
             if vote.target.slot <= vote.source.slot {
                 info!(
-                    "Skipping vote. Target slot not greater than source slot: validator_id={}, source={:?}, target={:?}",
-                    signed_vote.validator_id, vote.source, vote.target
+                    reason = "Target slot not greater than source slot",
+                    source_slot = vote.source.slot,
+                    target_slot = vote.target.slot,
+                    "Skipping vote by Validator {}",
+                    signed_vote.validator_id,
                 );
                 continue;
             }
 
             if !is_justifiable_slot(self.latest_finalized.slot, vote.target.slot) {
                 info!(
-                    "Skipping vote. Target slot not justifiable: validator_id={}, source={:?}, target={:?}",
-                    signed_vote.validator_id, vote.source, vote.target
+                    reason = "Target slot not justifiable",
+                    source_slot = vote.source.slot,
+                    target_slot = vote.target.slot,
+                    "Skipping vote by Validator {}",
+                    signed_vote.validator_id,
                 );
                 continue;
             }
@@ -403,8 +421,9 @@ impl LeanState {
                 justifications_map.remove(&vote.target.root);
 
                 info!(
-                    "Block justified: checkpoint={:?}, num_votes={count}",
-                    vote.target
+                    slot = self.latest_justified.slot,
+                    root = ?self.latest_justified.root,
+                    "Justification event",
                 );
                 set_int_gauge_vec(&JUSTIFIED_SLOT, self.latest_justified.slot as i64, &[]);
 
@@ -417,7 +436,11 @@ impl LeanState {
                 if is_target_next_valid_justifiable_slot {
                     self.latest_finalized = vote.source.clone();
 
-                    info!("Block finalized: checkpoint={:?}", vote.source);
+                    info!(
+                        slot = self.latest_finalized.slot,
+                        root = ?self.latest_finalized.root,
+                        "Finalization event",
+                    );
                     set_int_gauge_vec(&FINALIZED_SLOT, self.latest_finalized.slot as i64, &[]);
                 }
             }

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -7,7 +7,7 @@ use ream_chain_lean::{
 use ream_consensus_lean::{block::SignedBlock, vote::SignedVote};
 use ream_network_spec::networks::lean_network_spec;
 use tokio::sync::{mpsc, oneshot};
-use tracing::info;
+use tracing::{debug, info};
 use tree_hash::TreeHash;
 
 use crate::registry::LeanKeystore;
@@ -41,9 +41,9 @@ impl ValidatorService {
 
     pub async fn start(self) -> anyhow::Result<()> {
         info!(
-            "ValidatorService started with {} validator(s), genesis_time: {}",
-            self.keystores.len(),
-            lean_network_spec().genesis_time
+            genesis_time = lean_network_spec().genesis_time,
+            "ValidatorService started with {} validator(s)",
+            self.keystores.len()
         );
 
         let mut tick_count = 0u64;
@@ -63,7 +63,7 @@ impl ValidatorService {
 
                             // First tick (t=0): Propose a block.
                             if let Some(keystore) = self.is_proposer(slot) {
-                                info!("Validator {} proposing block for slot {slot} (tick {tick_count})", keystore.validator_id);
+                                info!(slot, tick = tick_count, "Proposing block by Validator {}", keystore.validator_id);
 
                                 let (tx, rx) = oneshot::channel();
                                 self.chain_sender
@@ -74,13 +74,10 @@ impl ValidatorService {
                                 let new_block = rx.await.expect("Failed to receive block from LeanChainService");
 
                                 info!(
-                                    "Validator {} built block: slot={}, root={:?}, parent={:?}, votes={}, state_root={:?}",
+                                    slot = new_block.slot,
+                                    block_root = ?new_block.tree_hash_root(),
+                                    "Building block finished by Validator {}",
                                     keystore.validator_id,
-                                    new_block.slot,
-                                    new_block.tree_hash_root(),
-                                    new_block.parent_root,
-                                    new_block.body.attestations.len(),
-                                    new_block.state_root
                                 );
 
                                 // TODO: Sign the block with the keystore.
@@ -100,14 +97,20 @@ impl ValidatorService {
                         }
                         1 => {
                             // Second tick (t=1/4): Vote.
-                            info!("Starting vote phase at slot {slot} (tick {tick_count}): {} validator(s) voting", self.keystores.len());
+                            info!(slot, tick = tick_count, "Starting vote phase: {} validator(s) voting", self.keystores.len());
 
                             // Build the vote from LeanChain, and modify its validator ID
                             let vote_template = self.lean_chain.read().await.build_vote(slot).await.expect("Failed to build vote");
                             info!(
-                                "Built vote template for head={:?}, slot={}, source={:?}, target={:?}",
+                                slot = vote_template.slot,
+                                head_slot = vote_template.head.slot,
+                                source_slot = vote_template.source.slot,
+                                target_slot = vote_template.target.slot,
+                                "Building vote template finished",
+                            );
+                            debug!(
+                                "Vote template details: head={:?}, source={:?}, target={:?}",
                                 vote_template.head,
-                                vote_template.slot,
                                 vote_template.source,
                                 vote_template.target
                             );

--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -19,9 +19,7 @@ use libp2p::{
 };
 use libp2p_identity::{Keypair, PeerId, secp256k1};
 use parking_lot::Mutex;
-use ream_chain_lean::{
-    lean_chain::LeanChainReader, messages::LeanChainServiceMessage, p2p_request::LeanP2PRequest,
-};
+use ream_chain_lean::{messages::LeanChainServiceMessage, p2p_request::LeanP2PRequest};
 use ream_executor::ReamExecutor;
 use ssz::Encode;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -79,7 +77,6 @@ pub struct LeanNetworkConfig {
 ///
 /// TBD: It will be best if we reuse the existing NetworkManagerService for the beacon node.
 pub struct LeanNetworkService {
-    lean_chain: LeanChainReader,
     network_config: Arc<LeanNetworkConfig>,
     swarm: Swarm<ReamBehaviour>,
     peer_table: Arc<Mutex<HashMap<PeerId, ConnectionState>>>,
@@ -90,7 +87,6 @@ pub struct LeanNetworkService {
 impl LeanNetworkService {
     pub async fn new(
         network_config: Arc<LeanNetworkConfig>,
-        lean_chain: LeanChainReader,
         executor: ReamExecutor,
         chain_message_sender: UnboundedSender<LeanChainServiceMessage>,
         outbound_p2p_request: UnboundedReceiver<LeanP2PRequest>,
@@ -170,7 +166,6 @@ impl LeanNetworkService {
         };
 
         let mut lean_network_service = LeanNetworkService {
-            lean_chain,
             network_config: network_config.clone(),
             swarm,
             peer_table: Arc::new(Mutex::new(HashMap::new())),
@@ -206,10 +201,6 @@ impl LeanNetworkService {
 
     pub async fn start(&mut self, bootnodes: Bootnodes) -> anyhow::Result<()> {
         info!("LeanNetworkService started");
-        info!(
-            "Current LeanChain head: {}",
-            self.lean_chain.read().await.head
-        );
 
         self.connect_to_peers(bootnodes.to_multiaddrs_lean()).await;
         loop {
@@ -231,9 +222,16 @@ impl LeanNetworkService {
                                     signed_block.as_ssz_bytes(),
                                 )
                             {
-                                warn!("publish block for slot {} failed: {err:?}", signed_block.message.slot);
+                                warn!(
+                                    slot = signed_block.message.slot,
+                                    error = ?err,
+                                    "Publish block failed"
+                                );
                             } else {
-                                info!("broadcasted block for slot {}", signed_block.message.slot);
+                                info!(
+                                    slot = signed_block.message.slot,
+                                    "Broadcasted block"
+                                );
                             }
                         }
                         LeanP2PRequest::GossipVote(signed_vote) => {
@@ -251,9 +249,16 @@ impl LeanNetworkService {
                                     signed_vote.as_ssz_bytes(),
                                 )
                             {
-                                warn!("publish vote for slot {} failed: {err:?}", signed_vote.message.slot);
+                                warn!(
+                                    slot = signed_vote.message.slot,
+                                    error = ?err,
+                                    "Publish vote failed"
+                                );
                             } else {
-                                info!("broadcasted vote for slot {}", signed_vote.message.slot);
+                                info!(
+                                    slot = signed_vote.message.slot,
+                                    "Broadcasted vote"
+                                );
                             }
                         }
                     }
@@ -389,14 +394,9 @@ impl LeanNetworkService {
 mod tests {
     use std::{net::Ipv4Addr, sync::Once, time::Duration};
 
-    use alloy_primitives::B256;
     use libp2p::{Multiaddr, multiaddr::Protocol};
-    use ream_chain_lean::lean_chain::LeanChain;
     use ream_network_spec::networks::{LeanNetworkSpec, set_lean_network_spec};
-    use ream_storage::db::ReamDB;
-    use ream_sync::rwlock::Writer;
-    use tempdir::TempDir;
-    use tokio::sync::{Mutex, mpsc};
+    use tokio::sync::mpsc;
     use tracing_test::traced_test;
 
     use super::*;
@@ -410,30 +410,11 @@ mod tests {
         });
     }
 
-    fn create_lean_chain() -> LeanChain {
-        let temp_dir = TempDir::new("lean_node_test").unwrap();
-        let temp_path = temp_dir.path().to_path_buf();
-
-        let ream_db = ReamDB::new(temp_path).expect("unable to init Ream Database");
-        let lean_db = ream_db
-            .init_lean_db()
-            .expect("unable to init Ream Lean Database");
-        LeanChain {
-            store: Arc::new(Mutex::new(lean_db)),
-            head: B256::default(),
-            safe_target: B256::default(),
-            new_votes: Vec::new(),
-            genesis_hash: B256::default(),
-            num_validators: 0,
-        }
-    }
-
     pub async fn setup_lean_node(
         socket_port: u16,
     ) -> anyhow::Result<(LeanNetworkService, Multiaddr)> {
         ensure_network_spec_init();
 
-        let (_, lean_chain_reader) = Writer::new(create_lean_chain());
         let executor = ReamExecutor::new().expect("Failed to create executor");
         let config = Arc::new(LeanNetworkConfig {
             gossipsub_config: LeanGossipsubConfig::default(),
@@ -444,14 +425,9 @@ mod tests {
         let (sender, _receiver) = mpsc::unbounded_channel::<LeanChainServiceMessage>();
         let (_outbound_request_sender_unused, outbound_request_receiver) =
             mpsc::unbounded_channel::<LeanP2PRequest>();
-        let node = LeanNetworkService::new(
-            config.clone(),
-            lean_chain_reader,
-            executor,
-            sender,
-            outbound_request_receiver,
-        )
-        .await?;
+        let node =
+            LeanNetworkService::new(config.clone(), executor, sender, outbound_request_receiver)
+                .await?;
         let multi_addr: Multiaddr = config.socket_address.into();
         Ok((node, multi_addr))
     }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

- Logging isn't clear and verbose. In Lean development, we mostly see the slot number for justification/finalization.
- Verbosity wasn't applied even though we all have it in subcommand.


### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

<img width="2286" height="1328" alt="image" src="https://github.com/user-attachments/assets/3433cd51-8c61-4bca-9a28-4d819d434832" />

- Used structured logging with consistency. 
  - I didn't use structured manner for validator (`by Validator N`) for readability.
- Add `verbosity` as a common flag for all subcommands.


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
