### PR TITLE
feat: Update metrics to lean_validators_count metric to represent locally running validators, not the network count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6083,6 +6083,7 @@ dependencies = [
  "ream-consensus-lean",
  "ream-consensus-misc",
  "ream-keystore",
+ "ream-metrics",
  "ream-network-spec",
  "ream-post-quantum-crypto",
  "ream-sync",

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -13,8 +13,8 @@ use ream_consensus_misc::constants::lean::INTERVALS_PER_SLOT;
 use ream_metrics::{
     ATTESTATION_VALIDATION_TIME, ATTESTATIONS_INVALID_TOTAL, ATTESTATIONS_VALID_TOTAL,
     FINALIZED_SLOT, FORK_CHOICE_BLOCK_PROCESSING_TIME, HEAD_SLOT, JUSTIFIED_SLOT,
-    LATEST_FINALIZED_SLOT, LATEST_JUSTIFIED_SLOT, PROPOSE_BLOCK_TIME, VALIDATORS_COUNT,
-    inc_int_counter_vec, set_int_gauge_vec, start_timer, stop_timer,
+    LATEST_FINALIZED_SLOT, LATEST_JUSTIFIED_SLOT, PROPOSE_BLOCK_TIME, inc_int_counter_vec,
+    set_int_gauge_vec, start_timer, stop_timer,
 };
 use ream_network_spec::networks::lean_network_spec;
 use ream_network_state_lean::NetworkState;
@@ -83,12 +83,6 @@ impl Store {
         db.safe_target_provider()
             .insert(anchor_root)
             .expect("Failed to insert genesis block hash");
-
-        set_int_gauge_vec(
-            &VALIDATORS_COUNT,
-            lean_network_spec().num_validators as i64,
-            &[],
-        );
 
         Ok(Store {
             store: Arc::new(Mutex::new(db)),

--- a/crates/common/validator/lean/Cargo.toml
+++ b/crates/common/validator/lean/Cargo.toml
@@ -26,6 +26,7 @@ ream-chain-lean.workspace = true
 ream-consensus-lean.workspace = true
 ream-consensus-misc.workspace = true
 ream-keystore.workspace = true
+ream-metrics.workspace = true
 ream-network-spec.workspace = true
 ream-post-quantum-crypto.workspace = true
 ream-sync.workspace = true

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -5,6 +5,7 @@ use ream_consensus_lean::{
     block::{BlockWithAttestation, BlockWithSignatures, SignedBlockWithAttestation},
 };
 use ream_keystore::lean_keystore::ValidatorKeystore;
+use ream_metrics::{VALIDATORS_COUNT, set_int_gauge_vec};
 use ream_network_spec::networks::lean_network_spec;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{Level, debug, enabled, info};
@@ -40,6 +41,7 @@ impl ValidatorService {
             "ValidatorService started with {} validator(s)",
             self.keystores.len()
         );
+        set_int_gauge_vec(&VALIDATORS_COUNT, self.keystores.len() as i64, &[]);
 
         let mut tick_count = 0u64;
 


### PR DESCRIPTION
### What was wrong?

Fixes: https://github.com/ReamLabs/ream/issues/1020

### How was it fixed?

Updates metrics to lean_validators_count metric to represent locally running validators, not the network count