### PR TITLE
chore: fixing up the good pr test on the ci

### DIFF
--- a/.github/workflows/lean-interop.yml
+++ b/.github/workflows/lean-interop.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  KNOWN_GOOD_REF: 6f8c567bd33baf6ee0e76dd5bfc4407f7650be7f
+  KNOWN_GOOD_REF: 8fc998c6f6660cc72e19e312605512d24e517422
 
 jobs:
   devnet3-known-good-vs-current-pr:


### PR DESCRIPTION
### What was wrong?

Previously, the sync logic had some issues, which sort of means the commit hash for the good known ref was outdated.

### How was it fixed?

It just replaces the old hash with the one of main currently.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
