### PR TITLE
feat(lean): print database storage stats once a minute

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -122,6 +122,9 @@ impl LeanChainService {
                             let (head, block_provider, slot_index_provider, state_provider) = {
                                 let fork_choice = self.store.read().await;
                                 let store = fork_choice.store.lock().await;
+                                if get_current_slot().is_multiple_of(15) {
+                                    store.report_storage_metrics(0)?;
+                                }
                                 (store.head_provider().get()?, store.block_provider(), store.slot_index_provider(), store.state_provider())
                             };
                             let head_slot = block_provider.get(head)?.ok_or_else(|| anyhow!("Post state not found for head: {head}"))?.message.block.slot;

--- a/crates/storage/src/db/lean.rs
+++ b/crates/storage/src/db/lean.rs
@@ -1,16 +1,21 @@
-use std::sync::Arc;
+use std::{fmt::Write, sync::Arc};
 
-use redb::Database;
+use redb::{Database, ReadableDatabase, ReadableTableMetadata};
+use tracing::info;
 
 use crate::{
     cache::LeanCacheDB,
-    tables::lean::{
-        latest_finalized::LatestFinalizedField, latest_justified::LatestJustifiedField,
-        latest_known_attestation::LatestKnownAttestationTable, lean_block::LeanBlockTable,
-        lean_head::LeanHeadField, lean_latest_new_attestations::LeanLatestNewAttestationsTable,
-        lean_safe_target::LeanSafeTargetField, lean_state::LeanStateTable,
-        lean_time::LeanTimeField, slot_index::LeanSlotIndexTable,
-        state_root_index::LeanStateRootIndexTable,
+    tables::{
+        field::REDBField,
+        lean::{
+            latest_finalized::LatestFinalizedField, latest_justified::LatestJustifiedField,
+            latest_known_attestation::LatestKnownAttestationTable, lean_block::LeanBlockTable,
+            lean_head::LeanHeadField, lean_latest_new_attestations::LeanLatestNewAttestationsTable,
+            lean_safe_target::LeanSafeTargetField, lean_state::LeanStateTable,
+            lean_time::LeanTimeField, slot_index::LeanSlotIndexTable,
+            state_root_index::LeanStateRootIndexTable,
+        },
+        table::REDBTable,
     },
 };
 
@@ -93,5 +98,89 @@ impl LeanDB {
         LeanLatestNewAttestationsTable {
             db: self.db.clone(),
         }
+    }
+
+    /// Checks the storage usage of all tables and reports metrics.
+    ///
+    /// # Arguments
+    ///
+    /// * `threshold_mb` - Only report if total storage exceeds this many megabytes. Pass `0` to
+    ///   force print the report.
+    pub fn report_storage_metrics(&self, threshold_mb: u64) -> anyhow::Result<()> {
+        let threshold_bytes = threshold_mb * 1024 * 1024;
+        let read_txn = self.db.begin_read()?;
+        let mut total_bytes = 0u64;
+        let mut table_metrics = Vec::new();
+
+        macro_rules! collect_stats {
+            ($table_type:ty, $name:expr) => {
+                let table = read_txn.open_table(<$table_type>::TABLE_DEFINITION)?;
+                let stats = table.stats()?;
+                let size = stats.stored_bytes() + stats.metadata_bytes() + stats.fragmented_bytes();
+                total_bytes += size;
+                table_metrics.push(($name, size));
+            };
+        }
+
+        macro_rules! collect_field_stats {
+            ($field_type:ty, $name:expr) => {
+                let table = read_txn.open_table(<$field_type>::FIELD_DEFINITION)?;
+                let stats = table.stats()?;
+                let size = stats.stored_bytes() + stats.metadata_bytes() + stats.fragmented_bytes();
+                total_bytes += size;
+                table_metrics.push(($name, size));
+            };
+        }
+
+        collect_stats!(LeanBlockTable, "LeanBlockTable");
+        collect_stats!(LeanStateTable, "LeanStateTable");
+        collect_stats!(LeanSlotIndexTable, "LeanSlotIndexTable");
+        collect_stats!(LeanStateRootIndexTable, "LeanStateRootIndexTable");
+        collect_stats!(LatestKnownAttestationTable, "LatestKnownAttestationTable");
+        collect_stats!(
+            LeanLatestNewAttestationsTable,
+            "LeanLatestNewAttestationsTable"
+        );
+        collect_field_stats!(LatestFinalizedField, "LatestFinalizedField");
+        collect_field_stats!(LatestJustifiedField, "LatestJustifiedField");
+        collect_field_stats!(LeanTimeField, "LeanTimeField");
+        collect_field_stats!(LeanHeadField, "LeanHeadField");
+        collect_field_stats!(LeanSafeTargetField, "LeanSafeTargetField");
+
+        if total_bytes < threshold_bytes {
+            return Ok(());
+        }
+
+        table_metrics.sort_by(|a, b| b.1.cmp(&a.1));
+        let mut report = String::with_capacity(512);
+        let total_mb = total_bytes as f64 / (1024.0 * 1024.0);
+        if total_mb >= 1024.0 {
+            writeln!(
+                report,
+                "LeanDB Storage Report (Total: {:.2} GB)",
+                total_mb / 1024.0
+            )?;
+        } else {
+            writeln!(report, "LeanDB Storage Report (Total: {total_mb:.2} MB)")?;
+        }
+
+        writeln!(report, "{:<35} | {:<15}", "Table Name", "Size")?;
+        writeln!(report, "{:-<35}-|-{:-<15}", "", "")?;
+
+        for (name, bytes) in table_metrics {
+            if bytes > 0 {
+                let kb = bytes as f64 / 1024.0;
+                let size_str = if kb < 1024.0 {
+                    format!("{kb:.2} KB")
+                } else {
+                    format!("{:.2} MB", kb / 1024.0)
+                };
+                writeln!(report, "{name:<35} | {size_str:<15}")?;
+            }
+        }
+
+        info!("\n{}", report);
+
+        Ok(())
     }
 }

--- a/crates/storage/src/tables/lean/lean_block.rs
+++ b/crates/storage/src/tables/lean/lean_block.rs
@@ -19,7 +19,7 @@ pub struct LeanBlockTable {
 
 /// Table definition for the Lean Block table
 ///
-/// Key: block_id
+/// Key: block_root
 /// Value: [SignedBlockWithAttestation]
 impl REDBTable for LeanBlockTable {
     const TABLE_DEFINITION: TableDefinition<


### PR DESCRIPTION
### What was wrong?

fixes #1117

We had no insights into our database's storage usage
### How was it fixed?

use redb stats, print it every minute 
