### PR TITLE
fix: updated tests to fulu to fix the broken state tests

### DIFF
--- a/testing/ef-tests/src/macros/ssz_static.rs
+++ b/testing/ef-tests/src/macros/ssz_static.rs
@@ -22,7 +22,7 @@ macro_rules! test_consensus_type {
                 #[case("case_4")]
                 fn test_type(#[case] case: &str) {
                     let path = format!(
-                        "mainnet/tests/mainnet/electra/ssz_static/{}/ssz_random/{case}/",
+                        "mainnet/tests/mainnet/fulu/ssz_static/{}/ssz_random/{case}/",
                         stringify!($struct_name)
                     );
 


### PR DESCRIPTION
### What was wrong?

We were using the old electra tests which caused some of our tests to output as failing instead of the fulu tests. Fixes https://github.com/ReamLabs/ream/issues/1205

### How was it fixed?

I simply changed it to use the fulu folder.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
