### PR TITLE
fix: fork digest is always devnet0

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -300,11 +300,7 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
     let network_state = lean_chain_reader.read().await.network_state.clone();
 
     // Initialize the lean network service
-
-    #[cfg(feature = "devnet2")]
-    let fork = "devnet2".to_string();
-    #[cfg(feature = "devnet3")]
-    let fork = "devnet3".to_string();
+    let fork = "devnet0".to_string();
 
     #[cfg(feature = "devnet2")]
     let topics: Vec<LeanGossipTopic> = vec![


### PR DESCRIPTION
### What was wrong?

Reverts a change made in an earlier PR to maintain fork digest as per the spec.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
