### PR TITLE
chore: add head commit sha as docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ docker-build-push:
 
 	docker buildx build --file ./Dockerfile.cross . \
 		--platform linux/amd64,linux/arm64 \
+		--tag ghcr.io/reamlabs/ream:$(shell git rev-parse --short HEAD) \
 		--tag ghcr.io/reamlabs/ream:latest \
 		--provenance=false \
 		--push


### PR DESCRIPTION
### What was wrong?

Right now it's a little difficult to find ream's docker image at a specific commit because only `latest` tag is available (see https://github.com/reamlabs/ream/pkgs/container/ream). This PR adds another docker tag with the commit's short SHA.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
