### PR TITLE
feat: use bytes in signature container

### DIFF
--- a/crates/crypto/post_quantum/src/hashsig/errors.rs
+++ b/crates/crypto/post_quantum/src/hashsig/errors.rs
@@ -3,8 +3,8 @@ pub enum SignatureError {
     #[error("Signing failed: {0:?}")]
     SigningFailed(hashsig::signature::SigningError),
 
-    #[error("Signature serialization failed")]
-    SerializationFailed,
+    #[error("Signature encode failed: {0:?}")]
+    SignatureEncodeFailed(bincode::error::EncodeError),
 
     #[error("Invalid signature length")]
     InvalidSignatureLength,

--- a/crates/crypto/post_quantum/src/hashsig/private_key.rs
+++ b/crates/crypto/post_quantum/src/hashsig/private_key.rs
@@ -12,9 +12,8 @@ use hashsig::{
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
-use crate::hashsig::{HashSigScheme, public_key::PublicKey, signature::Signature};
-
 use super::errors::SignatureError;
+use crate::hashsig::{HashSigScheme, public_key::PublicKey, signature::Signature};
 
 const BINCODE_CONFIG: bincode::config::Configuration<LittleEndian, Fixint, NoLimit> =
     bincode::config::standard().with_fixed_int_encoding();

--- a/crates/crypto/post_quantum/src/hashsig/signature.rs
+++ b/crates/crypto/post_quantum/src/hashsig/signature.rs
@@ -1,4 +1,3 @@
-use crate::hashsig::{HashSigScheme, public_key::PublicKey};
 use alloy_primitives::FixedBytes;
 use bincode::config::{Fixint, LittleEndian, NoLimit};
 use hashsig::{MESSAGE_LENGTH, signature::SignatureScheme};
@@ -7,6 +6,7 @@ use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
 use super::errors::SignatureError;
+use crate::hashsig::{HashSigScheme, public_key::PublicKey};
 
 type HashSigSignature = <HashSigScheme as SignatureScheme>::Signature;
 
@@ -45,7 +45,7 @@ impl Signature {
         hash_sig_signature: HashSigSignature,
     ) -> Result<Self, SignatureError> {
         let serialized = bincode::serde::encode_to_vec(&hash_sig_signature, BINCODE_CONFIG)
-            .map_err(|_| SignatureError::SerializationFailed)?;
+            .map_err(SignatureError::SignatureEncodeFailed)?;
 
         if serialized.len() > SIGNATURE_SIZE {
             return Err(SignatureError::InvalidSignatureLength);
@@ -66,7 +66,7 @@ impl Signature {
 
         bincode::serde::decode_from_slice(&self.inner[..], BINCODE_CONFIG)
             .map(|(signature, _)| signature)
-            .map_err(|err| SignatureError::SignatureDecodeFailed(err))
+            .map_err(SignatureError::SignatureDecodeFailed)
     }
 
     pub fn verify(


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
It would be difficult to use the existing `Signature` in Ream as internally it was [this](https://github.com/b-wagn/hash-sig/blob/23517cf35a4806c93a864f55ace5c4e4a67a08b3/src/signature/generalized_xmss.rs#L40)
This does not derive most of the macros we need (encode/decode, treehash). Hence, we need a compatible type for signature which we can serialize/deserialize from the hash-sig type

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Instead use a `FixedBytes` type which converts to the correct signature. 
Added a test for serialization roundtrip

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
