### PR TITLE
fix: remove manual re-gossip of attestations received from gossip

### DIFF
--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -564,7 +564,7 @@ impl LeanNetworkService {
                         self.chain_message_sender
                             .send(LeanChainServiceMessage::ProcessBlock {
                                 signed_block_with_attestation,
-                                need_gossip: true,
+                                need_gossip: false,
                             })
                     {
                         warn!("failed to send block for slot {slot} item to chain: {err:?}");
@@ -577,7 +577,7 @@ impl LeanNetworkService {
                     if let Err(err) = self.chain_message_sender.send(
                         LeanChainServiceMessage::ProcessAttestation {
                             signed_attestation,
-                            need_gossip: true,
+                            need_gossip: false,
                         },
                     ) {
                         warn!("failed to send attestation for slot {slot} to chain: {err:?}");
@@ -594,7 +594,7 @@ impl LeanNetworkService {
                         LeanChainServiceMessage::ProcessAttestation {
                             signed_attestation,
                             subnet_id,
-                            need_gossip: true,
+                            need_gossip: false,
                         },
                     ) {
                         warn!(
@@ -609,7 +609,7 @@ impl LeanNetworkService {
                     if let Err(err) = self.chain_message_sender.send(
                         LeanChainServiceMessage::ProcessAggregatedAttestation {
                             aggregated_attestation,
-                            need_gossip: true,
+                            need_gossip: false,
                         },
                     ) {
                         warn!(


### PR DESCRIPTION
### What was wrong?

Removing manual re-gossip of attestations received from gossip. I suspect this was flooding our send pool:

This also makes our logs massive as attestations have proofs which are printed by libp2p-gossipsub.

<img width="1248" height="222" alt="image" src="https://github.com/user-attachments/assets/c156adfb-3c44-4518-995f-e1bf7f4c72c6" />


### How was it fixed?

Remove need gossip from received attestations.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
