### PR TITLE
fix: don't aggregate on forward sync

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -334,6 +334,7 @@ impl LeanChainService {
                         std::future::pending().await
                     }
                 }, if self.forward_syncer.is_some() => {
+                    self.forward_syncer = None;
                     let forward_syncer = match forward_syncer {
                         Ok(forward_syncer) => forward_syncer,
                         Err(err) => {
@@ -341,7 +342,6 @@ impl LeanChainService {
                             continue;
                         },
                     };
-                    self.forward_syncer = None;
 
                     let forward_syncer = match forward_syncer {
                         Ok(forward_syncer) => forward_syncer,

--- a/crates/common/chain/lean/src/sync/forward_background_syncer.rs
+++ b/crates/common/chain/lean/src/sync/forward_background_syncer.rs
@@ -110,7 +110,7 @@ impl ForwardBackgroundSyncer {
             let time = lean_network_spec().genesis_time
                 + (block.block.slot * lean_network_spec().seconds_per_slot);
             let block_slot = block.block.slot;
-            store_writer.on_tick(time, false, true).await?;
+            store_writer.on_tick(time, false, false).await?;
             store_writer.on_block(&block, true).await?;
             blocks_synced += 1;
             if imported_start_slot.is_none() {


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
This fixes a problem where lean multisig crashes when we're aggregating during forward sync. 

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
