### PR TITLE
feat: added CLI documentation update check

### DIFF
--- a/.github/workflows/book-cli-check.yml
+++ b/.github/workflows/book-cli-check.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Build debug binary
-        run: cargo build --bin ream
-
       - name: Run update-book-cli
         run: make update-book-cli
 


### PR DESCRIPTION
Adds a GitHub Actions workflow to ensure `make update-book-cli` has been run before merging PRs. 

This prevents outdated CLI documentation in the book.


Solves issue #958 