### PR TITLE
feat: remove repetitive db calls

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -404,6 +404,10 @@ impl Store {
             .ok_or(anyhow!("State not found for head root"))?;
         stop_timer(initialize_block_timer);
 
+        // cache latest known attestations
+        let latest_known_attestations_map =
+            latest_known_attestation_provider.get_all_attestations()?;
+
         let num_validators = head_state.validators.len();
 
         ensure!(
@@ -433,10 +437,7 @@ impl Store {
 
             let mut new_attestations: VariableList<Attestation, U4096> = VariableList::empty();
             let mut new_signatures: Vec<Signature> = Vec::new();
-            for signed_attestation in latest_known_attestation_provider
-                .get_all_attestations()?
-                .values()
-            {
+            for signed_attestation in latest_known_attestations_map.values() {
                 let data = &signed_attestation.message.data;
                 if !block_provider.contains_key(data.head.root) {
                     continue;


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
While looking into the `produce_block_with_signatures` function,I found that we are repeatedly making db calls inside the loop in a few places:
https://github.com/ReamLabs/ream/blob/fdc75939357ffbf2d50d5afbbfeacd27de463aa6/crates/common/fork_choice/lean/src/store.rs#L442
and 
https://github.com/ReamLabs/ream/blob/fdc75939357ffbf2d50d5afbbfeacd27de463aa6/crates/common/fork_choice/lean/src/store.rs#L446

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->
Cache known_attesations and ~block hashes~ before the loop starts and use those for processing

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
