### PR TITLE
feat: implements eth/v1/node/peers api endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5353,6 +5353,7 @@ dependencies = [
  "ream-bls",
  "ream-consensus-beacon",
  "ream-consensus-misc",
+ "ream-peer",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/common/api_types/beacon/Cargo.toml
+++ b/crates/common/api_types/beacon/Cargo.toml
@@ -25,6 +25,7 @@ url.workspace = true
 ream-bls.workspace = true
 ream-consensus-beacon.workspace = true
 ream-consensus-misc.workspace = true
+ream-peer.workspace = true
 
 [lints]
 workspace = true

--- a/crates/common/api_types/beacon/src/query.rs
+++ b/crates/common/api_types/beacon/src/query.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::B256;
+use ream_peer::{ConnectionState, Direction};
 use serde::{Deserialize, Serialize};
 
 use super::id::ValidatorID;
@@ -48,6 +49,16 @@ pub struct StatusQuery {
 pub struct AttestationQuery {
     pub slot: u64,
     pub committee_index: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConnectionStateQuery {
+    pub state: Option<Vec<ConnectionState>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DirectionQuery {
+    pub direction: Option<Vec<Direction>>,
 }
 
 impl StatusQuery {

--- a/crates/common/api_types/beacon/src/responses.rs
+++ b/crates/common/api_types/beacon/src/responses.rs
@@ -32,6 +32,26 @@ impl<T: Serialize> DataResponse<T> {
     }
 }
 
+/// A DataResponseWithMeta data struct that can be used to wrap data type
+/// used for json rpc responses
+///
+/// # Example
+/// {
+///  "data": json!(T),
+///  "meta": json!(U)
+/// }
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DataResponseWithMeta<T, U> {
+    pub data: T,
+    pub meta: U,
+}
+
+impl<T: Serialize, U: Serialize> DataResponseWithMeta<T, U> {
+    pub fn new(data: T, meta: U) -> Self {
+        Self { data, meta }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct RootResponse {
     pub root: B256,

--- a/crates/networking/peer/src/lib.rs
+++ b/crates/networking/peer/src/lib.rs
@@ -28,3 +28,9 @@ pub struct PeerCount {
     #[serde(with = "serde_utils::quoted_u64")]
     pub disconnecting: u64,
 }
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct PeersMetadata {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub count: u64,
+}

--- a/crates/rpc/beacon/src/routes/node.rs
+++ b/crates/rpc/beacon/src/routes/node.rs
@@ -3,7 +3,7 @@ use ream_rpc_common::handlers::version::get_version;
 
 use crate::handlers::{
     identity::get_identity,
-    peers::{get_peer, get_peer_count},
+    peers::{get_peer, get_peer_count, get_peers},
     syncing::get_syncing_status,
 };
 
@@ -11,6 +11,7 @@ pub fn register_node_routes(cfg: &mut ServiceConfig) {
     cfg.service(get_version)
         .service(get_peer)
         .service(get_peer_count)
+        .service(get_peers)
         .service(get_syncing_status)
         .service(get_identity);
 }


### PR DESCRIPTION
### What was wrong?

We implement the /node/peers api endpoint that was missing from the beacon rpc. Fixes #178

### How was it fixed?

Added a handler for this endpoint in `beacon/src/handlers/peers.rs`

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
