### PR TITLE
chore: extra head state logging

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -67,8 +67,12 @@ impl LeanChainService {
 
                             info!(
                                 slot = get_current_slot(),
+                                head_root = head.to_string(),
+                                head_parent_root = head_state.latest_block_header.parent_root.to_string(),
                                 justified_slot = head_state.latest_justified.slot,
+                                justified_root = head_state.latest_justified.root.to_string(),
                                 finalized_slot = head_state.latest_finalized.slot,
+                                finalized_root = head_state.latest_finalized.root.to_string(),
                                 "Current head state information",
                             );
                         }


### PR DESCRIPTION
### What was wrong?

Add extra logging for head root, head parent root, justified root and finalized root. It helped me with debugging client interop like this:

![telegram-cloud-photo-size-5-6143040356119940102-y](https://github.com/user-attachments/assets/fe75f925-2959-4cea-82d4-614eeab4832d)


### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
