### PR TITLE
refactor: remove redundant lean_/beacon_ prefix on db providers

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -332,7 +332,7 @@ pub async fn run_beacon_node(config: BeaconNodeConfig, executor: ReamExecutor, r
         .expect("No oldest root found");
     set_genesis_validator_root(
         beacon_db
-            .beacon_state_provider()
+            .state_provider()
             .get(oldest_root)
             .expect("Failed to access beacon state provider")
             .expect("No beacon state found")
@@ -714,8 +714,8 @@ mod tests {
         handle.abort();
 
         let lean_db = db.init_lean_db().unwrap();
-        let head = lean_db.lean_head_provider().get().unwrap();
-        let head_state = lean_db.lean_state_provider().get(head).unwrap().unwrap();
+        let head = lean_db.head_provider().get().unwrap();
+        let head_state = lean_db.state_provider().get(head).unwrap().unwrap();
 
         let justfication_lag = 4;
         let finalization_lag = 5;

--- a/crates/common/chain/beacon/src/beacon_chain.rs
+++ b/crates/common/chain/beacon/src/beacon_chain.rs
@@ -97,14 +97,7 @@ impl BeaconChain {
             }
         };
 
-        let head_slot = match self
-            .store
-            .lock()
-            .await
-            .db
-            .beacon_block_provider()
-            .get(head_root)
-        {
+        let head_slot = match self.store.lock().await.db.block_provider().get(head_root) {
             Ok(Some(block)) => block.message.slot,
             err => {
                 bail!("Failed to get block for head root {head_root}: {err:?}");

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -57,12 +57,12 @@ impl LeanChainService {
                     match tick_count % 4 {
                         0 => {
                             // First tick (t=0/4): Log current head state, including its justification/finalization status.
-                            let (head, store) = {
-                                let store = self.store.read().await;
-                                (store.store.lock().await.lean_head_provider().get()?, store.store.clone())
+                            let (head, state_provider) = {
+                                let fork_choice = self.store.read().await;
+                                let store = fork_choice.store.lock().await;
+                                (store.head_provider().get()?, store.state_provider())
                             };
-                            let head_state = store.lock().await
-                                .lean_state_provider()
+                            let head_state = state_provider
                                 .get(head)?.ok_or_else(|| anyhow!("Post state not found for head: {head}"))?;
 
                             info!(

--- a/crates/common/checkpoint_sync/src/lib.rs
+++ b/crates/common/checkpoint_sync/src/lib.rs
@@ -39,9 +39,9 @@ pub async fn initialize_db_from_checkpoint(
             .get_highest_root()?
             .expect("No highest root found");
         let state = db
-            .beacon_state_provider()
+            .state_provider()
             .get(highest_root)?
-            .ok_or_else(|| anyhow!("Unable to fetch beacon state"))?;
+            .ok_or_else(|| anyhow!("Unable to fetch state"))?;
 
         if let Some(weak_subjectivity_checkpoint) = &weak_subjectivity_checkpoint {
             if !verify_state_from_weak_subjectivity_checkpoint(

--- a/crates/common/fork_choice/beacon/src/handlers.rs
+++ b/crates/common/fork_choice/beacon/src/handlers.rs
@@ -31,11 +31,7 @@ pub async fn on_block(
 
     // Parent block must be known
     ensure!(
-        store
-            .db
-            .beacon_state_provider()
-            .get(block.parent_root)?
-            .is_some(),
+        store.db.state_provider().get(block.parent_root)?.is_some(),
         "Missing parent block state for parent_root: {:x}",
         block.parent_root
     );
@@ -82,7 +78,7 @@ pub async fn on_block(
     // Make a copy of the state to avoid mutability issues
     let mut state = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(block.parent_root)?
         .ok_or_else(|| anyhow!("beacon state not found"))?
         .clone();
@@ -94,13 +90,13 @@ pub async fn on_block(
     // Add new block to the store
     store
         .db
-        .beacon_block_provider()
+        .block_provider()
         .insert(block_root, signed_block.clone())?;
 
     // Add new state for this block to the store
     store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .insert(block_root, state.clone())?;
 
     // Add block timeliness to the store
@@ -150,7 +146,7 @@ pub fn on_attester_slashing(
 
     let state = &store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(store.db.justified_checkpoint_provider().get()?.root)?
         .ok_or_else(|| anyhow!("beacon state not found"))?;
 

--- a/crates/networking/manager/src/gossipsub/validate/attester_slashing.rs
+++ b/crates/networking/manager/src/gossipsub/validate/attester_slashing.rs
@@ -18,7 +18,7 @@ pub async fn validate_attester_slashing(
     let head_root = store.get_head()?;
     let mut state: BeaconState = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("Could not get beacon state: {head_root}"))?;
 

--- a/crates/networking/manager/src/gossipsub/validate/beacon_attestation.rs
+++ b/crates/networking/manager/src/gossipsub/validate/beacon_attestation.rs
@@ -27,7 +27,7 @@ pub async fn validate_beacon_attestation(
     let head_root = store.get_head()?;
     let state: BeaconState = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
 
@@ -52,7 +52,7 @@ pub async fn validate_beacon_attestation(
 
     let block = store
         .db
-        .beacon_block_provider()
+        .block_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("Could not get block for head root: {head_root}"))?;
 
@@ -144,7 +144,7 @@ pub async fn validate_beacon_attestation(
     // retrieved).
     if store
         .db
-        .beacon_block_provider()
+        .block_provider()
         .get(attestation.data.beacon_block_root)?
         .is_none()
     {

--- a/crates/networking/manager/src/gossipsub/validate/beacon_block.rs
+++ b/crates/networking/manager/src/gossipsub/validate/beacon_block.rs
@@ -35,19 +35,11 @@ pub async fn validate_gossip_beacon_block(
 
     let (parent_block, parent_state) = {
         let store = beacon_chain.store.lock().await;
-        let Some(parent_block) = store
-            .db
-            .beacon_block_provider()
-            .get(block.message.parent_root)?
-        else {
+        let Some(parent_block) = store.db.block_provider().get(block.message.parent_root)? else {
             return Err(anyhow!("failed to get parent block"));
         };
 
-        let Some(parent_state) = store
-            .db
-            .beacon_state_provider()
-            .get(block.message.parent_root)?
-        else {
+        let Some(parent_state) = store.db.state_provider().get(block.message.parent_root)? else {
             return Err(anyhow!("failed to get parent state"));
         };
 
@@ -156,11 +148,7 @@ pub async fn validate_beacon_block(
         }
     }
 
-    match store
-        .db
-        .beacon_block_provider()
-        .get(block.message.parent_root)?
-    {
+    match store.db.block_provider().get(block.message.parent_root)? {
         Some(parent_block) => {
             // [REJECT] The block is from a higher slot than its parent.
             if block.message.slot <= parent_block.message.slot {

--- a/crates/networking/manager/src/gossipsub/validate/blob_sidecar.rs
+++ b/crates/networking/manager/src/gossipsub/validate/blob_sidecar.rs
@@ -55,7 +55,7 @@ pub async fn validate_blob_sidecar(
     let head_root = store.get_head()?;
     let state: BeaconState = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
 
@@ -68,7 +68,7 @@ pub async fn validate_blob_sidecar(
     }
 
     // [IGNORE] The sidecar's block's parent (defined by block_header.parent_root) has been seen
-    let Some(parent_block) = store.db.beacon_block_provider().get(header.parent_root)? else {
+    let Some(parent_block) = store.db.block_provider().get(header.parent_root)? else {
         return Ok(ValidationResult::Ignore(
             "Parent block not seen".to_string(),
         ));

--- a/crates/networking/manager/src/gossipsub/validate/bls_to_execution_change.rs
+++ b/crates/networking/manager/src/gossipsub/validate/bls_to_execution_change.rs
@@ -21,7 +21,7 @@ pub async fn validate_bls_to_execution_change(
     let head_root = store.get_head()?;
     let mut state: BeaconState = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
 

--- a/crates/networking/manager/src/gossipsub/validate/proposer_slashing.rs
+++ b/crates/networking/manager/src/gossipsub/validate/proposer_slashing.rs
@@ -31,7 +31,7 @@ pub async fn validate_proposer_slashing(
     let head_root = store.get_head()?;
     let mut state: BeaconState = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("Could not get beacon state: {head_root}"))?;
 

--- a/crates/networking/manager/src/gossipsub/validate/sync_committee.rs
+++ b/crates/networking/manager/src/gossipsub/validate/sync_committee.rs
@@ -27,7 +27,7 @@ pub async fn validate_sync_committee(
     let head_root = store.get_head()?;
     let state: BeaconState = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
 

--- a/crates/networking/manager/src/gossipsub/validate/sync_committee_contribution_and_proof.rs
+++ b/crates/networking/manager/src/gossipsub/validate/sync_committee_contribution_and_proof.rs
@@ -34,13 +34,13 @@ pub async fn validate_sync_committee_contribution_and_proof(
 
     let block = store
         .db
-        .beacon_block_provider()
+        .block_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("Could not get block for head root: {head_root}"))?;
 
     let state = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
 

--- a/crates/networking/manager/src/gossipsub/validate/voluntary_exit.rs
+++ b/crates/networking/manager/src/gossipsub/validate/voluntary_exit.rs
@@ -17,7 +17,7 @@ pub async fn validate_voluntary_exit(
     let head_root = store.get_head()?;
     let state: BeaconState = store
         .db
-        .beacon_state_provider()
+        .state_provider()
         .get(head_root)?
         .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
 

--- a/crates/networking/manager/src/req_resp.rs
+++ b/crates/networking/manager/src/req_resp.rs
@@ -62,7 +62,7 @@ pub async fn handle_req_resp_message(
                     );
                     return;
                 };
-                let Ok(Some(block)) = ream_db.beacon_block_provider().get(block_root) else {
+                let Ok(Some(block)) = ream_db.block_provider().get(block_root) else {
                     trace!("No block found for root {block_root}");
                     p2p_sender.send_error_response(
                         peer_id,
@@ -85,7 +85,7 @@ pub async fn handle_req_resp_message(
         }
         BeaconRequestMessage::BeaconBlocksByRoot(BeaconBlocksByRootV2Request { inner }) => {
             for block_root in inner {
-                let Ok(Some(block)) = ream_db.beacon_block_provider().get(block_root) else {
+                let Ok(Some(block)) = ream_db.block_provider().get(block_root) else {
                     trace!("No block found for root {block_root}");
                     p2p_sender.send_error_response(
                         peer_id,
@@ -121,7 +121,7 @@ pub async fn handle_req_resp_message(
                     );
                     return;
                 };
-                let Ok(Some(block)) = ream_db.beacon_block_provider().get(block_root) else {
+                let Ok(Some(block)) = ream_db.block_provider().get(block_root) else {
                     trace!("No block found for root {block_root}");
                     p2p_sender.send_error_response(
                         peer_id,
@@ -191,9 +191,7 @@ pub async fn handle_req_resp_message(
                     return;
                 };
 
-                let Ok(Some(block)) = ream_db
-                    .beacon_block_provider()
-                    .get(blob_identifier.block_root)
+                let Ok(Some(block)) = ream_db.block_provider().get(blob_identifier.block_root)
                 else {
                     trace!("No block found for root {}", blob_identifier.block_root);
                     p2p_sender.send_error_response(

--- a/crates/rpc/beacon/src/handlers/block.rs
+++ b/crates/rpc/beacon/src/handlers/block.rs
@@ -147,7 +147,7 @@ pub async fn get_beacon_block_from_id(
 ) -> Result<SignedBeaconBlock, ApiError> {
     let block_root = get_block_root_from_id(block_id, db).await?;
 
-    db.beacon_block_provider()
+    db.block_provider()
         .get(block_root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get block by block_root, error: {err:?}"))

--- a/crates/rpc/beacon/src/handlers/header.rs
+++ b/crates/rpc/beacon/src/handlers/header.rs
@@ -45,7 +45,7 @@ pub async fn get_headers(
         (None, Some(parent_root)) => {
             // get parent block to have access to `slot`
             let parent_block = db
-                .beacon_block_provider()
+                .block_provider()
                 .get(parent_root)
                 .map_err(|err| {
                     ApiError::InternalError(format!("Failed to get headers, error: {err:?}"))

--- a/crates/rpc/beacon/src/handlers/light_client.rs
+++ b/crates/rpc/beacon/src/handlers/light_client.rs
@@ -30,7 +30,7 @@ pub async fn get_light_client_bootstrap(
 ) -> Result<impl Responder, ApiError> {
     let block_root = block_root.into_inner();
     let beacon_block = db
-        .beacon_block_provider()
+        .block_provider()
         .get(block_root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get block by block_root, error: {err:?}"))
@@ -40,7 +40,7 @@ pub async fn get_light_client_bootstrap(
         })?;
 
     let beacon_state = db
-        .beacon_state_provider()
+        .state_provider()
         .get(block_root)
         .map_err(|err| {
             ApiError::InternalError(format!(
@@ -89,31 +89,31 @@ pub async fn get_light_client_updates(
             })?;
 
         let block = db
-            .beacon_block_provider()
+            .block_provider()
             .get(block_root)
             .map_err(|err| {
                 ApiError::InternalError(format!(
-                    "Failed to get beacon_block from block_root, error: {err:?}"
+                    "Failed to get block from block_root, error: {err:?}"
                 ))
             })?
             .ok_or(ApiError::NotFound(format!(
-                "Failed to find beacon_block from {block_root:?}"
+                "Failed to find block from {block_root:?}"
             )))?;
 
         let state = db
-            .beacon_state_provider()
+            .state_provider()
             .get(block_root)
             .map_err(|err| {
                 ApiError::InternalError(format!(
-                    "Failed to get beacon_state from block_root, error: {err:?}"
+                    "Failed to get state from block_root, error: {err:?}"
                 ))
             })?
             .ok_or(ApiError::NotFound(format!(
-                "Failed to find beacon_state from {block_root:?}"
+                "Failed to find state from {block_root:?}"
             )))?;
 
         let attested_block = db
-            .beacon_block_provider()
+            .block_provider()
             .get(block.message.parent_root)
             .map_err(|err| {
                 ApiError::InternalError(format!(
@@ -127,7 +127,7 @@ pub async fn get_light_client_updates(
 
         let attested_block_root = attested_block.message.tree_hash_root();
         let attested_state = db
-            .beacon_state_provider()
+            .state_provider()
             .get(attested_block_root)
             .map_err(|err| {
                 ApiError::InternalError(format!(
@@ -139,7 +139,7 @@ pub async fn get_light_client_updates(
             )))?;
 
         let finalized_block = db
-            .beacon_block_provider()
+            .block_provider()
             .get(attested_state.finalized_checkpoint.root)
             .map_err(|err| {
                 ApiError::InternalError(format!(
@@ -206,7 +206,7 @@ pub async fn get_light_client_finality_update(
 
     // Get the head block and state
     let head_block = db
-        .beacon_block_provider()
+        .block_provider()
         .get(head_block_root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get head block, error: {err:?}"))
@@ -215,7 +215,7 @@ pub async fn get_light_client_finality_update(
 
     // Get the attested block (parent of head block) and its state
     let attested_block = db
-        .beacon_block_provider()
+        .block_provider()
         .get(head_block.message.parent_root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get attested block, error: {err:?}"))
@@ -224,7 +224,7 @@ pub async fn get_light_client_finality_update(
 
     let attested_block_root = attested_block.message.tree_hash_root();
     let attested_state = db
-        .beacon_state_provider()
+        .state_provider()
         .get(attested_block_root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get attested state, error: {err:?}"))
@@ -233,7 +233,7 @@ pub async fn get_light_client_finality_update(
 
     // Get the finalized block
     let finalized_block = db
-        .beacon_block_provider()
+        .block_provider()
         .get(finalized_checkpoint.root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get finalized block, error: {err:?}"))
@@ -311,7 +311,7 @@ pub async fn get_light_client_optimistic_update(
 
     // Get the head block
     let head_block = db
-        .beacon_block_provider()
+        .block_provider()
         .get(head_block_root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get head block, error: {err:?}"))
@@ -320,7 +320,7 @@ pub async fn get_light_client_optimistic_update(
 
     // Get the attested block (parent of head block)
     let attested_block = db
-        .beacon_block_provider()
+        .block_provider()
         .get(head_block.message.parent_root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get attested block, error: {err:?}"))

--- a/crates/rpc/beacon/src/handlers/state.rs
+++ b/crates/rpc/beacon/src/handlers/state.rs
@@ -96,7 +96,7 @@ pub async fn get_state_from_id(state_id: ID, db: &BeaconDB) -> Result<BeaconStat
     .map_err(|err| ApiError::InternalError(format!("Failed to get headers, error: {err:?}")))?
     .ok_or_else(|| ApiError::NotFound(format!("Failed to find `block_root` from {state_id:?}")))?;
 
-    db.beacon_state_provider()
+    db.state_provider()
         .get(block_root)
         .map_err(|err| {
             ApiError::InternalError(format!("Failed to get block by block_root, error: {err:?}"))

--- a/crates/rpc/beacon/src/handlers/syncing.rs
+++ b/crates/rpc/beacon/src/handlers/syncing.rs
@@ -49,7 +49,7 @@ pub async fn get_syncing_status(
         ApiError::InternalError(format!("Failed to get current slot, error: {err:?}"))
     })?;
 
-    let head_slot = match db.beacon_block_provider().get(head) {
+    let head_slot = match db.block_provider().get(head) {
         Ok(Some(block)) => block.message.slot,
         err => {
             return Err(ApiError::InternalError(format!(

--- a/crates/rpc/lean/src/handlers/block.rs
+++ b/crates/rpc/lean/src/handlers/block.rs
@@ -44,7 +44,7 @@ pub async fn get_block_by_id(
             .store
             .lock()
             .await
-            .lean_head_provider()
+            .head_provider()
             .get()
             .map_err(|err| ApiError::InternalError(format!("Could not get head: {err:?}"))),
         ID::Justified => lean_chain
@@ -62,7 +62,7 @@ pub async fn get_block_by_id(
         ID::Root(root) => Ok(root),
     };
 
-    let provider = lean_chain.store.clone().lock().await.lean_block_provider();
+    let provider = lean_chain.store.clone().lock().await.block_provider();
     provider
         .get(block_root?)
         .map(|maybe_signed_block| {

--- a/crates/rpc/lean/src/handlers/head.rs
+++ b/crates/rpc/lean/src/handlers/head.rs
@@ -14,7 +14,7 @@ pub async fn get_head(lean_chain: Data<LeanStoreReader>) -> Result<impl Responde
             .store
             .lock()
             .await
-            .lean_head_provider()
+            .head_provider()
             .get()
             .map_err(|err| ApiError::InternalError(format!("Could not get head: {err:?}")))?,
     }))

--- a/crates/rpc/lean/src/handlers/state.rs
+++ b/crates/rpc/lean/src/handlers/state.rs
@@ -34,7 +34,7 @@ pub async fn get_state(
             .store
             .lock()
             .await
-            .lean_head_provider()
+            .head_provider()
             .get()
             .map_err(|err| ApiError::InternalError(format!("Could not get head: {err:?}"))),
         ID::Justified => {
@@ -63,7 +63,7 @@ pub async fn get_state(
         }
     };
 
-    let provider = lean_chain.store.clone().lock().await.lean_state_provider();
+    let provider = lean_chain.store.clone().lock().await.state_provider();
 
     Ok(HttpResponse::Ok().json(
         provider

--- a/crates/storage/src/db/beacon.rs
+++ b/crates/storage/src/db/beacon.rs
@@ -28,12 +28,12 @@ pub struct BeaconDB {
 }
 
 impl BeaconDB {
-    pub fn beacon_block_provider(&self) -> BeaconBlockTable {
+    pub fn block_provider(&self) -> BeaconBlockTable {
         BeaconBlockTable {
             db: self.db.clone(),
         }
     }
-    pub fn beacon_state_provider(&self) -> BeaconStateTable {
+    pub fn state_provider(&self) -> BeaconStateTable {
         BeaconStateTable {
             db: self.db.clone(),
         }
@@ -149,7 +149,7 @@ impl BeaconDB {
             .expect("No highest root found");
 
         let state = self
-            .beacon_state_provider()
+            .state_provider()
             .get(highest_root)?
             .ok_or_else(|| anyhow!("Unable to fetch latest state"))?;
 

--- a/crates/storage/src/db/lean.rs
+++ b/crates/storage/src/db/lean.rs
@@ -16,12 +16,12 @@ pub struct LeanDB {
 }
 
 impl LeanDB {
-    pub fn lean_block_provider(&self) -> LeanBlockTable {
+    pub fn block_provider(&self) -> LeanBlockTable {
         LeanBlockTable {
             db: self.db.clone(),
         }
     }
-    pub fn lean_state_provider(&self) -> LeanStateTable {
+    pub fn state_provider(&self) -> LeanStateTable {
         LeanStateTable {
             db: self.db.clone(),
         }
@@ -57,25 +57,25 @@ impl LeanDB {
         }
     }
 
-    pub fn lean_time_provider(&self) -> LeanTimeField {
+    pub fn time_provider(&self) -> LeanTimeField {
         LeanTimeField {
             db: self.db.clone(),
         }
     }
 
-    pub fn lean_head_provider(&self) -> LeanHeadField {
+    pub fn head_provider(&self) -> LeanHeadField {
         LeanHeadField {
             db: self.db.clone(),
         }
     }
 
-    pub fn lean_safe_target_provider(&self) -> LeanSafeTargetField {
+    pub fn safe_target_provider(&self) -> LeanSafeTargetField {
         LeanSafeTargetField {
             db: self.db.clone(),
         }
     }
 
-    pub fn lean_latest_new_attestations_provider(&self) -> LeanLatestNewAttestationsTable {
+    pub fn latest_new_attestations_provider(&self) -> LeanLatestNewAttestationsTable {
         LeanLatestNewAttestationsTable {
             db: self.db.clone(),
         }

--- a/testing/gossip-validation/tests/validate_block.rs
+++ b/testing/gossip-validation/tests/validate_block.rs
@@ -81,40 +81,37 @@ mod tests {
     #[allow(clippy::too_many_arguments, clippy::unwrap_used)]
     pub async fn insert_mock_data(
         db: &mut BeaconDB,
-        ancestor_beacon_block: SignedBeaconBlock,
+        ancestor_block: SignedBeaconBlock,
         grandparent_block_root: B256,
         block_root: B256,
-        grandparent_beacon_state: BeaconState,
-        grandparent_beacon_block: SignedBeaconBlock,
-        parent_beacon_block: SignedBeaconBlock,
-        parent_beacon_state: BeaconState,
+        grandparent_state: BeaconState,
+        grandparent_block: SignedBeaconBlock,
+        parent_block: SignedBeaconBlock,
+        parent_state: BeaconState,
     ) {
         let ancestor_checkpoint = Checkpoint {
-            epoch: ancestor_beacon_block.message.slot / 32,
-            root: ancestor_beacon_block.message.block_root(),
+            epoch: ancestor_block.message.slot / 32,
+            root: ancestor_block.message.block_root(),
         };
-        db.beacon_block_provider()
-            .insert(
-                ancestor_beacon_block.message.block_root(),
-                ancestor_beacon_block,
-            )
+        db.block_provider()
+            .insert(ancestor_block.message.block_root(), ancestor_block)
             .unwrap();
 
-        let slot = parent_beacon_block.message.slot;
+        let slot = parent_block.message.slot;
         db.finalized_checkpoint_provider()
             .insert(ancestor_checkpoint)
             .unwrap();
-        db.beacon_block_provider()
-            .insert(grandparent_block_root, grandparent_beacon_block)
+        db.block_provider()
+            .insert(grandparent_block_root, grandparent_block)
             .unwrap();
-        db.beacon_state_provider()
-            .insert(grandparent_block_root, grandparent_beacon_state)
+        db.state_provider()
+            .insert(grandparent_block_root, grandparent_state)
             .unwrap();
-        db.beacon_block_provider()
-            .insert(block_root, parent_beacon_block)
+        db.block_provider()
+            .insert(block_root, parent_block)
             .unwrap();
-        db.beacon_state_provider()
-            .insert(block_root, parent_beacon_state)
+        db.state_provider()
+            .insert(block_root, parent_state)
             .unwrap();
         db.slot_index_provider().insert(slot, block_root).unwrap();
         db.genesis_time_provider()
@@ -133,12 +130,7 @@ mod tests {
 
             (
                 store.db.get_latest_state().unwrap(),
-                store
-                    .db
-                    .beacon_block_provider()
-                    .get(block_root)
-                    .unwrap()
-                    .unwrap(),
+                store.db.block_provider().get(block_root).unwrap().unwrap(),
             )
         };
         assert_eq!(latest_state_in_db.slot, latest_block.message.slot);


### PR DESCRIPTION
### What was wrong?

We have LeanDB and BeaconDB, the lean_/beacon_ prefix on the providers is redundant
### How was it fixed?

remove the redundant prefix
