### PR TITLE
feat: add break in get_attestation_target walk back

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -394,6 +394,8 @@ impl Store {
                     .message
                     .block
                     .parent_root;
+            } else {
+                break;
             }
         }
 


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
Fixes #967 

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Add a break in the walk back 
Ref: https://github.com/leanEthereum/leanSpec/pull/191

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
