### PR TITLE
chore: update docker ci to make it faster

### DIFF
--- a/.github/workflows/book-cli-check.yml
+++ b/.github/workflows/book-cli-check.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [master]
   merge_group:
+  workflow_dispatch:
 
 jobs:
   check-cli-docs:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -11,22 +11,23 @@ jobs:
   push:
     runs-on: ubuntu-latest
     if: github.repository == 'reamlabs/ream'
-
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v6
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
         with:
-          platforms: arm64, amd64
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/reamlabs/ream:latest
+          cache-on-failure: true
+      - name: Install cross main
+        id: cross_main
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+      - name: Log in to Docker
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+      - name: Set up Docker builder
+        run: |
+          docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
+          docker buildx create --use --name cross-builder
+      - name: Build and push ream image
+        run: make docker-build-push 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ testing/ef-tests/mainnet/*
 
 # keystore
 .keystore
+
+# include dist directory, where the reth binary is located after compilation
+!/dist

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -12,5 +12,5 @@ ARG TARGETARCH
 
 COPY ./dist/bin/$TARGETARCH/ream /usr/local/bin/ream
 
-EXPOSE 8545 8546
+EXPOSE 9000/udp 5052 8080
 ENTRYPOINT ["/usr/local/bin/ream"]


### PR DESCRIPTION
### What was wrong?

Our docker build ci takes 2 hours since adding the qemu arm64 build


### How was it fixed?

Heavily inspired by reth use cross

Basically does what they do, this will cache our builds and hence make it faster