### PR TITLE
ci: remove ci failed messages from riscv.yml

### DIFF
--- a/.github/workflows/riscv.yml
+++ b/.github/workflows/riscv.yml
@@ -1,6 +1,7 @@
 name: RISC-V
 
 on:
+  workflow_dispatch:
 # push:
   #   branches: [ "master" ]
   # pull_request:


### PR DESCRIPTION
### What was wrong?

Fixes all these failed workflow runs as workflow is triggered.
<img width="1377" height="955" alt="image" src="https://github.com/user-attachments/assets/cce846fc-7827-4cdc-a01e-c44c00c5a7e0" />

### How was it fixed?

Makes it so it is only triggered manually.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
