### PR TITLE
refactor: use macro for logging skipped attestations

### DIFF
--- a/crates/common/consensus/lean/src/utils.rs
+++ b/crates/common/consensus/lean/src/utils.rs
@@ -2,6 +2,29 @@ use ream_post_quantum_crypto::leansig::public_key::PublicKey;
 
 use crate::validator::Validator;
 
+/// Macro to log skipped attestations with feature-specific identifier
+#[macro_export]
+macro_rules! log_skip_attestation {
+    ($reason:expr, $attestation:expr) => {
+        #[cfg(feature = "devnet1")]
+        info!(
+            reason = $reason,
+            source_slot = $attestation.source().slot,
+            target_slot = $attestation.target().slot,
+            "Skipping attestation by Validator {}",
+            $attestation.validator_id,
+        );
+        #[cfg(feature = "devnet2")]
+        info!(
+            reason = $reason,
+            source_slot = $attestation.source().slot,
+            target_slot = $attestation.target().slot,
+            "Skipping attestation: {:?}",
+            $attestation.aggregation_bits,
+        );
+    };
+}
+
 pub fn generate_default_validators(number_of_validators: usize) -> Vec<Validator> {
     (0..number_of_validators)
         .map(|index| Validator {


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

`process_attestations` is over 400+ LOC, let's make this smaller.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Use a new macro for logging in attestations.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
