### PR TITLE
feat: add zk proof generated by risc0 for state transition in lean consensus

### DIFF
--- a/bin/ream/src/cli/mod.rs
+++ b/bin/ream/src/cli/mod.rs
@@ -48,6 +48,9 @@ pub struct Cli {
 
     #[arg(long, help = "Purges the database.")]
     pub purge_db: bool,
+
+    #[arg(long, short, help = "Proposer proves and gossips state transition, validators verify")]
+    pub proof_gen: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/common/chain/lean/src/messages.rs
+++ b/crates/common/chain/lean/src/messages.rs
@@ -37,4 +37,9 @@ pub enum LeanChainServiceMessage {
         is_trusted: bool,
         need_gossip: bool,
     },
+
+    ProduceProofBlock {
+        slot: u64,
+        sender: oneshot::Sender<Block>,
+    },
 }

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -157,6 +157,8 @@ impl LeanChainService {
                                 warn!("Failed to send item to outbound gossip channel: {err:?}");
                             }
                         }
+
+                        LeanChainServiceMessage::ProduceProofBlock { slot, sender } => todo!(),
                     }
                 }
             }


### PR DESCRIPTION
### Introducing zk proofs to lean consensus
The goal of this PR is to allow the block proposer to generate a zk proof of the state transition function. The proof will be gossiped and other validators will be able to verify it. We will use risc0 zkVM.

### To-Do

- [x] Create a cli flag `proof_gen`
- [x] Add `proof_gen` to `LeanNodeConfig`
- [x]  Create  `LeanProverServiceMessage` enum with `GenerateBlockProof` variant
- [x]  Add new field `proof_gen: bool` to struct `ValidatorService`
- [x] Set up guest environment and generate a proof
- [x] Implement proof triggering (every 200 slots)
- [x] Implement proof gossiping via new block_proof topic
- [ ] Gossip and validate the proof (implemented but not tested)