### PR TITLE
fix: Metrics endpoint not sending Content-Type header, causing Prometheus scraping errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5018,11 +5018,10 @@ dependencies = [
 [[package]]
 name = "prometheus_exporter"
 version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf17cbebe0bfdf4f279ef84eeefe0d50468b0b7116f078acf41d456e48fe81a"
+source = "git+https://github.com/AlexanderThaller/prometheus_exporter?rev=c49efe614486f998b20eb410ae0caf3e904cf540#c49efe614486f998b20eb410ae0caf3e904cf540"
 dependencies = [
  "ascii",
- "lazy_static",
+ "either",
  "log",
  "prometheus",
  "thiserror 1.0.69",
@@ -7142,15 +7141,14 @@ dependencies = [
 
 [[package]]
 name = "tiny_http"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f8734c6d6943ad6df6b588d228a87b4af184998bcffa268ceddf05c2055a8c"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
 dependencies = [
  "ascii",
  "chunked_transfer",
+ "httpdate",
  "log",
- "time",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ libp2p-identity = "0.2.12"
 libp2p-mplex = "0.43.1"
 lru = "0.16.2"
 parking_lot = "0.12.5"
-prometheus_exporter = "0.8.5"
+prometheus_exporter = { git = "https://github.com/AlexanderThaller/prometheus_exporter", rev = "c49efe614486f998b20eb410ae0caf3e904cf540" }
 rand = "0.9"
 rand_chacha = "0.9"
 redb = "3.1.0"

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -21,7 +21,7 @@ docker compose up
 Don't forget to run the lean node with metrics exporting on. Example:
 
 ```bash
-cargo run --release lean_node --network ephemery --metrics
+cargo run --release lean_node --network ephemery --validator-registry-path ./bin/ream/assets/lean/validator_registry.yml --metrics --metrics-address 0.0.0.0
 ```
 
 ## View the Dashboard

--- a/metrics/compose.yml
+++ b/metrics/compose.yml
@@ -10,6 +10,8 @@ services:
       - prometheus_data:/prometheus
     ports:
       - 9090:9090
+    extra_hosts:
+      - "host.docker.internal:host-gateway"      
   grafana:
     image: grafana/grafana
     container_name: grafana
@@ -20,6 +22,8 @@ services:
       - ./grafana/dashboards:/var/lib/grafana/dashboards
     ports:
       - 3000:3000
+    extra_hosts:
+      - "host.docker.internal:host-gateway"      
 
 volumes:
   prometheus_data:

--- a/metrics/prometheus/prometheus.yaml
+++ b/metrics/prometheus/prometheus.yaml
@@ -8,7 +8,5 @@ scrape_configs:
     static_configs:
       - targets:
         - host.docker.internal:8080
-        - localhost:8080
         labels:
           instance: local_node
-    fallback_scrape_protocol: PrometheusText0.0.4


### PR DESCRIPTION
### What was wrong?

fixes #842

This should make it so our Metrics setup now works on Linux and MacOS

### How was it fixed?

bump prometheus_exporter version, and remove [fallback_scrape_protocol: PrometheusText0.0.4](https://github.com/ReamLabs/ream/blob/master/metrics/prometheus/prometheus.yaml) from our prometheus.yaml config