### PR TITLE
refactor: use `all_unique` to be more declaritive

### DIFF
--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-#[cfg(feature = "devnet2")]
-use std::collections::HashSet;
 
 use alloy_primitives::B256;
 use anyhow::{Context, anyhow, ensure};
@@ -142,13 +140,15 @@ impl LeanState {
 
         #[cfg(feature = "devnet2")]
         {
-            let mut attestations_data = HashSet::new();
-            for aggregated_attestation in &block.body.attestations {
-                ensure!(
-                    attestations_data.insert(&aggregated_attestation.message),
-                    "Block contains duplicate AttestationData"
-                );
-            }
+            ensure!(
+                block
+                    .body
+                    .attestations
+                    .iter()
+                    .map(|aggregated_attestation| &aggregated_attestation.message)
+                    .all_unique(),
+                "Block contains duplicate attestation messages"
+            );
 
             self.process_attestations(&block.body.attestations)?;
         }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

*This PR doesn't modify functionality.*

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Use [`all_unique`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.all_unique) to make it more declarative.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
