### PR TITLE
chore(lean): add alias (`node-key`) for `private-key-path`

### DIFF
--- a/bin/ream/src/cli/lean_node.rs
+++ b/bin/ream/src/cli/lean_node.rs
@@ -35,7 +35,11 @@ pub struct LeanNodeConfig {
     )]
     pub node_id: String,
 
-    #[arg(long, help = "The path to the hex encoded secp256k1 libp2p key")]
+    #[arg(
+        long,
+        help = "The path to the hex encoded secp256k1 libp2p key",
+        alias = "node-key"
+    )]
     pub private_key_path: Option<PathBuf>,
 
     #[arg(long, help = "Set P2P socket address", default_value_t = DEFAULT_SOCKET_ADDRESS)]

--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -101,6 +101,9 @@ mod tests {
             "./assets/lean/sample_spec.yml",
             "--validator-registry-path",
             "./assets/lean/validator_registry.yml",
+            // Test for alias of `private-key-path`
+            "--node-key",
+            "awesome-node0.key",
         ]);
 
         assert_eq!(cli.verbosity, Verbosity::Trace);
@@ -117,6 +120,11 @@ mod tests {
                 assert_eq!(config.network.genesis_time, 0);
                 assert_eq!(config.network.justification_lookback_slots, 3);
                 assert_eq!(config.network.num_validators, 4);
+
+                assert_eq!(
+                    config.private_key_path.as_ref().unwrap().to_str().unwrap(),
+                    "awesome-node0.key"
+                );
             }
             _ => unreachable!("This test should only validate the lean node cli"),
         }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

> so as per our discussions 3 args are standard:
> 
> 1. —node-id (zeam_0, ream_0...)
> 2. —node_key : path to private key for enr/libp2p
> 3. —data-dir: path to data directory

We need an alias for `private-key-path` flag for better interop

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Use `alias` in `clap`

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
