### PR TITLE
feat: add safe target table to lean database

### DIFF
--- a/crates/rpc/lean/src/handlers/block.rs
+++ b/crates/rpc/lean/src/handlers/block.rs
@@ -35,7 +35,11 @@ pub async fn get_block_by_id(
             .get()
             .map(|checkpoint| checkpoint.root)
             .map_err(|err| ApiError::InternalError(format!("No latest finalized hash: {err:?}"))),
-        ID::Genesis => Ok(lean_chain.genesis_hash),
+        ID::Genesis => {
+            return Err(ApiError::NotFound(
+                "This ID type is currently not supported".to_string(),
+            ));
+        }
         ID::Head => lean_chain
             .store
             .lock()

--- a/crates/rpc/lean/src/handlers/state.rs
+++ b/crates/rpc/lean/src/handlers/state.rs
@@ -25,7 +25,11 @@ pub async fn get_state(
                 })?
                 .root)
         }
-        ID::Genesis => Ok(lean_chain.genesis_hash),
+        ID::Genesis => {
+            return Err(ApiError::NotFound(
+                "This ID type is currently not supported".to_string(),
+            ));
+        }
         ID::Head => lean_chain
             .store
             .lock()

--- a/crates/storage/src/db/lean.rs
+++ b/crates/storage/src/db/lean.rs
@@ -5,8 +5,8 @@ use redb::Database;
 use crate::tables::lean::{
     latest_finalized::LatestFinalizedField, latest_justified::LatestJustifiedField,
     latest_known_attestation::LatestKnownAttestationTable, lean_block::LeanBlockTable,
-    lean_head::LeanHeadField, lean_state::LeanStateTable, lean_time::LeanTimeField,
-    slot_index::SlotIndexTable, state_root_index::StateRootIndexTable,
+    lean_head::LeanHeadField, lean_safe_target::LeanSafeTargetField, lean_state::LeanStateTable,
+    lean_time::LeanTimeField, slot_index::SlotIndexTable, state_root_index::StateRootIndexTable,
 };
 
 #[derive(Clone, Debug)]
@@ -64,6 +64,12 @@ impl LeanDB {
 
     pub fn lean_head_provider(&self) -> LeanHeadField {
         LeanHeadField {
+            db: self.db.clone(),
+        }
+    }
+
+    pub fn lean_safe_target_provider(&self) -> LeanSafeTargetField {
+        LeanSafeTargetField {
             db: self.db.clone(),
         }
     }

--- a/crates/storage/src/db/mod.rs
+++ b/crates/storage/src/db/mod.rs
@@ -29,7 +29,8 @@ use crate::{
         },
         lean::{
             latest_finalized::LATEST_FINALIZED_FIELD, latest_justified::LATEST_JUSTIFIED_FIELD,
-            lean_block::LEAN_BLOCK_TABLE, lean_head::LEAN_HEAD_FIELD, lean_state::LEAN_STATE_TABLE,
+            lean_block::LEAN_BLOCK_TABLE, lean_head::LEAN_HEAD_FIELD,
+            lean_safe_target::LEAN_SAFE_TARGET_FIELD, lean_state::LEAN_STATE_TABLE,
             lean_time::LEAN_TIME_FIELD, slot_index::LEAN_SLOT_INDEX_TABLE,
             state_root_index::LEAN_STATE_ROOT_INDEX_TABLE,
         },
@@ -102,6 +103,7 @@ impl ReamDB {
         write_txn.open_table(LEAN_STATE_ROOT_INDEX_TABLE)?;
         write_txn.open_table(LEAN_TIME_FIELD)?;
         write_txn.open_table(LEAN_HEAD_FIELD)?;
+        write_txn.open_table(LEAN_SAFE_TARGET_FIELD)?;
         write_txn.commit()?;
 
         Ok(LeanDB {

--- a/crates/storage/src/tables/lean/lean_safe_target.rs
+++ b/crates/storage/src/tables/lean/lean_safe_target.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use alloy_primitives::{B256, FixedBytes};
+use redb::{Database, Durability, ReadableDatabase, TableDefinition};
+
+use crate::{
+    errors::StoreError,
+    tables::{field::Field, ssz_encoder::SSZEncoding},
+};
+
+/// Table definition for the Lean Safe Target table
+///
+/// Value: B256
+pub(crate) const LEAN_SAFE_TARGET_FIELD: TableDefinition<&str, SSZEncoding<B256>> =
+    TableDefinition::new("lean_safe_target");
+
+const LEAN_SAFE_TARGET_KEY: &str = "lean_safe_target_key";
+
+pub struct LeanSafeTargetField {
+    pub db: Arc<Database>,
+}
+
+impl Field for LeanSafeTargetField {
+    type Value = B256;
+
+    fn get(&self) -> Result<FixedBytes<32>, StoreError> {
+        let read_txn = self.db.begin_read()?;
+
+        let table = read_txn.open_table(LEAN_SAFE_TARGET_FIELD)?;
+        let result = table
+            .get(LEAN_SAFE_TARGET_KEY)?
+            .ok_or(StoreError::FieldNotInitilized)?;
+        Ok(result.value())
+    }
+
+    fn insert(&self, value: Self::Value) -> Result<(), StoreError> {
+        let mut write_txn = self.db.begin_write()?;
+        write_txn.set_durability(Durability::Immediate)?;
+        let mut table = write_txn.open_table(LEAN_SAFE_TARGET_FIELD)?;
+        table.insert(LEAN_SAFE_TARGET_KEY, value)?;
+        drop(table);
+        write_txn.commit()?;
+        Ok(())
+    }
+}

--- a/crates/storage/src/tables/lean/mod.rs
+++ b/crates/storage/src/tables/lean/mod.rs
@@ -3,6 +3,7 @@ pub mod latest_justified;
 pub mod latest_known_attestation;
 pub mod lean_block;
 pub mod lean_head;
+pub mod lean_safe_target;
 pub mod lean_state;
 pub mod lean_time;
 pub mod slot_index;


### PR DESCRIPTION
### What was wrong?

I'm currently implementing the updated fork choice logic and a few new types are introduced so I'm making tables 

### How was it fixed?

adds lean safe target table to the database