### PR TITLE
fix: fix Patch ethereum_hashing not used in the crate graph and updates reams rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand_core 0.4.2",
  "serde",
  "unicode-normalization",
 ]
@@ -1931,7 +1931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.111",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9153,8 +9153,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/ReamLabs/ethereum_hashing.git#c14a9ad96436e6b8b631faf49a3666e4558b71ae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ keywords = [
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ReamLabs/ream"
-rust-version = "1.88.0"
+rust-version = "1.90.0"
 version = "0.1.0"
 
 [workspace.lints.clippy]
@@ -91,7 +91,7 @@ delay_map = "0.4.1"
 directories = { version = "6.0.0" }
 discv5 = { version = "0.10.2", features = ["libp2p"] }
 enr = "0.13.0"
-ethereum_hashing = { git = "https://github.com/ReamLabs/ethereum_hashing.git", rev = "c14a9ad96436e6b8b631faf49a3666e4558b71ae" }
+ethereum_hashing = "0.7.0"
 ethereum_serde_utils = "0.8"
 ethereum_ssz = "0.10"
 ethereum_ssz_derive = "0.10"
@@ -175,7 +175,7 @@ ream-validator-beacon = { path = "crates/common/validator/beacon" }
 ream-validator-lean = { path = "crates/common/validator/lean" }
 
 [patch.crates-io]
-ethereum_hashing = { git = "https://github.com/ReamLabs/ethereum_hashing.git" }
+ethereum_hashing = { git = "https://github.com/ReamLabs/ethereum_hashing.git", rev = "c14a9ad96436e6b8b631faf49a3666e4558b71ae" }
 
 [profile.test]
 inherits = "release"


### PR DESCRIPTION
### What was wrong?

Fixes: https://github.com/ReamLabs/ream/issues/1033

### How was it fixed?

I added ethereum_hashing as a dependency and updated reams rust version
