### PR TITLE
feat: update Status ReqResp request to latest spec

### DIFF
--- a/crates/networking/p2p/src/req_resp/lean/messages/status.rs
+++ b/crates/networking/p2p/src/req_resp/lean/messages/status.rs
@@ -1,10 +1,11 @@
-use alloy_primitives::B256;
+use ream_consensus_lean::checkpoint::Checkpoint;
 use ssz_derive::{Decode, Encode};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct LeanStatus {
-    pub finalized_root: B256,
-    pub finalized_slot: u64,
-    pub head_root: B256,
-    pub head_slot: u64,
+    /// The client's latest finalized checkpoint
+    pub finalized: Checkpoint,
+
+    /// The client's current head checkpoint
+    pub head: Checkpoint,
 }


### PR DESCRIPTION
### What was wrong?

fixes https://github.com/ReamLabs/ream/issues/890

### How was it fixed?

updates Status message to latest spec https://github.com/leanEthereum/leanSpec/blob/main/src/lean_spec/subspecs/networking/reqresp/message.py
