### PR TITLE
fix: justified_slots needs to be subtracted with delta to match spec

### DIFF
--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -609,7 +609,7 @@ impl LeanState {
                             );
 
                             let mut new_bitlist =
-                                BitList::with_capacity(self.justified_slots.len())
+                                BitList::with_capacity(self.justified_slots.len() - delta)
                                     .map_err(|err| anyhow!("Failed to create BitList: {err:?}"))?;
 
                             for index in delta..self.justified_slots.len() {


### PR DESCRIPTION
### What was wrong?

https://github.com/leanEthereum/leanSpec/blob/914e09333578072c6bf02d2d405f8c13d5b55d38/src/lean_spec/subspecs/containers/state/state.py#L571

https://github.com/leanEthereum/leanSpec/blob/main/src/lean_spec/subspecs/containers/state/types.py#L153-L164

### How was it fixed?

By matching the spec.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
