### PR TITLE
feat: rename get_fork_choice_head to compute_lmd_ghost_head

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -97,7 +97,7 @@ impl Store {
 
     /// Use LMD GHOST to get the head, given a particular root (usually the
     /// latest known justified block)
-    pub async fn get_fork_choice_head(
+    async fn compute_lmd_ghost_head(
         &self,
         latest_votes: impl Iterator<Item = anyhow::Result<SignedAttestation>>,
         provided_root: B256,
@@ -214,7 +214,7 @@ impl Store {
         let latest_justified_root = latest_justified_provider.get()?.root;
 
         safe_target_provider.insert(
-            self.get_fork_choice_head(
+            self.compute_lmd_ghost_head(
                 latest_new_attestations_provider.iter_values()?,
                 latest_justified_root,
                 min_target_score,
@@ -319,7 +319,7 @@ impl Store {
         };
 
         let new_head = self
-            .get_fork_choice_head(
+            .compute_lmd_ghost_head(
                 latest_known_attestations.into_values().map(Ok),
                 latest_justified.root,
                 0,


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
Ref: https://github.com/leanEthereum/leanSpec/pull/190

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->
We already had this function in store so renaming to the new name

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
