### PR TITLE
fix: create tables for AggregatedPayloadsTable and GossipSignaturesTable

### DIFF
--- a/crates/storage/src/db/mod.rs
+++ b/crates/storage/src/db/mod.rs
@@ -9,6 +9,10 @@ use lean::LeanDB;
 use redb::{Builder, Database};
 use tracing::info;
 
+#[cfg(feature = "devnet2")]
+use crate::tables::lean::{
+    aggregated_payloads::AggregatedPayloadsTable, gossip_signatures::GossipSignaturesTable,
+};
 use crate::{
     errors::StoreError,
     tables::{
@@ -111,6 +115,11 @@ impl ReamDB {
         write_txn.open_table(LeanLatestNewAttestationsTable::TABLE_DEFINITION)?;
         write_txn.open_table(LatestKnownAttestationTable::TABLE_DEFINITION)?;
         write_txn.open_table(LeanPendingBlocksTable::TABLE_DEFINITION)?;
+        #[cfg(feature = "devnet2")]
+        {
+            write_txn.open_table(AggregatedPayloadsTable::TABLE_DEFINITION)?;
+            write_txn.open_table(GossipSignaturesTable::TABLE_DEFINITION)?;
+        }
         write_txn.commit()?;
 
         Ok(LeanDB {


### PR DESCRIPTION
### What was wrong?

Fixes
2026-01-20T15:14:51.484056Z  WARN lean_node{node_id=node1}: ream_chain_lean::service: Failed to handle process block message: Redb error: Table 'aggregated_payloads' does not exist

### How was it fixed?

By creating the tables. 

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
