### PR TITLE
fix: getrandom target error in risc0 and sp1 workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,2 @@
-# Custom getrandom backend for RISC Zero zkVM target
-[target.riscv32im-risc0-zkvm-elf]
-rustflags = ['--cfg', 'getrandom_backend="custom"']
-
-# Custom getrandom backend for SP1 zkVM target
-[target.riscv32im-succinct-zkvm-elf]
+[target.'cfg(target_os = "zkvm")']
 rustflags = ['--cfg', 'getrandom_backend="custom"']


### PR DESCRIPTION
### What was wrong?

risc0 and sp1 use unsupported targets for getrandom and cause an error in our worflow

### How was it fixed?

https://github.com/risc0/risc0/issues/634
https://docs.rs/getrandom/latest/getrandom/#opt-in-backends

The workaround as suggested by the above issue is to use a rust flag to tell getrandom a that custom backend will be used.

```
Opt-in backends can be enabled using the getrandom_backend configuration flag. The flag can be set either by specifying the rustflags field in [.cargo/config.toml](https://doc.rust-lang.org/cargo/reference/config.html):

# It's recommended to set the flag on a per-target basis:
[target.wasm32-unknown-unknown]
rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
```

We can put in the config.toml so devs don't have to add it with environment variables.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
