### PR TITLE
fix: minor sync improvements

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -292,6 +292,8 @@ impl LeanChainService {
                                 starting_slot = prevous_queue.starting_slot,
                                 "Forward background sync incomplete; re-queuing job",
                             );
+
+                            self.sync_status.remove_processed_queue(prevous_queue.starting_root);
                             self.checkpoints_to_queue.push((checkpoint_for_new_queue, true));
                         }
                     }

--- a/crates/common/chain/lean/src/sync/forward_background_syncer.rs
+++ b/crates/common/chain/lean/src/sync/forward_background_syncer.rs
@@ -44,7 +44,7 @@ impl ForwardBackgroundSyncer {
         let mut next_root = self.job_queue.starting_root;
         let mut last_block: Option<SignedBlockWithAttestation> = None;
         let mut chained_roots = vec![];
-        while next_root != head {
+        while next_root != head && next_root != B256::ZERO {
             let current_block = match pending_blocks_provider.get(next_root)? {
                 Some(block) => block,
                 None => match block_provider.get(next_root)? {
@@ -58,8 +58,8 @@ impl ForwardBackgroundSyncer {
                         return Ok(ForwardSyncResults::ChainIncomplete {
                             prevous_queue: self.job_queue.clone(),
                             checkpoint_for_new_queue: Checkpoint {
-                                root: last_block.message.block.tree_hash_root(),
-                                slot: last_block.message.block.slot,
+                                root: next_root,
+                                slot: last_block.message.block.slot.saturating_sub(1),
                             },
                         });
                     }


### PR DESCRIPTION
### What was wrong?

We we're getting jobs attempting to fetch the genesis at genesis which was leading to issues.

Backfill syncer should fetch blocks at last block - 1.

### How was it fixed?

In my testing this seems to sync up and forward the chain up to 700 slots but for some reason it all of them stopped finalizing at 225 last finalized.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
