### PR TITLE
fix: invalid genesis root + add genesis tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5433,6 +5433,7 @@ dependencies = [
  "ream-fork-choice-lean",
  "ream-metrics",
  "ream-network-spec",
+ "ream-post-quantum-crypto",
  "ream-storage",
  "ream-sync",
  "serde",

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -190,7 +190,8 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
             index: index as u64,
         })
         .collect::<Vec<_>>();
-    let (genesis_block, genesis_state) = lean_genesis::setup_genesis(validators);
+    let (genesis_block, genesis_state) =
+        lean_genesis::setup_genesis(lean_network_spec().genesis_time, validators);
     let (lean_chain_writer, lean_chain_reader) = Writer::new(
         Store::get_forkchoice_store(
             SignedBlockWithAttestation {

--- a/crates/common/chain/lean/Cargo.toml
+++ b/crates/common/chain/lean/Cargo.toml
@@ -25,6 +25,7 @@ ream-consensus-misc.workspace = true
 ream-fork-choice-lean.workspace = true
 ream-metrics.workspace = true
 ream-network-spec.workspace = true
+ream-post-quantum-crypto.workspace = true
 ream-storage.workspace = true
 ream-sync.workspace = true
 

--- a/crates/common/chain/lean/src/genesis.rs
+++ b/crates/common/chain/lean/src/genesis.rs
@@ -4,7 +4,6 @@ use ream_consensus_lean::{
     state::LeanState,
     validator::Validator,
 };
-use ream_network_spec::networks::lean_network_spec;
 use tree_hash::TreeHash;
 
 fn genesis_block(state_root: B256) -> Block {
@@ -23,10 +22,59 @@ fn genesis_block(state_root: B256) -> Block {
 ///
 /// See lean specification:
 /// <https://github.com/leanEthereum/leanSpec/blob/f869a7934fc4bccf0ba22159c64ecd398c543107/src/lean_spec/subspecs/containers/state/state.py#L65-L108>
-pub fn setup_genesis(validators: Vec<Validator>) -> (Block, LeanState) {
-    let genesis_state =
-        LeanState::generate_genesis(lean_network_spec().genesis_time, Some(validators));
+pub fn setup_genesis(genesis_time: u64, validators: Vec<Validator>) -> (Block, LeanState) {
+    let genesis_state = LeanState::generate_genesis(genesis_time, Some(validators));
     let genesis_block = genesis_block(genesis_state.tree_hash_root());
 
     (genesis_block, genesis_state)
+}
+
+#[cfg(test)]
+mod test {
+    use alloy_primitives::{FixedBytes, hex::ToHexExt};
+    use ream_consensus_lean::validator::Validator;
+    use ream_post_quantum_crypto::hashsig::public_key::PublicKey;
+    use tree_hash::TreeHash;
+
+    use crate::genesis::setup_genesis;
+
+    #[test]
+    fn test_genesis_block_hash_comparison() {
+        let public_keys_1 = (0..3)
+            .map(|index| Validator {
+                public_key: PublicKey::new(FixedBytes::from_slice(&[index + 1; 52])),
+                index: 0,
+            })
+            .collect::<Vec<_>>();
+
+        let (block_1, _) = setup_genesis(1000, public_keys_1.clone());
+        let (block_1_copy, _) = setup_genesis(1000, public_keys_1.clone());
+        assert_eq!(block_1.tree_hash_root(), block_1_copy.tree_hash_root());
+
+        let public_keys_2 = (0..3)
+            .map(|index| Validator {
+                public_key: PublicKey::new(FixedBytes::from_slice(&[index + 10; 52])),
+                index: 0,
+            })
+            .collect::<Vec<_>>();
+
+        let (block_2, _) = setup_genesis(1000, public_keys_2.clone());
+        assert_ne!(block_1.tree_hash_root(), block_2.tree_hash_root());
+
+        let (block_3, _) = setup_genesis(2000, public_keys_1.clone());
+        assert_ne!(block_1.tree_hash_root(), block_3.tree_hash_root());
+
+        assert_eq!(
+            block_1.tree_hash_root().encode_hex(),
+            "4c0bcc4750b71818224a826cd59f8bcb75ae2920eb3e75b4097b818be6d1049a"
+        );
+        assert_eq!(
+            block_2.tree_hash_root().encode_hex(),
+            "639b6162e6b432653a77a64b678717e7634428eda88ad6ccb1862e6397c0c47b"
+        );
+        assert_eq!(
+            block_3.tree_hash_root().encode_hex(),
+            "6593976e31c915b5d534e2ee6172652aed7690be24777947de39c726aa2af59e"
+        );
+    }
 }

--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
     BitList, VariableList,
-    typenum::{U262144, U1073741824},
+    typenum::{U4096, U262144, U1073741824},
 };
 use tracing::info;
 use tree_hash::TreeHash;
@@ -44,7 +44,7 @@ pub struct LeanState {
     pub historical_block_hashes: VariableList<B256, U262144>,
     pub justified_slots: BitList<U262144>,
 
-    pub validators: VariableList<Validator, U262144>,
+    pub validators: VariableList<Validator, U4096>,
 
     pub justifications_roots: VariableList<B256, U262144>,
     pub justifications_validators: BitList<U1073741824>,


### PR DESCRIPTION
### What was wrong?

fixes https://github.com/ReamLabs/ream/issues/976

### How was it fixed?

Ok I refound out why we were generating the wrong state root. It was because we were using the wrong limit for the VariableList of valiators in the state. Originally @shariqnaiyer found this bug, but we didn't merge it because it was in a bigger PR integrating fork_choice tests the data was generated without signatures https://github.com/ReamLabs/ream/pull/919/files