### PR TITLE
fix: use default for network service

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -62,7 +62,7 @@ use ream_rpc_common::config::RpcServerConfig;
 use ream_storage::{
     db::{ReamDB, reset_db},
     dir::setup_data_dir,
-    tables::{field::REDBField, table::REDBTable},
+    tables::table::REDBTable,
 };
 use ream_sync::rwlock::Writer;
 use ream_validator_beacon::{
@@ -192,20 +192,6 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
 
     // Initialize the lean network service
 
-    let head_block_hash = lean_db
-        .lean_head_provider()
-        .get()
-        .expect("Head blockhash should be available");
-    let head_block = lean_db
-        .lean_block_provider()
-        .get(head_block_hash)
-        .expect("Head block should be available")
-        .expect("Head block should be Some");
-    let head_cheakpoint = Checkpoint {
-        root: head_block_hash,
-        slot: head_block.message.block.slot,
-    };
-
     let fork = "devnet0".to_string();
     let topics: Vec<LeanGossipTopic> = vec![
         LeanGossipTopic {
@@ -232,11 +218,8 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
         chain_sender.clone(),
         outbound_p2p_receiver,
         Status {
-            finalized: lean_db
-                .latest_finalized_provider()
-                .get()
-                .expect("Finalized checkpoint should be avaliable"),
-            head: head_cheakpoint,
+            finalized: Checkpoint::default(),
+            head: Checkpoint::default(),
         },
     )
     .await


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
<img width="1046" height="191" alt="image" src="https://github.com/user-attachments/assets/5dba52c0-05dc-4466-8fac-87af987b7ffe" />


### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->
The node was failing on startup because there is no data in the DB when running a fresh node. 
This PR initiates the network service manager with default Checkpoints on startup which is fine I think since there is no `finalized` root or  `head` root on startup.
The node is running after this fix and also finalizing:
<img width="1445" height="196" alt="image" src="https://github.com/user-attachments/assets/c5785522-a909-4c74-be24-6c98025e34f7" />


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
