### PR TITLE
fix: make it so set_lean_network_spec can only be ran once in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5753,7 +5753,6 @@ dependencies = [
  "ream-consensus-misc",
  "serde",
  "serde_yaml",
- "tracing",
 ]
 
 [[package]]

--- a/crates/common/network_spec/Cargo.toml
+++ b/crates/common/network_spec/Cargo.toml
@@ -15,7 +15,6 @@ anyhow.workspace = true
 ethereum_serde_utils.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
-tracing.workspace = true
 
 # ream-dependencies
 ream-consensus-misc.workspace = true


### PR DESCRIPTION
### What was wrong?

multiple tests were trying to set the `lean_network_spec()`
### How was it fixed?

add code to limit tests to only set `lean_network_spec()` once
