### PR TITLE
refactor: decouple `ValidatorService` with `LeanChain`

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -214,8 +214,7 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
 
     let keystores = load_validator_registry(&config.validator_registry_path, &config.node_id)
         .expect("Failed to load validator registry");
-    let validator_service =
-        LeanValidatorService::new(lean_chain_reader.clone(), keystores, chain_sender).await;
+    let validator_service = LeanValidatorService::new(keystores, chain_sender).await;
 
     let server_config = RpcServerConfig::new(
         config.http_address,

--- a/crates/common/chain/lean/src/lean_chain.rs
+++ b/crates/common/chain/lean/src/lean_chain.rs
@@ -326,7 +326,7 @@ impl LeanChain {
         Ok(new_block.message)
     }
 
-    pub async fn build_attestation(&self, slot: u64) -> anyhow::Result<AttestationData> {
+    pub async fn build_attestation_data(&self, slot: u64) -> anyhow::Result<AttestationData> {
         let (head, target, source) = {
             let db = self.store.lock().await;
             (

--- a/crates/common/chain/lean/src/messages.rs
+++ b/crates/common/chain/lean/src/messages.rs
@@ -1,5 +1,5 @@
 use ream_consensus_lean::{
-    attestation::SignedAttestation,
+    attestation::{AttestationData, SignedAttestation},
     block::{Block, SignedBlock},
 };
 use tokio::sync::oneshot;
@@ -8,11 +8,13 @@ use tokio::sync::oneshot;
 ///
 /// `ProduceBlock`: Request to produce a new [Block] based on current view of the node.
 ///
+/// `BuildAttestationData`: Request to build an [AttestationData] for a given slot.
+///
 /// `ProcessBlock`: Request to process a new [SignedBlock], with a couple of flags. For flags, see
 /// below for the explanation.
 ///
-/// `ProcessVote`: Request to process a new [SignedVote], with a couple of flags. For flags, see
-/// below for the explanation.
+/// `ProcessAttestation`: Request to process a new [SignedAttestation], with a couple of flags. For
+/// flags, see below for the explanation.
 ///
 /// Flags:
 /// `is_trusted`: If true, the block/vote is considered to 1) be from local or 2) already verified.
@@ -26,6 +28,10 @@ pub enum LeanChainServiceMessage {
     ProduceBlock {
         slot: u64,
         sender: oneshot::Sender<Block>,
+    },
+    BuildAttestationData {
+        slot: u64,
+        sender: oneshot::Sender<AttestationData>,
     },
     ProcessBlock {
         signed_block: SignedBlock,


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Ideally, `ValidatorService` would request to other services for building an attestation. But currently, it directly calls a `build_attestation` method from `LeanChain`.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Using channel, change the pattern similar to producing a block.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
