### PR TITLE
feat: created endpoint for sync committee duties

### DIFF
--- a/crates/common/api_types/beacon/src/responses.rs
+++ b/crates/common/api_types/beacon/src/responses.rs
@@ -156,13 +156,13 @@ impl<T: Serialize> DataVersionedResponse<T> {
 /// }
 #[derive(Debug, Deserialize, Serialize, Encode, Decode)]
 pub struct DutiesResponse<T: Encode + Decode> {
-    pub dependent_root: B256,
+    pub dependent_root: Option<B256>,
     pub execution_optimistic: bool,
     pub data: Vec<T>,
 }
 
 impl<T: Serialize + Encode + Decode> DutiesResponse<T> {
-    pub fn new(dependent_root: B256, data: Vec<T>) -> Self {
+    pub fn new(dependent_root: Option<B256>, data: Vec<T>) -> Self {
         Self {
             dependent_root,
             execution_optimistic: EXECUTION_OPTIMISTIC,

--- a/crates/rpc/beacon/src/routes/validator.rs
+++ b/crates/rpc/beacon/src/routes/validator.rs
@@ -1,7 +1,7 @@
 use actix_web::web::ServiceConfig;
 
 use crate::handlers::{
-    duties::{get_attester_duties, get_proposer_duties},
+    duties::{get_attester_duties, get_proposer_duties, get_sync_committee_duties},
     prepare_beacon_proposer::prepare_beacon_proposer,
     validator::{
         get_attestation_data, post_aggregate_and_proofs_v2, post_beacon_committee_selections,
@@ -12,6 +12,7 @@ use crate::handlers::{
 pub fn register_validator_routes_v1(config: &mut ServiceConfig) {
     config.service(get_proposer_duties);
     config.service(get_attester_duties);
+    config.service(get_sync_committee_duties);
     config.service(prepare_beacon_proposer);
     config.service(get_attestation_data);
     config.service(post_beacon_committee_selections);


### PR DESCRIPTION
### What was wrong?
closes #244 

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->
- endpoint `/validator/duties/sync/{epoch}` in the rpc crate
- In the response body of this endpoint, the dependent root is not returned. To use the same `DutiesResponse` struct, modified its dependent_root to take from B256 -> Option<B256>

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
