### PR TITLE
fix: suppress redundant log

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -127,6 +127,11 @@ fn main() {
         true => EnvFilter::builder().parse_lossy(cli.verbosity.directive()),
         false => EnvFilter::builder().parse_lossy(rust_log),
     };
+    let env_filter = env_filter.add_directive(
+        "libp2p_gossipsub::behaviour=error"
+            .parse()
+            .expect("valid gossipsub tracing directive"),
+    );
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
     info!("\n{}", startup_message());
 

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -21,6 +21,7 @@ use ream::{
         import_keystores::{load_keystore_directory, load_password_from_config, process_password},
         lean_node::LeanNodeConfig,
         validator_node::ValidatorNodeConfig,
+        verbosity::Verbosity,
         voluntary_exit::VoluntaryExitConfig,
     },
     startup_message::startup_message,
@@ -106,6 +107,7 @@ use tracing_subscriber::EnvFilter;
 use tree_hash::TreeHash;
 
 pub const APP_NAME: &str = "ream";
+const DEFAULT_QUIET_LOG_TARGETS: &str = "libp2p_gossipsub::behaviour=error";
 
 struct AbortOnDrop<T>(tokio::task::JoinHandle<T>);
 
@@ -124,14 +126,20 @@ fn main() {
     // Set the default log level based on verbosity flag or RUST_LOG env var
     let rust_log = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default();
     let env_filter = match rust_log.is_empty() {
-        true => EnvFilter::builder().parse_lossy(cli.verbosity.directive()),
+        true => {
+            let env_filter = EnvFilter::builder().parse_lossy(cli.verbosity.directive());
+
+            match cli.verbosity {
+                Verbosity::Debug | Verbosity::Trace => env_filter,
+                _ => env_filter.add_directive(
+                    DEFAULT_QUIET_LOG_TARGETS
+                        .parse()
+                        .expect("valid gossipsub tracing directive"),
+                ),
+            }
+        }
         false => EnvFilter::builder().parse_lossy(rust_log),
     };
-    let env_filter = env_filter.add_directive(
-        "libp2p_gossipsub::behaviour=error"
-            .parse()
-            .expect("valid gossipsub tracing directive"),
-    );
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
     info!("\n{}", startup_message());
 


### PR DESCRIPTION
### What was wrong?

In devnet runs with 7 or less nodes the send queue full log will still show as per defined behavior in slow peer handling. There is another log added that is not spammed in the same way to indicate the same behavior that already exists.

### How was it fixed?

Suppress the redundant lib_p2p log.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
