### PR TITLE
feat: fixed late joiner test issues(and our on_block in the process)

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -991,11 +991,6 @@ impl Store {
             "Attestation signature groups must match aggregated attestations"
         );
 
-        attestation_data_by_root_provider.insert(
-            proposer_attestation.data.tree_hash_root(),
-            proposer_attestation.data.clone(),
-        )?;
-
         for (attestation, proof) in aggregated_attestations
             .iter()
             .zip(attestation_signatures.iter())


### PR DESCRIPTION
### What was wrong?

Fixes https://github.com/ReamLabs/ream/issues/1298

I was reading through the code and noticed a few small issues with our on_block.

I sort of realize we do have a slightly modified version of it compared to the original lean spec meant to optimize for performance, but outside of the performance improvements, I noticed we did a double insert for the gossip signatures, and the logic for attestation_data_by_root_provider.insert() being performed was actually already handled elsewhere in the code.

### How was it fixed?

Essentially I went through the on_block spec code, and saw what was different, but made sure to keep all the performance enhancements(no unnecessary clones or copying performed).

Also removed an unnecessary curly brace.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
