### PR TITLE
fix: clippy error for making Gossip default variant for BroadcastValidation 

### DIFF
--- a/crates/common/api_types/beacon/src/block.rs
+++ b/crates/common/api_types/beacon/src/block.rs
@@ -6,22 +6,17 @@ use ream_consensus_beacon::{
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BroadcastValidation {
     /// Lightweight gossip checks only (default)
+    #[default]
     Gossip,
     /// Full consensus checks, including validation of all signatures and block fields
     /// except for the execution payload transactions
     Consensus,
     /// Same as consensus, with an extra equivocation check immediately before broadcast
     ConsensusAndEquivocation,
-}
-
-impl Default for BroadcastValidation {
-    fn default() -> Self {
-        Self::Gossip
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
### What was wrong?

Make pr gave me the following error:

```
error: this `impl` can be derived
  --> crates/common/api_types/beacon/src/block.rs:21:1
   |
21 | / impl Default for BroadcastValidation {
22 | |     fn default() -> Self {
23 | |         Self::Gossip
24 | |     }
25 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls
   = note: `-D clippy::derivable-impls` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::derivable_impls)]`
```

### How was it fixed?

```
help: replace the manual implementation with a derive attribute and mark the default variant
   |
11 + #[derive(Default)]
12 ~ pub enum BroadcastValidation {
13 |     /// Lightweight gossip checks only (default)
14 ~     #[default]
15 ~     Gossip,
```

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
