### PR TITLE
refactor: rename to produce_attestation_data

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -242,7 +242,12 @@ impl LeanChainService {
         slot: u64,
         response: oneshot::Sender<AttestationData>,
     ) -> anyhow::Result<()> {
-        let attestation_data = self.store.read().await.produce_attestation(slot).await?;
+        let attestation_data = self
+            .store
+            .read()
+            .await
+            .produce_attestation_data(slot)
+            .await?;
 
         // Send the built attestation data back to the requester
         response

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -701,7 +701,7 @@ impl Store {
         Ok(())
     }
 
-    pub async fn produce_attestation(&self, slot: u64) -> anyhow::Result<AttestationData> {
+    pub async fn produce_attestation_data(&self, slot: u64) -> anyhow::Result<AttestationData> {
         let (head_provider, block_provider, latest_justified_provider) = {
             let db = self.store.lock().await;
             (


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
`produce_attestation` name is misleading as it does not actually create an attestation rather `AttestationData`.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->
Renames `produce_attestation` to `produce_attestation_data`
also in line with https://github.com/leanEthereum/leanSpec/blob/050fa4a18881d54d7dc07601fe59e34eb20b9630/src/lean_spec/subspecs/forkchoice/store.py#L878


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
