### PR TITLE
feat: add shadow network simulator support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,7 +2275,7 @@ name = "ethereum_hashing"
 version = "0.7.0"
 source = "git+https://github.com/ReamLabs/ethereum_hashing.git?rev=c14a9ad96436e6b8b631faf49a3666e4558b71ae"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "sha2",
 ]
 
@@ -2284,7 +2284,7 @@ name = "ethereum_hashing"
 version = "0.7.0"
 source = "git+https://github.com/ReamLabs/ethereum_hashing.git#c14a9ad96436e6b8b631faf49a3666e4558b71ae"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "sha2",
 ]
 
@@ -3530,7 +3530,7 @@ dependencies = [
  "base64 0.22.1",
  "js-sys",
  "pem",
- "ring",
+ "ring 0.17.14",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -3619,8 +3619,7 @@ checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 [[package]]
 name = "libp2p"
 version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "bytes",
  "either",
@@ -3654,8 +3653,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3665,8 +3663,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -3675,9 +3672,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d28e2d2def7c344170f5c6450c0dbe3dfef655610dbfde2f6ac28a527abbe36"
+version = "0.43.0"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "either",
  "fnv",
@@ -3687,6 +3683,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "multistream-select",
+ "once_cell",
  "parking_lot",
  "pin-project",
  "quick-protobuf",
@@ -3694,15 +3691,14 @@ dependencies = [
  "rw-stream-sink",
  "thiserror 2.0.17",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "async-trait",
  "futures",
@@ -3717,8 +3713,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -3749,8 +3744,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c06862544f02d05d62780ff590cc25a75f5c2b9df38ec7a370dcae8bb873cf"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -3793,8 +3787,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3821,8 +3814,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -3840,8 +3832,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -3857,9 +3848,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a4019ba30c4e42b776113e9778071691fe3f34bf23b6b3bf0dfcf29d801f3d"
+version = "0.43.0"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3871,14 +3861,13 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "tracing",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-noise"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcc133e0f3cea07acde6eb8a9665cb11b600bd61110b010593a0210b8153b16"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3901,8 +3890,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2529993ff22deb2504c0130a58b60fb77f036be555053922db1a0490b5798b"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3917,8 +3905,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e659439578fc6d305da8303834beb9d62f155f40e7f5b9d81c9f2b2c69d1926"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3933,8 +3920,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41432a159b00424a0abaa2c80d786cddff81055ac24aa127e0cf375f7858d880"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3944,7 +3930,7 @@ dependencies = [
  "libp2p-tls",
  "quinn",
  "rand 0.8.5",
- "ring",
+ "ring 0.17.14",
  "rustls 0.23.26",
  "socket2 0.5.9",
  "thiserror 2.0.17",
@@ -3955,8 +3941,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803399b4b6f68adb85e63ab573ac568154b193e9a640f03e0f2890eabbcb37f8"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "either",
  "fnv",
@@ -3978,11 +3963,9 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "heck",
- "proc-macro2",
  "quote",
  "syn 2.0.101",
 ]
@@ -3990,8 +3973,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4005,16 +3987,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bbf5084fb44133267ad4caaa72a253d68d709edd2ed1cf9b42431a8ead8fd5"
+version = "0.6.0"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
  "rcgen",
- "ring",
+ "ring 0.17.14",
  "rustls 0.23.26",
  "rustls-webpki 0.101.7",
  "thiserror 2.0.17",
@@ -4025,8 +4006,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4040,8 +4020,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "either",
  "futures",
@@ -4254,7 +4233,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
 ]
 
@@ -4277,21 +4256,20 @@ checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "serde",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "bytes",
  "futures",
- "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -5066,21 +5044,19 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
+ "thiserror 2.0.17",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "quinn"
 version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+source = "git+https://github.com/qdrvm/quinn.git?branch=feature%2Fshadow-0.5.11#947bad48b40de2688bb5b19be158653d8ce4e99b"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5099,14 +5075,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+version = "0.11.10"
+source = "git+https://github.com/qdrvm/quinn.git?branch=feature%2Fshadow-0.5.11#947bad48b40de2688bb5b19be158653d8ce4e99b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
  "rand 0.9.2",
- "ring",
+ "ring 0.17.14",
  "rustc-hash",
  "rustls 0.23.26",
  "rustls-pki-types",
@@ -5120,8 +5095,7 @@ dependencies = [
 [[package]]
 name = "quinn-udp"
 version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+source = "git+https://github.com/qdrvm/quinn.git?branch=feature%2Fshadow-0.5.11#947bad48b40de2688bb5b19be158653d8ce4e99b"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5273,13 +5247,12 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
  "pem",
- "ring",
- "rustls-pki-types",
+ "ring 0.16.20",
  "time",
  "yasna",
 ]
