### PR TITLE
chore: update leanmultisig commit to latest pin, for panic fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 [[package]]
 name = "air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "multilinear-toolkit",
  "p3-util 0.3.0",
@@ -3640,7 +3640,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "clap",
  "lean_vm",
@@ -3675,7 +3675,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "air 0.1.0",
  "lean_vm",
@@ -3698,7 +3698,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "air 0.1.0",
  "itertools 0.14.0",
@@ -3724,7 +3724,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "air 0.1.0",
  "colored",
@@ -4293,7 +4293,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "lookup"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "multilinear-toolkit",
  "p3-challenger 0.3.0",
@@ -6779,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "air 0.1.0",
  "bincode",
@@ -7746,7 +7746,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "derive_more",
  "lookup",
@@ -8477,7 +8477,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "multilinear-toolkit",
  "p3-challenger 0.3.0",
@@ -9086,7 +9086,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "witness_generation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=825c1fc22bad0bfbdb3a656d209944f38d8733fa#825c1fc22bad0bfbdb3a656d209944f38d8733fa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9#8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9"
 dependencies = [
  "air 0.1.0",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ itertools = "0.14"
 jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
 lazy_static = "1.5.0"
-lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "825c1fc22bad0bfbdb3a656d209944f38d8733fa" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "8f526d6144b3beb1b1e6b0ec5b6dbdc6d26e81c9" }
 leansig = { git = "https://github.com/leanEthereum/leanSig.git", rev = "ae12a5feb25d917c42b6466444ebd56ec115a629" }
 libp2p = { version = "0.56", default-features = false, features = ["identify", "yamux", "noise", "dns", "serde", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping"] }
 libp2p-identity = "0.2.12"


### PR DESCRIPTION
### What was wrong?

The leanmultisig pin was updated in the pm repo

### How was it fixed?

Update leanmultisig commit to latest pin https://github.com/leanEthereum/pm/pull/64/files
