### PR TITLE
fix: docker push and book deploy workflows failing on forks

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -115,7 +115,7 @@ jobs:
 
   deploy:
     # Only deploy if a push to master
-    if: github.ref_name == 'master' && github.event_name == 'push'
+    if: github.ref_name == 'master' && github.event_name == 'push' && github.repository == 'reamlabs/ream'
     runs-on: ubuntu-latest
     needs: [test, lint, build]
 

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   push:
     runs-on: ubuntu-latest
+    if: github.repository == 'reamlabs/ream'
+
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3
@@ -22,4 +24,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/reamlabs/ream:latest  
+          tags: ghcr.io/reamlabs/ream:latest


### PR DESCRIPTION
### What was wrong?


As forks of the ream repo will not have secrets configured to pass these ci checks they will fail as expected. 

I think this is bad for developer experience as it gives unnecessary ugly emails like these:

<img width="883" height="90" alt="image" src="https://github.com/user-attachments/assets/938645f0-57a5-43dd-a6b1-17b632558216" />

### How was it fixed?

Improved CI by adding check to run these workflows only on parent repository.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
