### PR TITLE
chore: Add generated files to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+Cargo.lock linguist-generated=true
+book/cli/**/*.md linguist-generated=true
+book/cli/cli.md -linguist-generated


### PR DESCRIPTION
### What was wrong?

Machine generate files were included in repo stats

### How was it fixed?

Add a .gitattributes file