### PR TITLE
feat: add beacon committee selection endpoint

### DIFF
--- a/crates/common/consensus/beacon/src/beacon_committee_selection.rs
+++ b/crates/common/consensus/beacon/src/beacon_committee_selection.rs
@@ -1,0 +1,13 @@
+use ream_bls::BLSSignature;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use tree_hash_derive::TreeHash;
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+pub struct BeaconCommitteeSelection {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub slot: u64,
+    pub selection_proof: BLSSignature,
+}

--- a/crates/common/consensus/beacon/src/lib.rs
+++ b/crates/common/consensus/beacon/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod attestation;
 pub mod attester_slashing;
+pub mod beacon_committee_selection;
 pub mod blob_sidecar;
 pub mod bls_to_execution_change;
 pub mod consolidation_request;

--- a/crates/rpc/beacon/src/handlers/validator.rs
+++ b/crates/rpc/beacon/src/handlers/validator.rs
@@ -14,7 +14,8 @@ use ream_api_types_beacon::{
 use ream_api_types_common::{error::ApiError, id::ID};
 use ream_bls::PublicKey;
 use ream_consensus_beacon::{
-    electra::beacon_state::BeaconState, sync_committe_selection::SyncCommitteeSelection,
+    beacon_committee_selection::BeaconCommitteeSelection, electra::beacon_state::BeaconState,
+    sync_committe_selection::SyncCommitteeSelection,
 };
 use ream_consensus_misc::{
     attestation_data::AttestationData, constants::beacon::SLOTS_PER_EPOCH, validator::Validator,
@@ -492,6 +493,14 @@ pub async fn get_attestation_data(
 #[post("/validator/sync_committee_selections")]
 pub async fn post_sync_committee_selections(
     _selections: Json<SyncCommitteeSelection>,
+) -> Result<impl Responder, ApiError> {
+    Ok(HttpResponse::NotImplemented())
+}
+
+/// For the initial stage, this endpoint returns a 501 as DVT support is not planned.
+#[post("/validator/beacon_committee_selections")]
+pub async fn post_beacon_committee_selections(
+    _selections: Json<Vec<BeaconCommitteeSelection>>,
 ) -> Result<impl Responder, ApiError> {
     Ok(HttpResponse::NotImplemented())
 }

--- a/crates/rpc/beacon/src/routes/validator.rs
+++ b/crates/rpc/beacon/src/routes/validator.rs
@@ -3,7 +3,7 @@ use actix_web::web::ServiceConfig;
 use crate::handlers::{
     duties::{get_attester_duties, get_proposer_duties},
     prepare_beacon_proposer::prepare_beacon_proposer,
-    validator::get_attestation_data,
+    validator::{get_attestation_data, post_beacon_committee_selections},
 };
 
 pub fn register_validator_routes(config: &mut ServiceConfig) {
@@ -11,4 +11,5 @@ pub fn register_validator_routes(config: &mut ServiceConfig) {
     config.service(get_attester_duties);
     config.service(prepare_beacon_proposer);
     config.service(get_attestation_data);
+    config.service(post_beacon_committee_selections);
 }


### PR DESCRIPTION
### What was wrong?

 Fixes #237

### How was it fixed?

implemented GET [/eth/v1/validator/beacon_committee_selections](https://ethereum.github.io/beacon-APIs/#/Validator/submitBeaconCommitteeSelections) endpoint which returns a 501 Not Implemented.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
