### PR TITLE
feat(lean): remove `dependencies` in `LeanChainService` & implement `on_attestation` of fork choice specification 

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -177,13 +177,8 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
     let (chain_sender, chain_receiver) = mpsc::unbounded_channel::<LeanChainServiceMessage>();
     let (outbound_p2p_sender, outbound_p2p_receiver) = mpsc::unbounded_channel::<LeanP2PRequest>();
 
-    let chain_service = LeanChainService::new(
-        lean_chain_writer,
-        chain_receiver,
-        chain_sender.clone(),
-        outbound_p2p_sender,
-    )
-    .await;
+    let chain_service =
+        LeanChainService::new(lean_chain_writer, chain_receiver, outbound_p2p_sender).await;
 
     let fork = "devnet0".to_string();
     let topics: Vec<LeanGossipTopic> = vec![

--- a/crates/common/chain/lean/src/lean_chain.rs
+++ b/crates/common/chain/lean/src/lean_chain.rs
@@ -368,9 +368,7 @@ impl LeanChain {
             // ```
             if latest_known_votes_provider
                 .get(validator_id)?
-                .map_or(true, |latest_vote| {
-                    latest_vote.message.slot < signed_vote.message.slot
-                })
+                .is_none_or(|latest_vote| latest_vote.message.slot < signed_vote.message.slot)
             {
                 latest_known_votes_provider.insert(validator_id, signed_vote.clone())?;
             }
@@ -398,9 +396,7 @@ impl LeanChain {
             if self
                 .latest_new_votes
                 .get(&validator_id)
-                .map_or(true, |latest_vote| {
-                    latest_vote.message.slot < signed_vote.message.slot
-                })
+                .is_none_or(|latest_vote| latest_vote.message.slot < signed_vote.message.slot)
             {
                 self.latest_new_votes
                     .insert(validator_id, signed_vote.clone());

--- a/crates/common/chain/lean/src/lib.rs
+++ b/crates/common/chain/lean/src/lib.rs
@@ -3,6 +3,5 @@ pub mod genesis;
 pub mod lean_chain;
 pub mod messages;
 pub mod p2p_request;
-pub mod queue_item;
 pub mod service;
 pub mod slot;

--- a/crates/common/chain/lean/src/queue_item.rs
+++ b/crates/common/chain/lean/src/queue_item.rs
@@ -1,8 +1,7 @@
-use ream_consensus_lean::{block::Block, vote::SignedVote};
+use ream_consensus_lean::vote::SignedVote;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum QueueItem {
-    Block(Block),
     SignedVote(Box<SignedVote>),
 }

--- a/crates/common/chain/lean/src/queue_item.rs
+++ b/crates/common/chain/lean/src/queue_item.rs
@@ -1,7 +1,0 @@
-use ream_consensus_lean::vote::SignedVote;
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum QueueItem {
-    SignedVote(Box<SignedVote>),
-}

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -217,7 +217,7 @@ impl LeanChainService {
             return Ok(());
         }
 
-        let parent_state = self
+        let mut state = self
             .lean_chain
             .read()
             .await
@@ -232,8 +232,6 @@ impl LeanChainService {
                     signed_block.message.parent_root
                 )
             })?;
-
-        let mut state = parent_state.clone();
         state.state_transition(&signed_block, true, true)?;
 
         let mut lean_chain = self.lean_chain.write().await;

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-
-use alloy_primitives::B256;
 use anyhow::{Context, anyhow};
 use ream_consensus_lean::{
     block::{Block, SignedBlock},
@@ -25,25 +22,19 @@ use crate::{
 pub struct LeanChainService {
     lean_chain: LeanChainWriter,
     receiver: mpsc::UnboundedReceiver<LeanChainServiceMessage>,
-    sender: mpsc::UnboundedSender<LeanChainServiceMessage>,
     outbound_gossip: mpsc::UnboundedSender<LeanP2PRequest>,
-    // Objects that we will process once we have processed their parents
-    dependencies: HashMap<B256, Vec<SignedVote>>,
 }
 
 impl LeanChainService {
     pub async fn new(
         lean_chain: LeanChainWriter,
         receiver: mpsc::UnboundedReceiver<LeanChainServiceMessage>,
-        sender: mpsc::UnboundedSender<LeanChainServiceMessage>,
         outbound_gossip: mpsc::UnboundedSender<LeanP2PRequest>,
     ) -> Self {
         LeanChainService {
             lean_chain,
             receiver,
-            sender,
             outbound_gossip,
-            dependencies: HashMap::new(),
         }
     }
 

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -216,8 +216,7 @@ impl LeanChainService {
         self.lean_chain
             .write()
             .await
-            .on_attestation(signed_vote.clone(), false)
-            .await?;
+            .on_attestation_from_gossip(signed_vote);
 
         Ok(())
     }

--- a/crates/storage/src/tables/lean/latest_known_votes.rs
+++ b/crates/storage/src/tables/lean/latest_known_votes.rs
@@ -64,21 +64,6 @@ impl LatestKnownVotesTable {
         Ok(())
     }
 
-    /// Check if a given vote exists in the append-only array.
-    pub fn contains(&self, value: &SignedVote) -> Result<bool, StoreError> {
-        let read_txn = self.db.begin_read()?;
-        let table = read_txn.open_table(LATEST_KNOWN_VOTES_TABLE)?;
-
-        for entry in table.iter()? {
-            let (_, v) = entry?;
-            if &v.value() == value {
-                return Ok(true);
-            }
-        }
-
-        Ok(false)
-    }
-
     /// Get all votes.
     pub fn get_all_votes(&self) -> Result<HashMap<u64, SignedVote>, StoreError> {
         let read_txn = self.db.begin_read()?;


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Fixes #787.

Our codebase is mostly came from 3sf-mini, which uses `dependencies` as a queue. However, this implementation is not intuitive as well as complex for real-world devnets.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

This PR mainly implements `on_attestation` ([Link](https://github.com/leanEthereum/leanSpec/blob/ee16b19825a1f358b00a6fc2d7847be549daa03b/docs/client/forkchoice.md?plain=1#L279-L312)) function. I did some optimization regarding database transaction using `batch_insert` (thanks to @varun-doshi), so the current code quite deviates from Python spec.

Also, `handle_process_{block|vote}` are now just a wrapper for future p2p validation. By implementing `on_block` and `on_attestation_*` under `LeanChain`, the function becomes much simpler because it removes tackling with synchronization stuffs (e.g., `lock()`...).

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
