### PR TITLE
feat: add lean time table to the database

### DIFF
--- a/crates/storage/src/db/lean.rs
+++ b/crates/storage/src/db/lean.rs
@@ -5,7 +5,8 @@ use redb::Database;
 use crate::tables::lean::{
     latest_finalized::LatestFinalizedField, latest_justified::LatestJustifiedField,
     latest_known_attestation::LatestKnownAttestationTable, lean_block::LeanBlockTable,
-    lean_state::LeanStateTable, slot_index::SlotIndexTable, state_root_index::StateRootIndexTable,
+    lean_state::LeanStateTable, lean_time::LeanTimeField, slot_index::SlotIndexTable,
+    state_root_index::StateRootIndexTable,
 };
 
 #[derive(Clone, Debug)]
@@ -51,6 +52,12 @@ impl LeanDB {
 
     pub fn latest_justified_provider(&self) -> LatestJustifiedField {
         LatestJustifiedField {
+            db: self.db.clone(),
+        }
+    }
+
+    pub fn lean_time_provider(&self) -> LeanTimeField {
+        LeanTimeField {
             db: self.db.clone(),
         }
     }

--- a/crates/storage/src/db/mod.rs
+++ b/crates/storage/src/db/mod.rs
@@ -29,7 +29,7 @@ use crate::{
         },
         lean::{
             latest_finalized::LATEST_FINALIZED_FIELD, latest_justified::LATEST_JUSTIFIED_FIELD,
-            lean_block::LEAN_BLOCK_TABLE, lean_state::LEAN_STATE_TABLE,
+            lean_block::LEAN_BLOCK_TABLE, lean_state::LEAN_STATE_TABLE, lean_time::LEAN_TIME_FIELD,
             slot_index::LEAN_SLOT_INDEX_TABLE, state_root_index::LEAN_STATE_ROOT_INDEX_TABLE,
         },
     },
@@ -99,6 +99,7 @@ impl ReamDB {
         write_txn.open_table(LEAN_STATE_TABLE)?;
         write_txn.open_table(LEAN_SLOT_INDEX_TABLE)?;
         write_txn.open_table(LEAN_STATE_ROOT_INDEX_TABLE)?;
+        write_txn.open_table(LEAN_TIME_FIELD)?;
         write_txn.commit()?;
 
         Ok(LeanDB {

--- a/crates/storage/src/tables/lean/lean_time.rs
+++ b/crates/storage/src/tables/lean/lean_time.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use redb::{Database, Durability, ReadableDatabase, TableDefinition};
+
+use crate::{errors::StoreError, tables::field::Field};
+
+/// Table definition for the Lean Time table
+///
+/// Value: u64
+pub(crate) const LEAN_TIME_FIELD: TableDefinition<&str, u64> = TableDefinition::new("lean_time");
+
+const LEAN_TIME_KEY: &str = "lean_time_key";
+
+pub struct LeanTimeField {
+    pub db: Arc<Database>,
+}
+
+impl Field for LeanTimeField {
+    type Value = u64;
+
+    fn get(&self) -> Result<u64, StoreError> {
+        let read_txn = self.db.begin_read()?;
+
+        let table = read_txn.open_table(LEAN_TIME_FIELD)?;
+        let result = table
+            .get(LEAN_TIME_KEY)?
+            .ok_or(StoreError::FieldNotInitilized)?;
+        Ok(result.value())
+    }
+
+    fn insert(&self, value: Self::Value) -> Result<(), StoreError> {
+        let mut write_txn = self.db.begin_write()?;
+        write_txn.set_durability(Durability::Immediate)?;
+        let mut table = write_txn.open_table(LEAN_TIME_FIELD)?;
+        table.insert(LEAN_TIME_KEY, value)?;
+        drop(table);
+        write_txn.commit()?;
+        Ok(())
+    }
+}

--- a/crates/storage/src/tables/lean/mod.rs
+++ b/crates/storage/src/tables/lean/mod.rs
@@ -3,5 +3,6 @@ pub mod latest_justified;
 pub mod latest_known_attestation;
 pub mod lean_block;
 pub mod lean_state;
+pub mod lean_time;
 pub mod slot_index;
 pub mod state_root_index;


### PR DESCRIPTION
### What was wrong?

I'm currently implementing the updated fork choice logic and a few new types are introduced so I'm making tables 

### How was it fixed?

adds lean time table to the database