### PR TITLE
refactor: remove duplicate definitions of BINCODE_CONFIG

### DIFF
--- a/crates/crypto/post_quantum/src/hashsig/mod.rs
+++ b/crates/crypto/post_quantum/src/hashsig/mod.rs
@@ -3,6 +3,8 @@ pub mod private_key;
 pub mod public_key;
 pub mod signature;
 
+use bincode::config::{Fixint, LittleEndian, NoLimit};
+
 #[cfg(all(not(test), feature = "signature-scheme-prod"))]
 pub type HashSigScheme = hashsig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_32::hashing_optimized::SIGTopLevelTargetSumLifetime32Dim64Base8;
 
@@ -11,3 +13,11 @@ pub type HashSigScheme = hashsig::signature::generalized_xmss::instantiations_po
 
 #[cfg(test)]
 pub type HashSigScheme = hashsig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_8::SIGTopLevelTargetSumLifetime8Dim64Base8;
+
+/// NOTE: `GeneralizedXMSSSignature` doesn't implement methods like `to_bytes`,
+/// which means we need to use bincode to serialize/deserialize it.
+/// However, using bincode's default config (little-endian + variable int encoding)
+/// add extra bytes to the serialized output, which is not what we want.
+/// Thus, define a custom configuration for bincode here.
+const BINCODE_CONFIG: bincode::config::Configuration<LittleEndian, Fixint, NoLimit> =
+    bincode::config::standard().with_fixed_int_encoding();

--- a/crates/crypto/post_quantum/src/hashsig/private_key.rs
+++ b/crates/crypto/post_quantum/src/hashsig/private_key.rs
@@ -1,10 +1,7 @@
 use std::ops::Range;
 
 use alloy_primitives::Bytes;
-use bincode::{
-    self,
-    config::{Fixint, LittleEndian, NoLimit},
-};
+use bincode::{self};
 use hashsig::{
     MESSAGE_LENGTH,
     signature::{SignatureScheme, SignatureSchemeSecretKey},
@@ -12,11 +9,8 @@ use hashsig::{
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
-use super::errors::SignatureError;
+use super::{BINCODE_CONFIG, errors::SignatureError};
 use crate::hashsig::{HashSigScheme, public_key::PublicKey, signature::Signature};
-
-const BINCODE_CONFIG: bincode::config::Configuration<LittleEndian, Fixint, NoLimit> =
-    bincode::config::standard().with_fixed_int_encoding();
 
 pub type HashSigPrivateKey = <HashSigScheme as SignatureScheme>::SecretKey;
 

--- a/crates/crypto/post_quantum/src/hashsig/public_key.rs
+++ b/crates/crypto/post_quantum/src/hashsig/public_key.rs
@@ -1,8 +1,6 @@
 use alloy_primitives::{Bytes, hex};
-use bincode::{
-    self,
-    config::{Fixint, LittleEndian, NoLimit},
-};
+use anyhow::anyhow;
+use bincode::{self};
 use hashsig::signature::SignatureScheme;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::Encode;
@@ -10,17 +8,10 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, typenum::U52};
 use tree_hash_derive::TreeHash;
 
+use super::BINCODE_CONFIG;
 use crate::hashsig::HashSigScheme;
 
 type HashSigPublicKey = <HashSigScheme as SignatureScheme>::PublicKey;
-
-// NOTE: `GeneralizedXMSSPublicKey` doesn't implement methods like `to_bytes`,
-// which means we need to use bincode to serialize/deserialize it.
-// However, using bincode's default config (little-endian + variable int encoding)
-// add extra bytes to the serialized output, which is not what we want.
-// Thus, define a custom configuration for bincode here.
-const BINCODE_CONFIG: bincode::config::Configuration<LittleEndian, Fixint, NoLimit> =
-    bincode::config::standard().with_fixed_int_encoding();
 
 /// Wrapper around the `GeneralizedXMSSPublicKey` from the hashsig crate.
 ///
@@ -71,7 +62,7 @@ impl PublicKey {
     pub fn to_hash_sig_public_key(&self) -> anyhow::Result<HashSigPublicKey> {
         bincode::serde::decode_from_slice(&self.inner, BINCODE_CONFIG)
             .map(|(value, _)| value)
-            .map_err(|err| anyhow::anyhow!("Failed to decode public key: {err}"))
+            .map_err(|err| anyhow!("Failed to decode public key: {err}"))
     }
 }
 

--- a/crates/crypto/post_quantum/src/hashsig/signature.rs
+++ b/crates/crypto/post_quantum/src/hashsig/signature.rs
@@ -1,22 +1,13 @@
 use alloy_primitives::FixedBytes;
-use bincode::config::{Fixint, LittleEndian, NoLimit};
 use hashsig::{MESSAGE_LENGTH, signature::SignatureScheme};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
-use super::errors::SignatureError;
+use super::{BINCODE_CONFIG, errors::SignatureError};
 use crate::hashsig::{HashSigScheme, public_key::PublicKey};
 
 type HashSigSignature = <HashSigScheme as SignatureScheme>::Signature;
-
-// NOTE: `GeneralizedXMSSSignature` doesn't implement methods like `to_bytes`,
-// which means we need to use bincode to serialize/deserialize it.
-// However, using bincode's default config (little-endian + variable int encoding)
-// add extra bytes to the serialized output, which is not what we want.
-// Thus, define a custom configuration for bincode here.
-const BINCODE_CONFIG: bincode::config::Configuration<LittleEndian, Fixint, NoLimit> =
-    bincode::config::standard().with_fixed_int_encoding();
 
 const SIGNATURE_SIZE: usize = 3100;
 


### PR DESCRIPTION
### What was wrong?

We had BINCODE_CONFIG duplicated 3 times

### How was it fixed?

removed the duplication