@@ -5786,7 +5759,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "tree_hash",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -6154,6 +6127,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -6162,7 +6150,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6343,7 +6331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.14",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -6355,7 +6343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki 0.103.1",
  "subtle",
@@ -6398,8 +6386,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.14",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6408,9 +6396,9 @@ version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6434,8 +6422,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+source = "git+https://github.com/qdrvm/rust-libp2p.git?branch=feature%2Fshadow-0.55.0#1f0a106952499da708dc7819bbd29b9558df1eba"
 dependencies = [
  "futures",
  "pin-project",
@@ -6475,8 +6462,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.14",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6825,7 +6812,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "ring",
+ "ring 0.17.14",
  "rustc_version 0.4.1",
  "sha2",
  "subtle",
@@ -6850,6 +6837,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -7537,12 +7530,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
-name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
@@ -7551,6 +7538,12 @@ dependencies = [
  "bytes",
  "tokio-util",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,9 +99,9 @@ itertools = "0.14"
 jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
 lazy_static = "1.5.0"
-libp2p = { version = "0.55", default-features = false, features = ["identify", "yamux", "noise", "dns", "serde", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping"] }
+libp2p = { version = "0.55", default-features = false, features = ["identify", "yamux", "noise", "dns", "serde", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping", "shadow"] }
 libp2p-identity = "0.2.12"
-libp2p-mplex = "0.43.1"
+libp2p-mplex = "0.43.0"
 lru = "0.16.2"
 parking_lot = "0.12.5"
 prometheus_exporter = { git = "https://github.com/AlexanderThaller/prometheus_exporter", rev = "c49efe614486f998b20eb410ae0caf3e904cf540" }
@@ -168,3 +168,10 @@ ream-validator-lean = { path = "crates/common/validator/lean" }
 
 [patch.crates-io]
 ethereum_hashing = { git = "https://github.com/ReamLabs/ethereum_hashing.git" }
+
+# https://github.com/shadow/shadow
+libp2p = { git = "https://github.com/qdrvm/rust-libp2p.git", branch = "feature/shadow-0.55.0" }
+libp2p-mplex = { git = "https://github.com/qdrvm/rust-libp2p.git", branch = "feature/shadow-0.55.0" }
+libp2p-quic = { git = "https://github.com/qdrvm/rust-libp2p.git", branch = "feature/shadow-0.55.0" }
+quinn = { git = "https://github.com/qdrvm/quinn.git", branch = "feature/shadow-0.5.11" }
+quinn-udp = { git = "https://github.com/qdrvm/quinn.git", branch = "feature/shadow-0.5.11" }

--- a/crates/networking/p2p/src/network/misc.rs
+++ b/crates/networking/p2p/src/network/misc.rs
@@ -15,7 +15,7 @@ use libp2p::{
     yamux,
 };
 use libp2p_identity::{Keypair, PeerId, secp256k1::PublicKey as Secp256k1PublicKey};
-use libp2p_mplex::{Config, MaxBufferBehaviour};
+use libp2p_mplex::{MplexConfig, MaxBufferBehaviour};
 use ream_executor::ReamExecutor;
 use yamux::Config as YamuxConfig;
 
@@ -29,7 +29,7 @@ impl libp2p::swarm::Executor for Executor {
 
 pub fn build_transport(local_private_key: Keypair) -> io::Result<Boxed<(PeerId, StreamMuxerBox)>> {
     // mplex config
-    let mut mplex_config = Config::new();
+    let mut mplex_config = MplexConfig::new();
     mplex_config.set_max_buffer_size(256);
     mplex_config.set_max_buffer_behaviour(MaxBufferBehaviour::Block);
 


### PR DESCRIPTION
### What was wrong?
Couldn't run ream in [shadow network simulator](https://github.com/shadow/shadow).
Shadow doesn't implement some `setsockopt` options.

### How was it fixed?
Patch `quinn-udp` to avoid unsupported `setsockopt` by using [fallback.rs](https://github.com/quinn-rs/quinn/blob/main/quinn-udp/src/fallback.rs#L19-L25) instead of [unix.rs](https://github.com/quinn-rs/quinn/blob/fc5e219fd9c9418c874f3db4e6d26d9cc32cea67/quinn-udp/src/unix.rs#L86-L194).

`quinn-udp` is transitive dependency
`ream -> libp2p -> libp2p-quic -> quinn -> quinn-udp`
so `feature = "shadow"` was added to every crate in that chain.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
