### PR TITLE
feat: version lean spec tests to run for devnet1 and devnet2

### DIFF
--- a/testing/lean-spec-tests/Makefile
+++ b/testing/lean-spec-tests/Makefile
@@ -1,7 +1,7 @@
 EXTRACT_DIR = fixtures
 REPO_URL = https://github.com/ReamLabs/lean-spec-tests.git
 
-.PHONY: all clean test
+.PHONY: all clean test test-devnet1 test-devnet2
 
 all: test
 
@@ -14,10 +14,17 @@ $(EXTRACT_DIR):
 		echo "Fixtures downloaded successfully."; \
 	fi
 
-test: $(EXTRACT_DIR)
-	@echo "Running lean-spec tests..."
-	@cargo test --release --features lean-spec-tests
-	@echo "Tests complete."
+test: test-devnet1 test-devnet2
+
+test-devnet1: $(EXTRACT_DIR)
+	@echo "Running lean-spec tests (devnet1)..."
+	@cargo test --release --features lean-spec-tests,devnet1 --no-default-features
+	@echo "Devnet1 tests complete."
+
+test-devnet2: $(EXTRACT_DIR)
+	@echo "Running lean-spec tests (devnet2)..."
+	@cargo test --release --features lean-spec-tests,devnet2 --no-default-features
+	@echo "Devnet2 tests complete."
 
 clean:
 	@echo "Cleaning up downloaded fixtures..."

--- a/testing/lean-spec-tests/tests/tests.rs
+++ b/testing/lean-spec-tests/tests/tests.rs
@@ -46,7 +46,10 @@ async fn test_all_fork_choice_fixtures() {
         .with_env_filter(env_filter)
         .try_init();
 
-    let fixtures = find_json_files("fixtures/consensus/fork_choice");
+    #[cfg(feature = "devnet1")]
+    let fixtures = find_json_files("fixtures/devnet1/fork_choice");
+    #[cfg(feature = "devnet2")]
+    let fixtures = find_json_files("fixtures/devnet2/fork_choice");
 
     if fixtures.is_empty() {
         info!(
@@ -107,7 +110,10 @@ fn test_all_state_transition_fixtures() {
         .with_env_filter(env_filter)
         .try_init();
 
-    let fixtures = find_json_files("fixtures/consensus/state_transition");
+    #[cfg(feature = "devnet1")]
+    let fixtures = find_json_files("fixtures/devnet1/state_transition");
+    #[cfg(feature = "devnet2")]
+    let fixtures = find_json_files("fixtures/devnet2/state_transition");
 
     if fixtures.is_empty() {
         info!(


### PR DESCRIPTION
### What was wrong?

As we support 2 devnets we want to ensure that the spec tests pass for both of them.

### How was it fixed?

The lean-spec-tests repo was updated with versioned fixtures.
These versioned fixtures were then filled by the Makefile and ran against the client with feature flags.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
