### PR TITLE
feat: implements /eth/v1/validator/sync_committee_subscriptions

### DIFF
--- a/crates/common/api_types/beacon/src/committee.rs
+++ b/crates/common/api_types/beacon/src/committee.rs
@@ -12,3 +12,13 @@ pub struct BeaconCommitteeSubscription {
     pub slot: u64,
     pub is_aggregator: bool,
 }
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct SyncCommitteeSubscription {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub validator_index: u64,
+    #[serde(with = "serde_utils::quoted_u64_vec")]
+    pub sync_committee_indices: Vec<u64>,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub until_epoch: u64,
+}

--- a/crates/rpc/beacon/src/routes/validator.rs
+++ b/crates/rpc/beacon/src/routes/validator.rs
@@ -7,6 +7,7 @@ use crate::handlers::{
         get_aggregate_attestation, get_attestation_data, get_blocks_v3,
         post_aggregate_and_proofs_v2, post_beacon_committee_selections,
         post_beacon_committee_subscriptions, post_contribution_and_proofs, post_register_validator,
+        post_sync_committee_subscriptions,
     },
 };
 
@@ -18,6 +19,7 @@ pub fn register_validator_routes_v1(config: &mut ServiceConfig) {
     config.service(get_attestation_data);
     config.service(post_beacon_committee_selections);
     config.service(post_beacon_committee_subscriptions);
+    config.service(post_sync_committee_subscriptions);
     config.service(post_contribution_and_proofs);
     config.service(post_register_validator);
 }


### PR DESCRIPTION


### What was wrong?

Closes #236

### How was it fixed?

We implement the sync comittee subscriptions endpoint.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
