### PR TITLE
feat: if service panics stop the node + clean up interval panic log

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -54,7 +54,7 @@ impl LeanChainService {
         let mut tick_count = 0u64;
 
         let mut interval = create_lean_clock_interval()
-            .map_err(|err| anyhow!("Failed to create clock interval: {err:?}"))?;
+            .map_err(|err| anyhow!("Expected Ream to be started before genesis time: {err:?}"))?;
 
         loop {
             tokio::select! {

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -49,7 +49,7 @@ impl ValidatorService {
         let mut tick_count = 0u64;
 
         let mut interval = create_lean_clock_interval()
-            .map_err(|err| anyhow!("Failed to create clock interval: {err:?}"))?;
+            .map_err(|err| anyhow!("Expected Ream to be started before genesis time: {err:?}"))?;
 
         loop {
             tokio::select! {


### PR DESCRIPTION
### What was wrong?

- when one of ream's services paniced, the node would keep on running like nothing has ever happened
- our  logs weren't intuitive

### How was it fixed?

- remove a few panics, and handle if a service quits
- update log message
