### PR TITLE
fix(lean/p2p): remove hex encoding for lean gossip topic

### DIFF
--- a/crates/networking/p2p/src/gossipsub/lean/topics.rs
+++ b/crates/networking/p2p/src/gossipsub/lean/topics.rs
@@ -48,8 +48,7 @@ impl std::fmt::Display for LeanGossipTopic {
         write!(
             f,
             "/{TOPIC_PREFIX}/{}/{}/{ENCODING_POSTFIX}",
-            self.fork.encode_hex(),
-            self.kind,
+            self.fork, self.kind,
         )
     }
 }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
