### PR TITLE
feat(ci): add multi-architecture Docker builds for amd64 and arm64

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
-          context: .  
+          context: .
           file: ./Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
### What was wrong?
fixes https://github.com/ReamLabs/ream/issues/973
The existing Docker CI workflow only generated images for a single architecture.

### How was it fixed?
Added multi-architecture Docker build support for `amd64` and `arm64`.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [X] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [X] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
