### PR TITLE
feat(lean): properly handle p2p requests which fail when syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5954,8 +5954,10 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "futures",
  "libp2p-identity",
  "libp2p-swarm",
+ "rand 0.9.2",
  "ream-consensus-lean",
  "ream-consensus-misc",
  "ream-fork-choice-lean",

--- a/crates/common/chain/lean/Cargo.toml
+++ b/crates/common/chain/lean/Cargo.toml
@@ -25,8 +25,10 @@ devnet2 = [
 [dependencies]
 alloy-primitives.workspace = true
 anyhow.workspace = true
+futures.workspace = true
 libp2p-identity.workspace = true
 libp2p-swarm.workspace = true
+rand.workspace = true
 serde.workspace = true
 ssz_types.workspace = true
 tokio.workspace = true

--- a/crates/common/chain/lean/src/messages.rs
+++ b/crates/common/chain/lean/src/messages.rs
@@ -7,7 +7,7 @@ use ream_consensus_lean::{
     block::{BlockWithSignatures, SignedBlockWithAttestation},
     checkpoint::Checkpoint,
 };
-use ream_req_resp::lean::ReamNetworkEvent;
+use ream_req_resp::lean::NetworkEvent;
 use tokio::sync::oneshot;
 
 /// Represents the status of a peer's chain.
@@ -47,7 +47,7 @@ pub enum LeanChainServiceMessage {
         roots: Vec<B256>,
         sender: oneshot::Sender<Vec<Arc<SignedBlockWithAttestation>>>,
     },
-    NetworkEvent(ReamNetworkEvent),
+    NetworkEvent(NetworkEvent),
 }
 
 #[derive(Debug)]

--- a/crates/common/chain/lean/src/p2p_request.rs
+++ b/crates/common/chain/lean/src/p2p_request.rs
@@ -2,21 +2,28 @@ use alloy_primitives::B256;
 use libp2p_identity::PeerId;
 use libp2p_swarm::ConnectionId;
 use ream_consensus_lean::{attestation::SignedAttestation, block::SignedBlockWithAttestation};
-use ream_req_resp::lean::messages::LeanResponseMessage;
+use ream_req_resp::lean::{ResponseCallback, messages::LeanResponseMessage};
+use tokio::sync::mpsc;
 
 #[derive(Debug, Clone)]
 pub enum LeanP2PRequest {
     GossipBlock(Box<SignedBlockWithAttestation>),
     GossipAttestation(Box<SignedAttestation>),
-    RequestBlocksByRoot {
+    Request {
         peer_id: PeerId,
-        roots: Vec<B256>,
+        callback: mpsc::Sender<ResponseCallback>,
+        message: P2PCallbackRequest,
     },
-    RequestStatus(PeerId),
     Response {
         peer_id: PeerId,
         stream_id: u64,
         connection_id: ConnectionId,
         message: LeanResponseMessage,
     },
+}
+
+#[derive(Debug, Clone)]
+pub enum P2PCallbackRequest {
+    BlocksByRoot { roots: Vec<B256> },
+    Status,
 }

--- a/crates/common/chain/lean/src/sync/job/mod.rs
+++ b/crates/common/chain/lean/src/sync/job/mod.rs
@@ -1,2 +1,3 @@
+pub mod pending;
 pub mod queue;
 pub mod request;

--- a/crates/common/chain/lean/src/sync/job/pending.rs
+++ b/crates/common/chain/lean/src/sync/job/pending.rs
@@ -1,0 +1,28 @@
+use alloy_primitives::B256;
+use libp2p_identity::PeerId;
+
+#[derive(Debug, Clone)]
+pub enum PendingJobRequest {
+    Reset {
+        peer_id: PeerId,
+    },
+    Initial {
+        root: B256,
+        slot: u64,
+        parent_root: B256,
+    },
+}
+
+impl PendingJobRequest {
+    pub fn new_reset(peer_id: PeerId) -> Self {
+        PendingJobRequest::Reset { peer_id }
+    }
+
+    pub fn new_initial(root: B256, slot: u64, parent_root: B256) -> Self {
+        PendingJobRequest::Initial {
+            root,
+            slot,
+            parent_root,
+        }
+    }
+}

--- a/crates/networking/network_state/lean/src/cached_peer.rs
+++ b/crates/networking/network_state/lean/src/cached_peer.rs
@@ -23,6 +23,8 @@ pub struct CachedPeer {
     #[serde(with = "instant_serde")]
     pub last_seen: Instant,
 
+    pub peer_score: u8,
+
     /// Last Status update
 
     #[serde(with = "instant_serde::option")]
@@ -47,6 +49,7 @@ impl CachedPeer {
             last_status_update: None,
             head_checkpoint: None,
             finalized_checkpoint: None,
+            peer_score: u8::MAX / 2,
         }
     }
 

--- a/crates/networking/req_resp/src/configurations.rs
+++ b/crates/networking/req_resp/src/configurations.rs
@@ -8,4 +8,4 @@ pub type AttestationSubnetCount = U64;
 /// The number of sync committee subnets used in the gossipsub aggregation protocol.
 pub type SyncCommitteeSubnetCount = U4;
 
-pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);

--- a/crates/networking/req_resp/src/error.rs
+++ b/crates/networking/req_resp/src/error.rs
@@ -16,8 +16,8 @@ pub enum ReqRespError {
     #[error("Incomplete stream")]
     IncompleteStream,
 
-    #[error("Stream timed out")]
-    StreamTimedOut,
+    #[error("Stream timed out: {0}")]
+    StreamTimedOut(String),
 
     #[error("Tokio timed out {0}")]
     TokioTimedOut(#[from] tokio::time::error::Elapsed),

--- a/crates/networking/req_resp/src/lean/mod.rs
+++ b/crates/networking/req_resp/src/lean/mod.rs
@@ -1,25 +1,48 @@
+pub mod messages;
+pub mod protocol_id;
+
 use std::sync::Arc;
 
 use libp2p::PeerId;
 
 use crate::{
     ConnectionId,
+    handler::ReqRespMessageError,
     lean::messages::{LeanRequestMessage, LeanResponseMessage},
 };
 
-pub mod messages;
-pub mod protocol_id;
-
 #[derive(Debug)]
 pub enum ReamNetworkEvent {
+    Event(NetworkEvent),
+    ResponseCallback(ResponseCallback),
+}
+
+#[derive(Debug)]
+pub enum NetworkEvent {
     RequestMessage {
         peer_id: PeerId,
         stream_id: u64,
         connection_id: ConnectionId,
         message: LeanRequestMessage,
     },
+    NetworkError {
+        peer_id: PeerId,
+        error: ReqRespMessageError,
+    },
+}
+
+#[derive(Debug)]
+pub enum ResponseCallback {
     ResponseMessage {
         peer_id: PeerId,
+        request_id: u64,
         message: Arc<LeanResponseMessage>,
+    },
+    EndOfStream {
+        peer_id: PeerId,
+        request_id: u64,
+    },
+    NotConnected {
+        peer_id: PeerId,
     },
 }


### PR DESCRIPTION
### What was wrong?

Ream wasn't handling if a Peer didn't respond to our request or if an error in the request happened

### How was it fixed?

Forward what we get from the peer instead of just the final product.
