### PR TITLE
fix: sign only attestation data for devnet 2

### DIFF
--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -123,6 +123,9 @@ impl ValidatorService {
                                 let message = AggregatedAttestations { validator_id: keystore.index, data: attestation_data.clone() };
 
                                 let timer = start_timer(&PQ_SIGNATURE_ATTESTATION_SIGNING_TIME, &[]);
+                                #[cfg(feature = "devnet1")]
+                                let proposer_signature = keystore.private_key.sign(&message.tree_hash_root(), slot as u32)?;
+                                #[cfg(feature = "devnet2")]
                                 let proposer_signature = keystore.private_key.sign(&attestation_data.tree_hash_root(), slot as u32)?;
                                 stop_timer(timer);
 


### PR DESCRIPTION
### What was wrong?

Fixes "Proposer Signature Verification Failed" 

### How was it fixed?

We were signing the entire aggregated attestations and verifying with only the attestation.data

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
