### PR TITLE
chore: make head state logging easier to read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5438,6 +5438,7 @@ dependencies = [
  "ream-fork-choice-lean",
  "ream-metrics",
  "ream-network-spec",
+ "ream-network-state-lean",
  "ream-post-quantum-crypto",
  "ream-storage",
  "ream-sync",

--- a/crates/common/chain/lean/Cargo.toml
+++ b/crates/common/chain/lean/Cargo.toml
@@ -25,6 +25,7 @@ ream-consensus-misc.workspace = true
 ream-fork-choice-lean.workspace = true
 ream-metrics.workspace = true
 ream-network-spec.workspace = true
+ream-network-state-lean.workspace = true
 ream-post-quantum-crypto.workspace = true
 ream-storage.workspace = true
 ream-sync.workspace = true

--- a/crates/networking/network_state/lean/src/lib.rs
+++ b/crates/networking/network_state/lean/src/lib.rs
@@ -33,4 +33,12 @@ impl NetworkState {
                 cached_peer.state = state;
             });
     }
+
+    pub fn connected_peers(&self) -> usize {
+        self.peer_table
+            .lock()
+            .values()
+            .filter(|peer| matches!(peer.state, ConnectionState::Connected))
+            .count()
+    }
 }


### PR DESCRIPTION
### What was wrong?

Once O added more information, I found it hard to parse the information, so I updated our logg to look like zeams

<img width="1086" height="260" alt="image" src="https://github.com/user-attachments/assets/3f690eb8-81cd-414e-9d01-1f811f3d6bac" />

### How was it fixed?

doing it
