### PR TITLE
refactor: use database instead of memory for latest new attestations

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -233,7 +233,8 @@ impl LeanChainService {
         self.lean_chain
             .write()
             .await
-            .on_attestation_from_gossip(signed_attestation);
+            .on_attestation_from_gossip(signed_attestation)
+            .await?;
 
         Ok(())
     }

--- a/crates/storage/src/db/lean.rs
+++ b/crates/storage/src/db/lean.rs
@@ -5,9 +5,9 @@ use redb::Database;
 use crate::tables::lean::{
     latest_finalized::LatestFinalizedField, latest_justified::LatestJustifiedField,
     latest_known_attestation::LatestKnownAttestationTable, lean_block::LeanBlockTable,
-    lean_head::LeanHeadField, lean_safe_target::LeanSafeTargetField, lean_state::LeanStateTable,
-    lean_time::LeanTimeField, slot_index::LeanSlotIndexTable,
-    state_root_index::LeanStateRootIndexTable,
+    lean_head::LeanHeadField, lean_latest_new_attestations::LeanLatestNewAttestationsTable,
+    lean_safe_target::LeanSafeTargetField, lean_state::LeanStateTable, lean_time::LeanTimeField,
+    slot_index::LeanSlotIndexTable, state_root_index::LeanStateRootIndexTable,
 };
 
 #[derive(Clone, Debug)]
@@ -71,6 +71,12 @@ impl LeanDB {
 
     pub fn lean_safe_target_provider(&self) -> LeanSafeTargetField {
         LeanSafeTargetField {
+            db: self.db.clone(),
+        }
+    }
+
+    pub fn lean_latest_new_attestations_provider(&self) -> LeanLatestNewAttestationsTable {
+        LeanLatestNewAttestationsTable {
             db: self.db.clone(),
         }
     }

--- a/crates/storage/src/db/mod.rs
+++ b/crates/storage/src/db/mod.rs
@@ -30,6 +30,7 @@ use crate::{
         lean::{
             latest_finalized::LatestFinalizedField, latest_justified::LatestJustifiedField,
             lean_block::LeanBlockTable, lean_head::LeanHeadField,
+            lean_latest_new_attestations::LeanLatestNewAttestationsTable,
             lean_safe_target::LeanSafeTargetField, lean_state::LeanStateTable,
             lean_time::LeanTimeField, slot_index::LeanSlotIndexTable,
             state_root_index::LeanStateRootIndexTable,
@@ -105,6 +106,7 @@ impl ReamDB {
         write_txn.open_table(LeanTimeField::FIELD_DEFINITION)?;
         write_txn.open_table(LeanHeadField::FIELD_DEFINITION)?;
         write_txn.open_table(LeanSafeTargetField::FIELD_DEFINITION)?;
+        write_txn.open_table(LeanLatestNewAttestationsTable::TABLE_DEFINITION)?;
         write_txn.commit()?;
 
         Ok(LeanDB {

--- a/crates/storage/src/tables/lean/lean_latest_new_attestations.rs
+++ b/crates/storage/src/tables/lean/lean_latest_new_attestations.rs
@@ -1,0 +1,63 @@
+use std::{collections::HashMap, sync::Arc};
+
+use ream_consensus_lean::attestation::SignedAttestation;
+use redb::{Database, ReadableDatabase, TableDefinition};
+
+use crate::{
+    errors::StoreError,
+    tables::{ssz_encoder::SSZEncoding, table::REDBTable},
+};
+
+pub struct LeanLatestNewAttestationsTable {
+    pub db: Arc<Database>,
+}
+
+/// Table definition for the Latest New Attestations table
+///
+/// Key: u64
+/// Value: SignedAttestation
+impl REDBTable for LeanLatestNewAttestationsTable {
+    const TABLE_DEFINITION: TableDefinition<'_, u64, SSZEncoding<SignedAttestation>> =
+        TableDefinition::new("lean_latest_new_attestations");
+
+    type Key = u64;
+
+    type KeyTableDefinition = u64;
+
+    type Value = SignedAttestation;
+
+    type ValueTableDefinition = SSZEncoding<SignedAttestation>;
+
+    fn database(&self) -> Arc<Database> {
+        self.db.clone()
+    }
+}
+
+impl LeanLatestNewAttestationsTable {
+    pub fn iter_values(
+        &self,
+    ) -> Result<impl Iterator<Item = anyhow::Result<SignedAttestation>>, StoreError> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(Self::TABLE_DEFINITION)?;
+        Ok(table
+            .range::<<u64 as redb::Value>::SelfType<'_>>(..)?
+            .map(|result| {
+                result
+                    .map(|(_, value)| value.value())
+                    .map_err(|err| StoreError::from(err).into())
+            }))
+    }
+
+    pub fn drain(&self) -> Result<HashMap<u64, SignedAttestation>, StoreError> {
+        let write_txn = self.db.begin_write()?;
+        let mut table = write_txn.open_table(Self::TABLE_DEFINITION)?;
+
+        let mut result = HashMap::new();
+        while let Some((key, value)) = table.pop_first()? {
+            result.insert(key.value(), value.value());
+        }
+        drop(table);
+        write_txn.commit()?;
+        Ok(result)
+    }
+}

--- a/crates/storage/src/tables/lean/mod.rs
+++ b/crates/storage/src/tables/lean/mod.rs
@@ -3,6 +3,7 @@ pub mod latest_justified;
 pub mod latest_known_attestation;
 pub mod lean_block;
 pub mod lean_head;
+pub mod lean_latest_new_attestations;
 pub mod lean_safe_target;
 pub mod lean_state;
 pub mod lean_time;


### PR DESCRIPTION
### What was wrong?

I'm currently implementing the updated fork choice logic and a few new types are introduced so I'm making tables 

### How was it fixed?

adds lean latest new attestations table to the database