### PR TITLE
fix: updated MaxBlobCommitmentsPerBlock to the new value

### DIFF
--- a/crates/common/consensus/beacon/src/data_column_sidecar.rs
+++ b/crates/common/consensus/beacon/src/data_column_sidecar.rs
@@ -18,7 +18,7 @@ pub type Cell = FixedVector<u8, typenum::U2048>;
 pub const NUMBER_OF_COLUMNS: u64 = 128;
 pub const DATA_COLUMN_SIDECAR_SUBNET_COUNT: u64 = 128;
 
-pub type MaxBlobCommitmentsPerBlock = typenum::U128;
+pub type MaxBlobCommitmentsPerBlock = typenum::U4096;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Encode, Decode, TreeHash)]
 pub struct DataColumnSidecar {


### PR DESCRIPTION
### What was wrong?

Fixes https://github.com/ReamLabs/ream/issues/1222.

### How was it fixed?

 Essentially the solution here was just to update a type constant.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
