### PR TITLE
fix(lean/p2p): increase `max_established_per_peer` into 2

### DIFF
--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -95,7 +95,7 @@ impl LeanNetworkService {
             let limits = ConnectionLimits::default()
                 .with_max_pending_incoming(Some(5))
                 .with_max_pending_outgoing(Some(16))
-                .with_max_established_per_peer(Some(1));
+                .with_max_established_per_peer(Some(2));
 
             connection_limits::Behaviour::new(limits)
         };


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

When a node tries to establish a duplicated connection, the existing connection got disconnected, leading some p2p issues in pq devnet0. We're using same `nodes.yaml`, which means there should be at least two duplicated connection here.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Increase `max_established_per_peer` value into 2.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
