### PR TITLE
chore: clean `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ lint: fmt clippy sort # Run all linters.
 
 ##@ Others
 
+.PHONY: check
+check: # Run `cargo check`.
+	cargo check --workspace --features "$(FEATURES)"
+
 .PHONY: clean
 clean: # Run `cargo clean`.
 	cargo clean


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

- Our `Makefile` lacks clear documentation.
- Fix #724 (Hopefully, as the issue wasn't reproducible.) as well.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

- Divide commands by sectors.
- Add documentation for each command.

`make help` will show like:

```
Usage:
  make <target>

Help
  help             Display this help.

Build
  build            Build the Ream binary into `target` directory.
  build-debug      Build the Ream binary into `target/debug` directory
  install          Build and install the Ream binary under `~/.cargo/bin`.

Testing and Linting
  test             Run all tests.
  fmt              Run `rustfmt` on the entire workspace.
  clippy           Run `clippy` on the entire workspace.
  sort             Run `cargo sort` on the entire workspace.
  lint             Run all linters.

Others
  clean            Run `cargo clean`.
  update-book-cli  Update book cli documentation.
  clean-deps       Run `cargo udeps` except `ef-tests` directory.
  pr               Run all checks for a PR.
```

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
