### PR TITLE
feat: print feature flags used on startup, so users know which devnet is running

### DIFF
--- a/bin/ream/build.rs
+++ b/bin/ream/build.rs
@@ -1,0 +1,14 @@
+use std::{env, error::Error};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut cargo_features: Vec<String> = env::vars()
+        .filter_map(|(key, _)| key.strip_prefix("CARGO_FEATURE_").map(str::to_owned))
+        .map(|feature| feature.to_ascii_lowercase())
+        .collect();
+    cargo_features.sort();
+    let cargo_features = cargo_features.join(",");
+
+    println!("cargo:rustc-env=REAM_CARGO_FEATURES={cargo_features}");
+
+    Ok(())
+}

--- a/bin/ream/src/startup_message.rs
+++ b/bin/ream/src/startup_message.rs
@@ -3,7 +3,14 @@ use ream_node::version::{
     VERGEN_GIT_DESCRIBE,
 };
 
+const REAM_CARGO_FEATURES: &str = env!("REAM_CARGO_FEATURES");
+
 pub fn startup_message() -> String {
+    let cargo_features = if REAM_CARGO_FEATURES.is_empty() {
+        "none"
+    } else {
+        REAM_CARGO_FEATURES
+    };
     format!(
         "
  ███████████   ██████████   █████████   ██████   ██████
@@ -14,11 +21,12 @@ pub fn startup_message() -> String {
  ▒███    ▒███  ▒███ ▒   █ ▒███    ▒███  ▒███      ▒███ 
  █████   █████ ██████████ █████   █████ █████     █████
 ▒▒▒▒▒   ▒▒▒▒▒ ▒▒▒▒▒▒▒▒▒▒ ▒▒▒▒▒   ▒▒▒▒▒ ▒▒▒▒▒     ▒▒▒▒▒ 
-                                                       
-GIT_DESCRIBE     : {VERGEN_GIT_DESCRIBE}
-Full Commit      : {REAM_FULL_COMMIT}
-Build Platform   : {BUILD_OPERATING_SYSTEM}-{BUILD_ARCHITECTURE}
-Compiler Version : rustc{PROGRAMMING_LANGUAGE_VERSION}
+                                                        
+ GIT_DESCRIBE     : {VERGEN_GIT_DESCRIBE}
+ Full Commit      : {REAM_FULL_COMMIT}
+ Build Platform   : {BUILD_OPERATING_SYSTEM}-{BUILD_ARCHITECTURE}
+ Compiler Version : rustc{PROGRAMMING_LANGUAGE_VERSION}
+ Cargo Features   : {cargo_features}
 "
     )
 }


### PR DESCRIPTION
### What was wrong?

There has been a few times when people have ran the wrong verison of ream for a specific devnet which lead to user confusion

### How was it fixed?

Print the feature flags used to build the ream binary being ran