### PR TITLE
fix: handle edge case where peer sends an empty message

### DIFF
--- a/crates/networking/req_resp/src/outbound_protocol.rs
+++ b/crates/networking/req_resp/src/outbound_protocol.rs
@@ -176,6 +176,11 @@ impl Decoder for OutboundSSZSnappyCodec {
             }
         };
 
+        // A zero-length success payload is invalid SSZ for any response type.
+        if length == 0 && response_code == ResponseCode::Success {
+            return Ok(Some(RespMessage::EndOfStream));
+        }
+
         // The length-prefix is within the expected size bounds derived from the payload SSZ
         // type or MAX_PAYLOAD_SIZE, whichever is smaller.
         if length > max_message_size() as usize {


### PR DESCRIPTION
### What was wrong?

This shouldn't happen but was happening against lantern. We should handle it incase lantern takes a while to fix it.

### How was it fixed?

If peer says success and sends nothing, that's and end of stream.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
