### PR TITLE
feat: compact aggregated attestations as per leanspec

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1621,7 +1621,7 @@ fn compact_aggregated_proofs(
             continue;
         }
 
-        let group_proofs = indices
+        let mut group_proofs = indices
             .iter()
             .map(|&index| {
                 remaining_proofs
@@ -1630,18 +1630,17 @@ fn compact_aggregated_proofs(
                     .ok_or_else(|| anyhow!("proof slot {index} missing or already taken"))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
+        group_proofs.sort_by_key(|proof| proof.to_validator_indices());
+
         for &index in &indices {
             if let Some(slot) = remaining_attestations.get_mut(index) {
                 slot.take();
             }
         }
 
-        let mut merged_bits = group_proofs
-            .first()
-            .ok_or_else(|| anyhow!("multi-index group produced no proofs"))?
-            .participants
-            .clone();
-        for proof in group_proofs.iter().skip(1) {
+        let mut merged_bits = BitList::<U4096>::with_capacity(validators.len())
+            .map_err(|err| anyhow!("BitList error: {err:?}"))?;
+        for proof in &group_proofs {
             for (index, bit) in proof.participants.iter().enumerate() {
                 if bit {
                     merged_bits

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1616,9 +1616,7 @@ fn compact_aggregated_proofs(
                 remaining_proofs
                     .get_mut(*single_index)
                     .and_then(Option::take)
-                    .ok_or_else(|| {
-                        anyhow!("proof slot {single_index} missing or already taken")
-                    })?,
+                    .ok_or_else(|| anyhow!("proof slot {single_index} missing or already taken"))?,
             );
             continue;
         }

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -16,7 +16,7 @@ use ream_consensus_lean::{
     checkpoint::Checkpoint,
     slot::is_justifiable_after,
     state::LeanState,
-    validator::is_proposer,
+    validator::{Validator, is_proposer},
 };
 use ream_consensus_misc::constants::lean::{
     ATTESTATION_COMMITTEE_COUNT, INTERVALS_PER_SLOT, MAX_ATTESTATIONS_DATA,
@@ -34,7 +34,10 @@ use ream_metrics::{
 use ream_network_spec::networks::lean_network_spec;
 use ream_network_state_lean::NetworkState;
 use ream_post_quantum_crypto::{
-    lean_multisig::aggregate::{aggregate_signatures, verify_aggregate_signature},
+    lean_multisig::aggregate::{
+        ChildProof, aggregate_signatures, aggregate_signatures_recursive,
+        verify_aggregate_signature,
+    },
     leansig::signature::Signature,
 };
 use ream_storage::{
@@ -808,6 +811,12 @@ impl Store {
         let (aggregated_attestations, aggregated_proofs) =
             self.select_aggregated_proofs(&attestations_vec).await?;
 
+        let (aggregated_attestations, aggregated_proofs) = compact_aggregated_proofs(
+            aggregated_attestations,
+            aggregated_proofs,
+            &head_state.validators,
+        )?;
+
         let attestations_list =
             VariableList::new(aggregated_attestations).map_err(|err| anyhow!("{err:?}"))?;
 
@@ -1548,6 +1557,128 @@ static TEST_ATTESTATION_COMMITTEE_COUNT: AtomicU64 = AtomicU64::new(ATTESTATION_
 #[cfg(test)]
 fn swap_test_attestation_committee_count(new_value: u64) -> u64 {
     TEST_ATTESTATION_COMMITTEE_COUNT.swap(new_value, Ordering::Relaxed)
+}
+
+fn compact_aggregated_proofs(
+    attestations: Vec<AggregatedAttestation>,
+    proofs: Vec<AggregatedSignatureProof>,
+    validators: &VariableList<Validator, U4096>,
+) -> anyhow::Result<(Vec<AggregatedAttestation>, Vec<AggregatedSignatureProof>)> {
+    ensure!(
+        attestations.len() == proofs.len(),
+        "Mismatched attestations ({}) and proofs ({}) lengths",
+        attestations.len(),
+        proofs.len(),
+    );
+
+    if attestations.len() <= 1 {
+        return Ok((attestations, proofs));
+    }
+
+    let mut order = Vec::new();
+    let mut group_index: HashMap<AttestationData, usize> = HashMap::new();
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    for (attestation_index, attestation) in attestations.iter().enumerate() {
+        match group_index.get(&attestation.message) {
+            Some(&index) => groups[index].push(attestation_index),
+            None => {
+                group_index.insert(attestation.message.clone(), groups.len());
+                order.push(attestation.message.clone());
+                groups.push(vec![attestation_index]);
+            }
+        }
+    }
+
+    if order.len() == attestations.len() {
+        return Ok((attestations, proofs));
+    }
+
+    let mut remaining_attestations: Vec<_> = attestations.into_iter().map(Some).collect();
+    let mut remaining_proofs: Vec<_> = proofs.into_iter().map(Some).collect();
+
+    let mut out_attestations = Vec::with_capacity(order.len());
+    let mut out_proofs = Vec::with_capacity(order.len());
+
+    for (data, indices) in order.into_iter().zip(groups.into_iter()) {
+        if indices.len() == 1 {
+            out_attestations.push(
+                remaining_attestations[indices[0]]
+                    .take()
+                    .expect("index used once"),
+            );
+            out_proofs.push(
+                remaining_proofs[indices[0]]
+                    .take()
+                    .expect("index used once"),
+            );
+            continue;
+        }
+
+        let group_proofs: Vec<_> = indices
+            .iter()
+            .map(|&index| remaining_proofs[index].take().expect("index used once"))
+            .collect();
+        for &index in &indices {
+            remaining_attestations[index].take();
+        }
+
+        let mut merged_bits = group_proofs[0].participants.clone();
+        for proof in &group_proofs[1..] {
+            for (index, bit) in proof.participants.iter().enumerate() {
+                if bit {
+                    merged_bits
+                        .set(index, true)
+                        .map_err(|err| anyhow!("BitList error: {err:?}"))?;
+                }
+            }
+        }
+
+        let children = group_proofs
+            .iter()
+            .map(|proof| {
+                let public_keys = proof
+                    .to_validator_indices()
+                    .into_iter()
+                    .map(|validator_index| {
+                        validators
+                            .get(validator_index as usize)
+                            .map(|validator| validator.attestation_public_key)
+                            .ok_or_else(|| {
+                                anyhow!(
+                                    "Validator index {validator_index} out of range during compaction"
+                                )
+                            })
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                Ok(ChildProof {
+                    public_keys,
+                    proof_data: proof.proof_data.to_vec(),
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let merged_proof_data = aggregate_signatures_recursive(
+            &children,
+            &[],
+            &[],
+            &data.tree_hash_root().0,
+            data.slot as u32,
+        )?;
+
+        let merged_proof = AggregatedSignatureProof::new(
+            merged_bits.clone(),
+            VariableList::new(merged_proof_data)
+                .map_err(|err| anyhow!("Merged proof exceeds size limit: {err:?}"))?,
+        );
+
+        out_attestations.push(AggregatedAttestation {
+            aggregation_bits: merged_bits,
+            message: data,
+        });
+        out_proofs.push(merged_proof);
+    }
+
+    Ok((out_attestations, out_proofs))
 }
 
 #[cfg(test)]

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1580,7 +1580,10 @@ fn compact_aggregated_proofs(
     let mut groups: Vec<Vec<usize>> = Vec::new();
     for (attestation_index, attestation) in attestations.iter().enumerate() {
         match group_index.get(&attestation.message) {
-            Some(&index) => groups[index].push(attestation_index),
+            Some(&index) => groups
+                .get_mut(index)
+                .ok_or_else(|| anyhow!("group_index pointed to missing group at {index}"))?
+                .push(attestation_index),
             None => {
                 group_index.insert(attestation.message.clone(), groups.len());
                 order.push(attestation.message.clone());
@@ -1600,30 +1603,47 @@ fn compact_aggregated_proofs(
     let mut out_proofs = Vec::with_capacity(order.len());
 
     for (data, indices) in order.into_iter().zip(groups.into_iter()) {
-        if indices.len() == 1 {
+        if let [single_index] = indices.as_slice() {
             out_attestations.push(
-                remaining_attestations[indices[0]]
-                    .take()
-                    .expect("index used once"),
+                remaining_attestations
+                    .get_mut(*single_index)
+                    .and_then(Option::take)
+                    .ok_or_else(|| {
+                        anyhow!("attestation slot {single_index} missing or already taken")
+                    })?,
             );
             out_proofs.push(
-                remaining_proofs[indices[0]]
-                    .take()
-                    .expect("index used once"),
+                remaining_proofs
+                    .get_mut(*single_index)
+                    .and_then(Option::take)
+                    .ok_or_else(|| {
+                        anyhow!("proof slot {single_index} missing or already taken")
+                    })?,
             );
             continue;
         }
 
-        let group_proofs: Vec<_> = indices
+        let group_proofs = indices
             .iter()
-            .map(|&index| remaining_proofs[index].take().expect("index used once"))
-            .collect();
+            .map(|&index| {
+                remaining_proofs
+                    .get_mut(index)
+                    .and_then(Option::take)
+                    .ok_or_else(|| anyhow!("proof slot {index} missing or already taken"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
         for &index in &indices {
-            remaining_attestations[index].take();
+            if let Some(slot) = remaining_attestations.get_mut(index) {
+                slot.take();
+            }
         }
 
-        let mut merged_bits = group_proofs[0].participants.clone();
-        for proof in &group_proofs[1..] {
+        let mut merged_bits = group_proofs
+            .first()
+            .ok_or_else(|| anyhow!("multi-index group produced no proofs"))?
+            .participants
+            .clone();
+        for proof in group_proofs.iter().skip(1) {
             for (index, bit) in proof.participants.iter().enumerate() {
                 if bit {
                     merged_bits


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
Proposers were emitting multiple proofs per AttestationData (one per subnet), which block validation rejects as duplicates

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  --> 
By adding compact_aggregated_proofs to merge same-data proofs into one recursive proof with the union of participants before assembling the block as per the leanSpec for devnet4

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
