### PR TITLE
docs: clarify parent block validation for data column sidecar

### DIFF
--- a/crates/networking/manager/src/gossipsub/validate/data_column_sidecar.rs
+++ b/crates/networking/manager/src/gossipsub/validate/data_column_sidecar.rs
@@ -58,9 +58,9 @@ pub async fn validate_data_column_sidecar_full(
         ));
     }
 
-    // TODO [REJECT] The sidecar's block's parent (defined by block_header.parent_root) passes
-    // validation.
-
+    // The sidecar's block's parent (defined by block_header.parent_root) passes validation.
+    // Blocks are only added to block_provider after passing full validation (ST func)
+    // so existence in the store implies validation passed. If parent is not in store, we IGNORE.
     let Some(parent_block) = store.db.block_provider().get(header.parent_root)? else {
         return Ok(ValidationResult::Ignore(
             "Parent block not seen".to_string(),


### PR DESCRIPTION
### What was wrong?

"TODO comment" for parent block validation in data column sidecar gossip validation. Closes #1061

### How was it fixed?

Documented that checking parent block existence in `block_provider` is sufficient since blocks are only stored after passing validation.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
