### PR TITLE
fix: hash sig tests should use the testing signature scheme

### DIFF
--- a/crates/crypto/post_quantum/src/hashsig/mod.rs
+++ b/crates/crypto/post_quantum/src/hashsig/mod.rs
@@ -3,11 +3,11 @@ pub mod private_key;
 pub mod public_key;
 pub mod signature;
 
-#[cfg(test)]
-pub type HashSigScheme = hashsig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_8::SIGTopLevelTargetSumLifetime8Dim64Base8;
-
 #[cfg(all(not(test), feature = "signature-scheme-prod"))]
 pub type HashSigScheme = hashsig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_32::hashing_optimized::SIGTopLevelTargetSumLifetime32Dim64Base8;
 
 #[cfg(all(not(test), feature = "signature-scheme-test"))]
+pub type HashSigScheme = hashsig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_8::SIGTopLevelTargetSumLifetime8Dim64Base8;
+
+#[cfg(test)]
 pub type HashSigScheme = hashsig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_8::SIGTopLevelTargetSumLifetime8Dim64Base8;


### PR DESCRIPTION
### What was wrong?

When running make PR right now my laptop starts overheating and the fan goes at full speed. I realized this is because when running the test in hash-sig it defaults to the production signature scheme.

```bash
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/ream_post_quantum_crypto-979fe95a5eb0d963)

running 1 test
test hashsig::private_key::tests::test_sign_and_verify has been running for over 60 seconds
^Cmake: *** [test] Interrupt: 2
```

### How was it fixed?

Improved the configuration for the hash sig library by enforcing the test signature scheme when running cargo test.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
