### PR TITLE
feat: endpoint for validator aggregate attestations

### DIFF
--- a/crates/rpc/beacon/src/routes/validator.rs
+++ b/crates/rpc/beacon/src/routes/validator.rs
@@ -4,15 +4,9 @@ use crate::handlers::{
     duties::{get_attester_duties, get_proposer_duties, get_sync_committee_duties},
     prepare_beacon_proposer::prepare_beacon_proposer,
     validator::{
-<<<<<<< HEAD
-        get_attestation_data, get_blocks_v3, post_aggregate_and_proofs_v2,
-        post_beacon_committee_selections, post_beacon_committee_subscriptions,
-        post_contribution_and_proofs, post_register_validator, get_aggregate_attestation
-=======
-        get_aggregate_attestation, get_attestation_data, post_aggregate_and_proofs_v2,
-        post_beacon_committee_selections, post_beacon_committee_subscriptions,
-        post_contribution_and_proofs, post_register_validator,
->>>>>>> b8a4f9e (feat: compute attestation aggregate)
+        get_aggregate_attestation, get_attestation_data, get_blocks_v3,
+        post_aggregate_and_proofs_v2, post_beacon_committee_selections,
+        post_beacon_committee_subscriptions, post_contribution_and_proofs, post_register_validator,
     },
 };
 


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
closes #233 
missing beacon endpoint `eth/v2//validator/aggregate_attestation`

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->
Implementing the v2 endpoint, fetching the attestation vec from the operation pool hashmap with attestation key

### To-Do
 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
