### PR TITLE
feat: increase libp2p timeout to 10s

### DIFF
--- a/crates/networking/req_resp/src/configurations.rs
+++ b/crates/networking/req_resp/src/configurations.rs
@@ -8,4 +8,4 @@ pub type AttestationSubnetCount = U64;
 /// The number of sync committee subnets used in the gossipsub aggregation protocol.
 pub type SyncCommitteeSubnetCount = U4;
 
-pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

When running the devnet in 2 subnets, we were running in to a lot of timeouts on the req/resp. All other clients and the leanspec implements a 10 second timeout for req/resp. I suspect the 2 sec timeout is the cause behind this issue. 

I'm going to run a test to confirm if this is the issue. 

https://github.com/leanEthereum/leanSpec/blob/81830527532c9c9b1f3b72d4022ea14c2efc1bbb/src/lean_spec/subspecs/networking/client/reqresp_client.py#L57

```
026-04-27T18:09:07.627608Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAkvi2sxT75Bpq1c7yV2FjnSQJJ432d6jeshbmfdJss1i6f") head_slot=168 finalized_slot=93
2026-04-27T18:09:07.676495Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAkvDcypHamUxUt8bNQJErgfuRfBJK8ErAVQPuQcn7DCjSV") head_slot=658 finalized_slot=93
2026-04-27T18:09:07.888401Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAmKpiUoZ8PUiiKkiXWyAFoqn2PbpNDerM1BBbfvQkfsF7A") head_slot=660 finalized_slot=93
2026-04-27T18:09:08.514502Z  WARN ream_p2p::network::lean: Failed to parse req/resp message from peer: Inbound { stream_id: 0, err: StreamTimedOut("/leanconsensus/req/blocks_by_root/1/ssz_snappy") } peer_id=PeerId("16Uiu2HAm8AZjZYiXw17iHm4eUEtAx1GESUUREZS7cKDAb3CwoPpS") connection_id=ConnectionId(94)
2026-04-27T18:09:08.585150Z  WARN ream_p2p::network::lean: Failed to parse req/resp message from peer: Inbound { stream_id: 19, err: StreamTimedOut("/leanconsensus/req/blocks_by_root/1/ssz_snappy") } peer_id=PeerId("16Uiu2HAm8AZjZYiXw17iHm4eUEtAx1GESUUREZS7cKDAb3CwoPpS") connection_id=ConnectionId(92)
2026-04-27T18:09:09.609069Z  WARN ream_p2p::network::lean: Failed to parse req/resp message from peer: Inbound { stream_id: 20, err: StreamTimedOut("/leanconsensus/req/blocks_by_root/1/ssz_snappy") } peer_id=PeerId("16Uiu2HAm8AZjZYiXw17iHm4eUEtAx1GESUUREZS7cKDAb3CwoPpS") connection_id=ConnectionId(92)
2026-04-27T18:09:10.687426Z  WARN ream_p2p::network::lean: Failed to parse req/resp message from peer: Inbound { stream_id: 1, err: StreamTimedOut("/leanconsensus/req/blocks_by_root/1/ssz_snappy") } peer_id=PeerId("16Uiu2HAm8AZjZYiXw17iHm4eUEtAx1GESUUREZS7cKDAb3CwoPpS") connection_id=ConnectionId(94)
2026-04-27T18:09:11.626359Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAkudhJ13gYw2SBp7qTWgwpJtb36GLGGv4HnFCUGRbAaVDZ") head_slot=248 finalized_slot=0
2026-04-27T18:09:11.626762Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAmAepziFUiqiZ6w94uTqbQRc4BDDLfbuwvMU5bwfLTtPy4") head_slot=661 finalized_slot=93
2026-04-27T18:09:11.626817Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAmSz1wjLKPNn3DhMa7CYEg8o2V9kSSrQpeT8s4wJY3n6EJ") head_slot=661 finalized_slot=93
2026-04-27T18:09:11.673386Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAm7qhnwwTeGj3UMwWYYK8jKwwAeNweo1DHozg2zLNqqMoM") head_slot=661 finalized_slot=93
2026-04-27T18:09:11.923938Z  WARN ream_p2p::network::lean: Failed to parse req/resp message from peer: Inbound { stream_id: 2, err: StreamTimedOut("/leanconsensus/req/blocks_by_root/1/ssz_snappy") } peer_id=PeerId("16Uiu2HAm8AZjZYiXw17iHm4eUEtAx1GESUUREZS7cKDAb3CwoPpS") connection_id=ConnectionId(94)
2026-04-27T18:09:12.400607Z  WARN ream_p2p::network::lean: Failed to parse req/resp message from peer: Inbound { stream_id: 21, err: StreamTimedOut("/leanconsensus/req/blocks_by_root/1/ssz_snappy") } peer_id=PeerId("16Uiu2HAm8AZjZYiXw17iHm4eUEtAx1GESUUREZS7cKDAb3CwoPpS") connection_id=ConnectionId(92)
2026-04-27T18:09:12.401575Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAm8AZjZYiXw17iHm4eUEtAx1GESUUREZS7cKDAb3CwoPpS") head_slot=72 finalized_slot=0
2026-04-27T18:09:12.756603Z  WARN ream_p2p::network::lean: Failed to parse req/resp message from peer: Inbound { stream_id: 3, err: StreamTimedOut("/leanconsensus/req/blocks_by_root/1/ssz_snappy") } peer_id=PeerId("16Uiu2HAm8AZjZYiXw17iHm4eUEtAx1GESUUREZS7cKDAb3CwoPpS") connection_id=ConnectionId(94)
2026-04-27T18:09:12.913358Z  INFO ream_p2p::network::lean: Received status response from peer peer_id=PeerId("16Uiu2HAm7TYVs6qvDKnrovd9m4vvRikc4HPXm1WyLumKSe5fHxBv") head_slot=658 finalized_slot=93
```


### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
