### PR TITLE
fix: handle case when tally is equal in common_highest_checkpoint

### DIFF
--- a/crates/networking/network_state/lean/src/lib.rs
+++ b/crates/networking/network_state/lean/src/lib.rs
@@ -82,8 +82,6 @@ impl NetworkState {
 
     pub fn common_highest_checkpoint(&self) -> Option<Checkpoint> {
         let peer_table = self.peer_table.lock();
-        let mut common_checkpoint: Option<Checkpoint> = None;
-
         let mut checkpoint_tally: HashMap<Checkpoint, usize> = HashMap::new();
         for peer in peer_table.values() {
             if let (ConnectionState::Connected, Some(head_checkpoint)) =
@@ -92,15 +90,11 @@ impl NetworkState {
                 *checkpoint_tally.entry(*head_checkpoint).or_insert(0) += 1;
             }
         }
-        let mut highest_tally = 0;
-        for (checkpoint, tally) in checkpoint_tally {
-            if tally > highest_tally {
-                highest_tally = tally;
-                common_checkpoint = Some(checkpoint);
-            }
-        }
 
-        common_checkpoint
+        checkpoint_tally
+            .into_iter()
+            .max_by_key(|(checkpoint, tally)| (*tally, checkpoint.slot))
+            .map(|(checkpoint, _)| checkpoint)
     }
 
     pub fn successful_response_from_peer(&self, peer_id: PeerId) {


### PR DESCRIPTION
### What was wrong?

When comparing checkpoints from peers. We tally peers but in case of a tie, we should choose the checkpoint with the highest slot.

This should fix the late joiner test on Devnet3.

### How was it fixed?

```rust        
let mut highest_tally = 0;
        for (checkpoint, tally) in checkpoint_tally {
            if tally > highest_tally
                || (tally == highest_tally
                    && common_checkpoint
                        .is_some_and(|common_checkpoint| checkpoint.slot > common_checkpoint.slot))
            {
                highest_tally = tally;
                common_checkpoint = Some(checkpoint);
            }
        }

        common_checkpoint
```

I initially expanded the if statement which looked a little ugly to read and found a clean way to do the loop.

Tuples in Rust are compared left to right so it's equivalent to the above loop.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
