### PR TITLE
feat: add DiscardOnDropHistogramTimer

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -10,7 +10,7 @@ use ream_consensus_lean::{
     validator::is_proposer,
 };
 use ream_consensus_misc::constants::lean::INTERVALS_PER_SLOT;
-use ream_metrics::{HEAD_SLOT, PROPOSE_BLOCK_TIME, set_int_gauge_vec, start_timer_vec, stop_timer};
+use ream_metrics::{HEAD_SLOT, PROPOSE_BLOCK_TIME, set_int_gauge_vec, start_timer, stop_timer};
 use ream_network_spec::networks::lean_network_spec;
 use ream_network_state_lean::NetworkState;
 use ream_post_quantum_crypto::hashsig::signature::Signature;
@@ -426,7 +426,7 @@ impl Store {
         validator_index: u64,
     ) -> anyhow::Result<BlockWithSignatures> {
         let head_root = self.get_proposal_head(slot).await?;
-        let initialize_block_timer = start_timer_vec(&PROPOSE_BLOCK_TIME, &["initialize_block"]);
+        let initialize_block_timer = start_timer(&PROPOSE_BLOCK_TIME, &["initialize_block"]);
         let (state_provider, latest_known_attestation_provider, block_provider) = {
             let db = self.store.lock().await;
             (
@@ -448,7 +448,7 @@ impl Store {
         );
 
         let add_attestations_timer =
-            start_timer_vec(&PROPOSE_BLOCK_TIME, &["add_valid_attestations_to_block"]);
+            start_timer(&PROPOSE_BLOCK_TIME, &["add_valid_attestations_to_block"]);
 
         let mut attestations = VariableList::empty();
         let mut signatures: Vec<Signature> = Vec::new();
@@ -512,8 +512,7 @@ impl Store {
             body: BlockBody { attestations },
         };
         head_state.process_block(&final_block)?;
-        let compute_state_root_timer =
-            start_timer_vec(&PROPOSE_BLOCK_TIME, &["compute_state_root"]);
+        let compute_state_root_timer = start_timer(&PROPOSE_BLOCK_TIME, &["compute_state_root"]);
         final_block.state_root = head_state.tree_hash_root();
         stop_timer(compute_state_root_timer);
         Ok(BlockWithSignatures {

--- a/crates/common/metrics/src/lib.rs
+++ b/crates/common/metrics/src/lib.rs
@@ -1,40 +1,41 @@
+pub mod timer;
+
 use prometheus_exporter::prometheus::{
     HistogramTimer, HistogramVec, IntGaugeVec, default_registry,
     register_histogram_vec_with_registry, register_int_gauge_vec_with_registry,
 };
 
+use crate::timer::DiscardOnDropHistogramTimer;
+
 // Provisioning each metrics
 lazy_static::lazy_static! {
-    pub static ref PROPOSE_BLOCK_TIME: HistogramVec = create_histogram_vec(
+    pub static ref PROPOSE_BLOCK_TIME: HistogramVec = register_histogram_vec_with_registry!(
         "lean_propose_block_time",
         "Duration of the sections it takes to propose a new block",
-        &["section"]
-    );
+        &["section"],
+        default_registry()
+    ).expect("failed to create PROPOSE_BLOCK_TIME histogram vec");
 
-    pub static ref HEAD_SLOT: IntGaugeVec = create_int_gauge_vec(
+    pub static ref HEAD_SLOT: IntGaugeVec = register_int_gauge_vec_with_registry!(
         "lean_head_slot",
         "The current head slot",
-        &[]
-    );
+        &[],
+        default_registry()
+    ).expect("failed to create HEAD_SLOT int gauge vec");
 
-    pub static ref JUSTIFIED_SLOT: IntGaugeVec = create_int_gauge_vec(
+    pub static ref JUSTIFIED_SLOT: IntGaugeVec = register_int_gauge_vec_with_registry!(
         "lean_justified_slot",
         "The current justified slot",
-        &[]
-    );
+        &[],
+        default_registry()
+    ).expect("failed to create JUSTIFIED_SLOT int gauge vec");
 
-    pub static ref FINALIZED_SLOT: IntGaugeVec = create_int_gauge_vec(
+    pub static ref FINALIZED_SLOT: IntGaugeVec = register_int_gauge_vec_with_registry!(
         "lean_finalized_slot",
         "The current finalized slot",
-        &[]
-    );
-}
-
-/// Create a new gauge metric
-pub fn create_int_gauge_vec(name: &str, help: &str, label_names: &[&str]) -> IntGaugeVec {
-    let registry = default_registry();
-    register_int_gauge_vec_with_registry!(name, help, label_names, registry)
-        .expect("failed to create int gauge vec")
+        &[],
+        default_registry()
+    ).expect("failed to create FINALIZED_SLOT int gauge vec");
 }
 
 /// Set the value of a gauge metric
@@ -42,19 +43,24 @@ pub fn set_int_gauge_vec(gauge_vec: &IntGaugeVec, value: i64, label_values: &[&s
     gauge_vec.with_label_values(label_values).set(value);
 }
 
-/// Create a new histogram metric
-pub fn create_histogram_vec(name: &str, help: &str, label_names: &[&str]) -> HistogramVec {
-    let registry = default_registry();
-    register_histogram_vec_with_registry!(name, help, label_names, registry)
-        .expect("failed to create histogram")
-}
-
 /// Start a timer for a histogram metric
-pub fn start_timer_vec(histogram_vec: &HistogramVec, label_values: &[&str]) -> HistogramTimer {
+pub fn start_timer(histogram_vec: &HistogramVec, label_values: &[&str]) -> HistogramTimer {
     histogram_vec.with_label_values(label_values).start_timer()
 }
 
-/// Stop a timer for a histogram metric
 pub fn stop_timer(timer: HistogramTimer) {
+    timer.observe_duration()
+}
+
+/// Start a timer for a histogram metric that discards the result on drop if
+/// stop_timer_discard_on_drop is not called
+pub fn start_timer_discard_on_drop(
+    histogram_vec: &HistogramVec,
+    label_values: &[&str],
+) -> DiscardOnDropHistogramTimer {
+    DiscardOnDropHistogramTimer::new(histogram_vec.with_label_values(label_values).clone())
+}
+
+pub fn stop_timer_discard_on_drop(timer: DiscardOnDropHistogramTimer) {
     timer.observe_duration()
 }

--- a/crates/common/metrics/src/timer.rs
+++ b/crates/common/metrics/src/timer.rs
@@ -1,0 +1,266 @@
+use std::time::Instant;
+
+use prometheus_exporter::prometheus::Histogram;
+
+/// Timer to measure and record the duration of an event.
+///
+/// This timer can be stopped and observed at most once manually.
+/// Alternatively, if it isn't manually stopped it will be discarded in order to not record its
+/// value.
+#[must_use = "Timer should be kept in a variable otherwise it cannot observe duration"]
+#[derive(Debug)]
+pub struct DiscardOnDropHistogramTimer {
+    /// A histogram for automatic recording of observations.
+    histogram: Histogram,
+    /// Whether the timer has already been observed once.
+    observed: bool,
+    /// Starting instant for the timer.
+    start: Instant,
+}
+
+impl DiscardOnDropHistogramTimer {
+    pub fn new(histogram: Histogram) -> Self {
+        Self {
+            histogram,
+            observed: false,
+            start: Instant::now(),
+        }
+    }
+
+    /// Observe and record timer duration (in seconds).
+    ///
+    /// It observes the floating-point number of seconds elapsed since the timer
+    /// started, and it records that value to the attached histogram.
+    pub fn observe_duration(self) {
+        self.stop_and_record();
+    }
+
+    /// Observe, record and return timer duration (in seconds).
+    ///
+    /// It observes and returns a floating-point number for seconds elapsed since
+    /// the timer started, recording that value to the attached histogram.
+    pub fn stop_and_record(self) -> f64 {
+        let mut timer = self;
+        timer.observe(true)
+    }
+
+    /// Observe and return timer duration (in seconds).
+    ///
+    /// It returns a floating-point number of seconds elapsed since the timer started,
+    /// without recording to any histogram.
+    pub fn stop_and_discard(self) -> f64 {
+        let mut timer = self;
+        timer.observe(false)
+    }
+
+    fn observe(&mut self, record: bool) -> f64 {
+        let duration_eclipsed_since_start = Instant::now().saturating_duration_since(self.start);
+        let nanos = f64::from(duration_eclipsed_since_start.subsec_nanos()) / 1e9;
+        let seconds_eclipsed_since_start = duration_eclipsed_since_start.as_secs() as f64 + nanos;
+        self.observed = true;
+        if record {
+            self.histogram.observe(seconds_eclipsed_since_start);
+        }
+        seconds_eclipsed_since_start
+    }
+}
+
+impl Drop for DiscardOnDropHistogramTimer {
+    fn drop(&mut self) {
+        if !self.observed {
+            self.observe(false);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{thread, time::Duration};
+
+    use prometheus_exporter::prometheus::{Histogram, HistogramOpts, core::Collector};
+
+    use crate::timer::DiscardOnDropHistogramTimer;
+
+    #[test]
+    fn test_observe_duration() {
+        let opts =
+            HistogramOpts::new("test_observe_duration", "testing").const_label("defense", "1");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        let timer = DiscardOnDropHistogramTimer::new(histogram.clone());
+        thread::sleep(Duration::from_millis(100));
+        timer.observe_duration();
+
+        let mut metric_families = histogram.collect();
+        assert_eq!(metric_families.len(), 1);
+
+        let metric_family = metric_families.pop().unwrap();
+        let metric = metric_family.get_metric().first().unwrap();
+        assert_eq!(metric.get_label().len(), 1);
+        let proto_histogram = metric.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 1);
+        assert!(proto_histogram.get_sample_sum() >= 0.1);
+    }
+
+    #[test]
+    fn test_observe_duration_in_thread() {
+        let opts = HistogramOpts::new("test_observe_duration_in_thread", "testing")
+            .const_label("defense", "1");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        let timer = DiscardOnDropHistogramTimer::new(histogram.clone());
+        let handler = thread::spawn(move || {
+            let timer = timer;
+            thread::sleep(Duration::from_millis(100));
+            timer.observe_duration();
+        });
+        assert!(handler.join().is_ok());
+
+        let mut metric_families = histogram.collect();
+        assert_eq!(metric_families.len(), 1);
+
+        let metric_family = metric_families.pop().unwrap();
+        let metric = metric_family.get_metric().first().unwrap();
+        assert_eq!(metric.get_label().len(), 1);
+        let proto_histogram = metric.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 1);
+        assert!(proto_histogram.get_sample_sum() >= 0.1);
+    }
+
+    #[test]
+    fn test_stop_and_record_in_thread() {
+        let opts = HistogramOpts::new("test_stop_and_record_in_thread", "testing")
+            .const_label("defense", "1");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        let timer = DiscardOnDropHistogramTimer::new(histogram.clone());
+        let handler = thread::spawn(move || {
+            let timer = timer;
+            thread::sleep(Duration::from_millis(100));
+            let time = timer.stop_and_record();
+            assert!(time >= 0.1);
+        });
+        assert!(handler.join().is_ok());
+
+        let mut metric_families = histogram.collect();
+        assert_eq!(metric_families.len(), 1);
+
+        let metric_family = metric_families.pop().unwrap();
+        let metric = metric_family.get_metric().first().unwrap();
+        assert_eq!(metric.get_label().len(), 1);
+        let proto_histogram = metric.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 1);
+        assert!(proto_histogram.get_sample_sum() >= 0.1);
+    }
+
+    #[test]
+    fn test_stop_and_record() {
+        let opts =
+            HistogramOpts::new("test_stop_and_record", "testing").const_label("defense", "1");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        let timer = DiscardOnDropHistogramTimer::new(histogram.clone());
+        thread::sleep(Duration::from_millis(100));
+        let time = timer.stop_and_record();
+        assert!(time >= 0.1);
+
+        let mut metric_families = histogram.collect();
+        assert_eq!(metric_families.len(), 1);
+
+        let metric_family = metric_families.pop().unwrap();
+        let metric = metric_family.get_metric().first().unwrap();
+        assert_eq!(metric.get_label().len(), 1);
+        let proto_histogram = metric.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 1);
+        assert!(proto_histogram.get_sample_sum() >= 0.1);
+    }
+
+    #[test]
+    fn test_stop_and_discard() {
+        let opts =
+            HistogramOpts::new("test_stop_and_discard", "testing").const_label("defense", "1");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        let timer = DiscardOnDropHistogramTimer::new(histogram.clone());
+        thread::sleep(Duration::from_millis(100));
+        let time = timer.stop_and_discard();
+        assert!(time >= 0.1);
+
+        let mut metric_families = histogram.collect();
+        assert_eq!(metric_families.len(), 1);
+
+        let metric_family = metric_families.pop().unwrap();
+        let metric = metric_family.get_metric().first().unwrap();
+        assert_eq!(metric.get_label().len(), 1);
+        let proto_histogram = metric.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 0);
+        assert!(proto_histogram.get_sample_sum() >= 0.0);
+    }
+
+    #[test]
+    fn test_discard_through_explicit_drop() {
+        let opts = HistogramOpts::new("test_discard_through_explicit_drop", "testing")
+            .const_label("defense", "1");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        let timer = DiscardOnDropHistogramTimer::new(histogram.clone());
+        thread::sleep(Duration::from_millis(100));
+        drop(timer);
+
+        let mut metric_families = histogram.collect();
+        assert_eq!(metric_families.len(), 1);
+
+        let metric_family = metric_families.pop().unwrap();
+        let metric = metric_family.get_metric().first().unwrap();
+        assert_eq!(metric.get_label().len(), 1);
+        let proto_histogram = metric.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 0);
+        assert!(proto_histogram.get_sample_sum() >= 0.0);
+    }
+
+    #[test]
+    fn test_discard_through_implicit_drop() {
+        let opts = HistogramOpts::new("test_discard_through_implicit_drop", "testing")
+            .const_label("defense", "1");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        {
+            let _timer = DiscardOnDropHistogramTimer::new(histogram.clone());
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        let mut metric_families = histogram.collect();
+        assert_eq!(metric_families.len(), 1);
+
+        let metric_family = metric_families.pop().unwrap();
+        let metric = metric_family.get_metric().first().unwrap();
+        assert_eq!(metric.get_label().len(), 1);
+        let proto_histogram = metric.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 0);
+        assert!(proto_histogram.get_sample_sum() >= 0.0);
+    }
+
+    #[test]
+    fn test_discard_through_implicit_drop_in_thread() {
+        let opts = HistogramOpts::new("test_discard_through_implicit_drop_in_thread", "testing")
+            .const_label("defense", "1");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        let timer = DiscardOnDropHistogramTimer::new(histogram.clone());
+        let handler = thread::spawn(move || {
+            let _timer = timer;
+            thread::sleep(Duration::from_millis(100));
+        });
+        assert!(handler.join().is_ok());
+
+        let mut metric_families = histogram.collect();
+        assert_eq!(metric_families.len(), 1);
+
+        let metric_family = metric_families.pop().unwrap();
+        let metric = metric_family.get_metric().first().unwrap();
+        assert_eq!(metric.get_label().len(), 1);
+        let proto_histogram = metric.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 0);
+        assert!(proto_histogram.get_sample_sum() >= 0.0);
+    }
+}


### PR DESCRIPTION
### What was wrong?

In certain situations we don't want to record the metrics timer, if the timer is dropped
### How was it fixed?

add DiscardOnDropHistogramTimer
