### PR TITLE
fix: correct reporting for lean_head_slot metric

### DIFF
--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -4,7 +4,7 @@ use alloy_primitives::B256;
 use anyhow::{Context, anyhow, ensure};
 use itertools::Itertools;
 use ream_consensus_misc::constants::lean::{MAX_HISTORICAL_BLOCK_HASHES, VALIDATOR_REGISTRY_LIMIT};
-use ream_metrics::{FINALIZED_SLOT, HEAD_SLOT, JUSTIFIED_SLOT, set_int_gauge_vec};
+use ream_metrics::{FINALIZED_SLOT, JUSTIFIED_SLOT, set_int_gauge_vec};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
@@ -199,9 +199,6 @@ impl LeanState {
     }
 
     fn process_block(&mut self, block: &Block) -> anyhow::Result<()> {
-        // Send latest head slot to metrics
-        set_int_gauge_vec(&HEAD_SLOT, block.slot as i64, &[]);
-
         self.process_block_header(block)?;
         self.process_operations(&block.body)?;
 


### PR DESCRIPTION
### What was wrong?

Fixes: #821 

### How was it fixed?

Moved metric tracking to update_head() as recommended in the issue.

<img width="753" height="587" alt="image" src="https://github.com/user-attachments/assets/50bd007c-86b5-4404-adde-cd269cf84372" />

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
