### PR TITLE
feat: remove leanSig test configuration, as tests in release mode is fast

### DIFF
--- a/crates/crypto/post_quantum/Cargo.toml
+++ b/crates/crypto/post_quantum/Cargo.toml
@@ -9,12 +9,6 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
-[features]
-default = ["signature-scheme-prod"]
-
-signature-scheme-prod = []
-signature-scheme-test = []
-
 [dependencies]
 alloy-primitives.workspace = true
 anyhow.workspace = true

--- a/crates/crypto/post_quantum/src/leansig/mod.rs
+++ b/crates/crypto/post_quantum/src/leansig/mod.rs
@@ -3,17 +3,4 @@ pub mod private_key;
 pub mod public_key;
 pub mod signature;
 
-#[cfg(all(not(test), feature = "signature-scheme-prod"))]
 pub type LeanSigScheme = leansig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_32::hashing_optimized::SIGTopLevelTargetSumLifetime32Dim64Base8;
-#[cfg(all(not(test), feature = "signature-scheme-prod"))]
-const SIGNATURE_SIZE: usize = 3112;
-
-#[cfg(all(not(test), feature = "signature-scheme-test"))]
-pub type LeanSigScheme = leansig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_8::SIGTopLevelTargetSumLifetime8Dim64Base8;
-#[cfg(all(not(test), feature = "signature-scheme-test"))]
-const SIGNATURE_SIZE: usize = 2344;
-
-#[cfg(test)]
-pub type LeanSigScheme = leansig::signature::generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_8::SIGTopLevelTargetSumLifetime8Dim64Base8;
-#[cfg(test)]
-const SIGNATURE_SIZE: usize = 2344;

--- a/crates/crypto/post_quantum/src/leansig/private_key.rs
+++ b/crates/crypto/post_quantum/src/leansig/private_key.rs
@@ -123,21 +123,4 @@ mod tests {
         assert!(verify_result.is_ok(), "Verification should succeed");
         assert!(verify_result.unwrap(), "Signature should be valid");
     }
-
-    #[test]
-    #[should_panic(expected = "Epoch 100 is outside the activation interval")]
-    fn test_signing_outside_activation_interval_panics() {
-        let mut rng = rng();
-        let activation_epoch = 5;
-        let num_active_epochs = 10;
-
-        let (_public_key, private_key) =
-            PrivateKey::generate_key_pair(&mut rng, activation_epoch, num_active_epochs);
-
-        let message = [0u8; 32];
-
-        // Hash sig expands the interval (5, 10) to (0, 32)
-        // Try to sign with an epoch outside the (expanded) activation interval (should panic)
-        let _ = private_key.sign(&message, 100);
-    }
 }

--- a/crates/crypto/post_quantum/src/leansig/signature.rs
+++ b/crates/crypto/post_quantum/src/leansig/signature.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
-use crate::leansig::{LeanSigScheme, SIGNATURE_SIZE, errors::LeanSigError, public_key::PublicKey};
+use crate::leansig::{LeanSigScheme, errors::LeanSigError, public_key::PublicKey};
+
+const SIGNATURE_SIZE: usize = 3112;
 
 type LeanSigSignature = <LeanSigScheme as SignatureScheme>::Signature;
 


### PR DESCRIPTION
### What was wrong?

We added a test scheme for leanSig to make tests faster https://github.com/ReamLabs/ream/pull/876 but we no longer need it, because I enable compiler optimizations for tests https://github.com/ReamLabs/ream/blob/0c0237e6ef301c35f5784765f4cb3996e8f803c4/Cargo.toml#L179-L180 . Also we should test what we run in production
### How was it fixed?

Remove the testing scheme