### PR TITLE
feat: add process_attestations_justification_and_finalization test to leanState

### DIFF
--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -480,9 +480,8 @@ impl LeanState {
 
 #[cfg(test)]
 mod test {
-    use crate::vote::Vote;
-
     use super::*;
+    use crate::vote::Vote;
 
     #[test]
     fn get_justifications_empty() {
@@ -997,9 +996,11 @@ mod test {
         state.process_slots(5).unwrap();
 
         // Process a block at slot 5 to push block4's root into historical_block_hashes.
-        // This is required by the our implementation based off 3SF-mini which validates that target roots
-        // exist in historical_block_hashes before accepting votes
+        // This is required by the our implementation based off 3SF-mini which validates that target
+        // roots exist in historical_block_hashes before accepting votes
         // This validation does not exist in leanSpec so the test passes without processing block 5
+        // We deviate from the leanSpec in this test and process block 5 before testing
+        // process_attestations for slot 4
         let block5 = Block {
             slot: 5,
             proposer_index: 5,
@@ -1043,7 +1044,7 @@ mod test {
         // The target (slot 4) should now be justified.
         assert_eq!(state.latest_justified, checkpoint4);
         // The justified bit for slot 4 must be set.
-        assert_eq!(state.justified_slots.get(4).unwrap(), true);
+        assert!(state.justified_slots.get(4).unwrap_or(false));
         // Since no other justifiable slot exists between 0 and 4, genesis is finalized.
         assert_eq!(state.latest_finalized, genesis_checkpoint);
         // The per-root vote tracker for the justified target has been cleared.


### PR DESCRIPTION
### What was wrong?

Fixes: #834 

This is a test that was left out from earlier. I was debugging on why the exact implementation was failing. I think going foward we will not be duplicating logic and will use test vectors when released in leanSpec.

### How was it fixed?

Ok so the 1:1 implementation from the spec of this test fails as we perform additional validations performed in 3SF mini but not in leanSpec. These validations prohibit us from processing attestations for a slot till a block for the next slot has been processed. 

In the case of this test, we can not process attestations for slot 4 if block for slot 5 has not been processed. 

```python
# Validate that this is a reasonable vote (source comes before target).
if source.slot.as_int() >= target.slot.as_int():
    continue  # Skip invalid votes

# Check if source checkpoint is justified.
source_slot_int = source.slot.as_int()
target_slot_int = target.slot.as_int()

# Ensure we have enough justified slots history.
if source_slot_int < len(justified_slots):
    source_is_justified = justified_slots[source_slot_int]
else:
    continue  # Source is too far in the past
```

https://github.com/leanEthereum/leanSpec/blob/main/src/lean_spec/subspecs/containers/state/state.py#L437-L439

The leanSpec does not validate the following:

https://github.com/ReamLabs/ream/blob/2d4d8e15a6ef3e8aac80c9e81fb7f7af0a9511e9/crates/common/consensus/lean/src/state.rs#L354-L384

I believe this deviation is justified as we're implementing validations from 3SF mini but I wonder if leanSpec should also implement [all validations](https://github.com/ethereum/research/blob/master/3sf-mini/consensus.py#L78C1-L84C11) for process_attestation from 3SF mini. 

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
