### PR TITLE
fix: wrapped SyncStatus struct to match the eth/v1/node/syncing json response

### DIFF
--- a/crates/common/api_types/beacon/src/sync.rs
+++ b/crates/common/api_types/beacon/src/sync.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 
 #[derive(Debug, Deserialize, Serialize, Encode, Decode, Default)]
+pub struct SyncStatusWrapper {
+    pub sync_status: SyncStatus,
+}
+
+#[derive(Debug, Deserialize, Serialize, Encode, Decode, Default)]
 pub struct SyncStatus {
     #[serde(with = "serde_utils::quoted_u64")]
     pub head_slot: u64,

--- a/crates/common/validator/beacon/src/beacon_api_client/mod.rs
+++ b/crates/common/validator/beacon/src/beacon_api_client/mod.rs
@@ -20,7 +20,7 @@ use ream_api_types_beacon::{
         BeaconResponse, DataResponse, DataVersionedResponse, DutiesResponse,
         ETH_CONSENSUS_VERSION_HEADER, RootResponse, SyncCommitteeDutiesResponse, VERSION,
     },
-    sync::SyncStatus,
+    sync::SyncStatusWrapper,
     validator::{ValidatorData, ValidatorStatus},
 };
 use ream_api_types_common::id::ID;
@@ -275,7 +275,7 @@ impl BeaconApiClient {
 
     pub async fn get_node_syncing_status(
         &self,
-    ) -> anyhow::Result<DataResponse<SyncStatus>, ValidatorError> {
+    ) -> anyhow::Result<DataResponse<SyncStatusWrapper>, ValidatorError> {
         let response = self
             .http_client
             .execute(

--- a/crates/common/validator/beacon/src/voluntary_exit.rs
+++ b/crates/common/validator/beacon/src/voluntary_exit.rs
@@ -54,6 +54,7 @@ pub async fn process_voluntary_exit(
         .get_node_syncing_status()
         .await?
         .data
+        .sync_status
         .is_syncing
     {
         bail!("Cannot process voluntary exit while node is syncing");


### PR DESCRIPTION
# Fixes #904 

### What was wrong?

The code implementation did not match the actual json response of `/eth/v1/node/syncing` 

### How was it fixed?

Wrapped the `SyncStatus` struct into `SyncStatusWrapper` struct

### To-Do

- [X] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [X] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
