### PR TITLE
chore: remove all abbreviations

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -1,10 +1,5 @@
 use std::{
-    env, fs,
-    net::SocketAddr,
-    path::{Path, PathBuf},
-    process,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    collections::BTreeSet, env, fs, net::SocketAddr, path::{Path, PathBuf}, process, sync::Arc, time::{Duration, SystemTime, UNIX_EPOCH}
 };
 
 use alloy_primitives::hex;
@@ -76,7 +71,11 @@ use ream_post_quantum_crypto::{
     },
 };
 use ream_rpc_common::config::RpcServerConfig;
-use ream_rpc_lean::aggregator_controller::AggregatorController;
+use ream_rpc_lean::{
+    aggregator_controller::AggregatorController,
+    handlers::test_driver::test_driver_enabled,
+    server::start_test_driver,
+};
 use ream_storage::{
     cache::{BeaconCacheDB, LeanCacheDB},
     db::{ReamDB, reset_db},
@@ -96,9 +95,8 @@ use ream_validator_lean::{
 };
 use ssz_types::VariableList;
 use tokio::{
-    sync::{broadcast, mpsc},
-    time,
-    time::Instant,
+    sync::{broadcast, mpsc::{unbounded_channel}},
+    time::{self, Instant},
 };
 use tracing::{Instrument, error, info};
 use tracing_subscriber::EnvFilter;
@@ -266,8 +264,8 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
     info!("ream lean database has been initialized");
 
     // Initialize the services that will run in the lean node.
-    let (chain_sender, chain_receiver) = mpsc::unbounded_channel::<LeanChainServiceMessage>();
-    let (outbound_p2p_sender, outbound_p2p_receiver) = mpsc::unbounded_channel::<LeanP2PRequest>();
+    let (chain_sender, chain_receiver) = unbounded_channel::<LeanChainServiceMessage>();
+    let (outbound_p2p_sender, outbound_p2p_receiver) = unbounded_channel::<LeanP2PRequest>();
 
     let (anchor_signed_block, anchor_state) = if let Some(url) = config.checkpoint_sync_url.clone()
     {
@@ -313,7 +311,7 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
         .expect("Could not get forkchoice store"),
     );
 
-    let test_driver_enabled = ream_rpc_lean::handlers::test_driver::test_driver_enabled();
+    let test_driver_enabled = test_driver_enabled();
     let network_state = lean_chain_reader.read().await.network_state.clone();
 
     let aggregator_controller = Arc::new(AggregatorController::new(network_state.clone()));
@@ -324,7 +322,7 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
             config.http_port,
             config.http_allow_origin,
         );
-        ream_rpc_lean::server::start_test_driver(
+        start_test_driver(
             server_config,
             lean_chain_reader,
             lean_chain_writer,
@@ -341,7 +339,7 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
 
     let committee_count = attestation_committee_count();
     let subscribed_subnets = {
-        let mut set: std::collections::BTreeSet<u64> = keystores
+        let mut set: BTreeSet<u64> = keystores
             .iter()
             .map(|keystore| keystore.index % committee_count)
             .collect();
@@ -877,10 +875,7 @@ pub async fn countdown_for_genesis() {
 #[cfg(test)]
 mod tests {
     use std::{
-        fs,
-        path::{Path, PathBuf},
-        process::{Command, Stdio},
-        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+        env::temp_dir, fs, path::{Path, PathBuf}, process::{Command, Stdio}, time::{Duration, Instant, SystemTime, UNIX_EPOCH}
     };
 
     use alloy_primitives::hex;
@@ -1024,7 +1019,7 @@ mod tests {
 
             for (i, db_slot) in db_instances.iter_mut().enumerate().take(node_count) {
                 let node_index = i + 1;
-                let ream_dir = std::env::temp_dir()
+                let ream_dir = temp_dir()
                     .join(format!("{APP_NAME}_{}_node_{node_index}", scenario.test_name));
 
                 if ream_dir.exists()
@@ -1354,7 +1349,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("System time is before UNIX epoch")
             .as_nanos();
-        let network_config_path = std::env::temp_dir().join(format!(
+        let network_config_path = temp_dir().join(format!(
             "{APP_NAME}_{test_name}_{unique_suffix}_network.yaml"
         ));
 
@@ -1591,7 +1586,7 @@ mod tests {
                 let node_id = format!("node{node_index}");
 
                 let ream_dir =
-                    std::env::temp_dir().join(format!("{APP_NAME}_{test_name}_node_{node_index}"));
+                    temp_dir().join(format!("{APP_NAME}_{test_name}_node_{node_index}"));
 
                 if ream_dir.exists()
                     && let Err(err) = fs::remove_dir_all(&ream_dir)
@@ -1802,7 +1797,7 @@ mod tests {
                 let node_index = i + 1;
 
                 let ream_dir =
-                    std::env::temp_dir().join(format!("{APP_NAME}_{test_name}_node_{node_index}"));
+                    temp_dir().join(format!("{APP_NAME}_{test_name}_node_{node_index}"));
 
                 if ream_dir.exists()
                     && let Err(err) = fs::remove_dir_all(&ream_dir)
@@ -1826,7 +1821,7 @@ mod tests {
             for (i, node_boot_config) in topology.iter().enumerate() {
                 let node_index = i + 1;
                 let db = db_instances[i].clone().unwrap();
-                let key_path = std::env::temp_dir()
+                let key_path = temp_dir()
                     .join(format!("{APP_NAME}_{test_name}_node_{node_index}"))
                     .join("node_key");
 
@@ -2125,7 +2120,7 @@ mod tests {
             let node_index = i + 1;
 
             let ream_data_directory =
-                std::env::temp_dir().join(format!("{APP_NAME}_{test_name}_node_{node_index}"));
+                temp_dir().join(format!("{APP_NAME}_{test_name}_node_{node_index}"));
 
             if ream_data_directory.exists()
                 && let Err(err) = fs::remove_dir_all(&ream_data_directory)

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -1,5 +1,11 @@
 use std::{
-    collections::BTreeSet, env, fs, net::SocketAddr, path::{Path, PathBuf}, process, sync::Arc, time::{Duration, SystemTime, UNIX_EPOCH}
+    collections::BTreeSet,
+    env, fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    process,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use alloy_primitives::hex;
@@ -72,8 +78,7 @@ use ream_post_quantum_crypto::{
 };
 use ream_rpc_common::config::RpcServerConfig;
 use ream_rpc_lean::{
-    aggregator_controller::AggregatorController,
-    handlers::test_driver::test_driver_enabled,
+    aggregator_controller::AggregatorController, handlers::test_driver::test_driver_enabled,
     server::start_test_driver,
 };
 use ream_storage::{
@@ -95,7 +100,7 @@ use ream_validator_lean::{
 };
 use ssz_types::VariableList;
 use tokio::{
-    sync::{broadcast, mpsc::{unbounded_channel}},
+    sync::{broadcast, mpsc::unbounded_channel},
     time::{self, Instant},
 };
 use tracing::{Instrument, error, info};
@@ -140,27 +145,29 @@ fn main() {
 
     let executor = ReamExecutor::new().expect("unable to create executor");
     let executor_clone = executor.clone();
-    let ream_dir = setup_data_dir(APP_NAME, cli.data_dir.clone(), cli.ephemeral)
+    let ream_directory = setup_data_dir(APP_NAME, cli.data_dir.clone(), cli.ephemeral)
         .expect("Unable to initialize database directory");
 
     if cli.purge_db {
-        reset_db(&ream_dir).expect("Unable to delete database");
+        reset_db(&ream_directory).expect("Unable to delete database");
     }
 
     let task_handle = match cli.command {
         Commands::LeanNode(config) => {
-            let ream_db = ReamDB::new(ream_dir.clone()).expect("unable to init Ream Database");
+            let ream_db =
+                ReamDB::new(ream_directory.clone()).expect("unable to init Ream Database");
             executor_clone.spawn(async move { run_lean_node(*config, executor, ream_db).await })
         }
         Commands::BeaconNode(config) => {
-            let ream_db = ReamDB::new(ream_dir.clone()).expect("unable to init Ream Database");
+            let ream_db =
+                ReamDB::new(ream_directory.clone()).expect("unable to init Ream Database");
             executor_clone.spawn(async move { run_beacon_node(*config, executor, ream_db).await })
         }
         Commands::ValidatorNode(config) => {
             executor_clone.spawn(async move { run_validator_node(*config, executor).await })
         }
         Commands::AccountManager(config) => {
-            executor_clone.spawn(async move { run_account_manager(*config, ream_dir).await })
+            executor_clone.spawn(async move { run_account_manager(*config, ream_directory).await })
         }
         Commands::VoluntaryExit(config) => {
             executor_clone.spawn(async move { run_voluntary_exit(*config).await })
@@ -646,7 +653,7 @@ pub async fn run_validator_node(config: ValidatorNodeConfig, executor: ReamExecu
 ///
 /// This function initializes the account manager by validating the configuration,
 /// generating keys, and starting the account manager service.
-pub async fn run_account_manager(config: AccountManagerConfig, ream_dir: PathBuf) {
+pub async fn run_account_manager(config: AccountManagerConfig, ream_directory: PathBuf) {
     info!("Starting account manager...");
 
     info!(
@@ -671,10 +678,10 @@ pub async fn run_account_manager(config: AccountManagerConfig, ream_dir: PathBuf
             if path.is_absolute() {
                 path.to_path_buf()
             } else {
-                ream_dir.join(custom_path)
+                ream_directory.join(custom_path)
             }
         }
-        None => ream_dir.join("keystores"),
+        None => ream_directory.join("keystores"),
     };
 
     if !keystore_dir.exists() {
@@ -875,7 +882,11 @@ pub async fn countdown_for_genesis() {
 #[cfg(test)]
 mod tests {
     use std::{
-        env::temp_dir, fs, path::{Path, PathBuf}, process::{Command, Stdio}, time::{Duration, Instant, SystemTime, UNIX_EPOCH}
+        env::temp_dir,
+        fs,
+        path::{Path, PathBuf},
+        process::{Command, Stdio},
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
     };
 
     use alloy_primitives::hex;
@@ -1019,17 +1030,17 @@ mod tests {
 
             for (i, db_slot) in db_instances.iter_mut().enumerate().take(node_count) {
                 let node_index = i + 1;
-                let ream_dir = temp_dir()
+                let ream_directory = temp_dir()
                     .join(format!("{APP_NAME}_{}_node_{node_index}", scenario.test_name));
 
-                if ream_dir.exists()
-                    && let Err(err) = fs::remove_dir_all(&ream_dir)
+                if ream_directory.exists()
+                    && let Err(err) = fs::remove_dir_all(&ream_directory)
                 {
                     warn!("Failed to remove ream directory: {err}");
                 }
-                fs::create_dir_all(&ream_dir).expect("Failed to create data dir");
+                fs::create_dir_all(&ream_directory).expect("Failed to create data directory");
 
-                let key_path = ream_dir.join("node_key");
+                let key_path = ream_directory.join("node_key");
                 let peer_id = generate_node_identity(&key_path);
                 key_paths.push(key_path);
 
@@ -1039,7 +1050,7 @@ mod tests {
                     format!("/ip4/127.0.0.1/udp/{p2p_port}/quic-v1/p2p/{peer_id}");
                 node_addresses.push(address);
 
-                *db_slot = Some(ReamDB::new(ream_dir).unwrap());
+                *db_slot = Some(ReamDB::new(ream_directory).unwrap());
             }
 
             let node_1_http_port = base_http_port + port_offset;
@@ -1153,7 +1164,7 @@ mod tests {
                 {
                     if node_3_started {
                         info!(
-                            "Restarting Node 3 with --checkpoint-sync-url using existing data dir..."
+                            "Restarting Node 3 with --checkpoint-sync-url using existing data directory..."
                         );
                         node_3_state_before_restart =
                             db_instances[2].as_ref().and_then(read_head_state);
@@ -1391,8 +1402,8 @@ mod tests {
             panic!("Expected lean_node command");
         };
 
-        let ream_dir = setup_data_dir(APP_NAME, None, true).unwrap();
-        let db = ReamDB::new(ream_dir).unwrap();
+        let ream_directory = setup_data_dir(APP_NAME, None, true).unwrap();
+        let db = ReamDB::new(ream_directory).unwrap();
         let executor = ReamExecutor::new().unwrap();
         let executor_handle = executor.clone();
 
@@ -1447,8 +1458,8 @@ mod tests {
             panic!("Expected lean_node command");
         };
 
-        let ream_dir = setup_data_dir(APP_NAME, None, true).unwrap();
-        let db = ReamDB::new(ream_dir).unwrap();
+        let ream_directory = setup_data_dir(APP_NAME, None, true).unwrap();
+        let db = ReamDB::new(ream_directory).unwrap();
         let executor = ReamExecutor::new().unwrap();
         let executor_handle = executor.clone();
 
@@ -1517,7 +1528,7 @@ mod tests {
     fn generate_node_identity(path: &PathBuf) -> String {
         let secp256k1_key = secp256k1::Keypair::generate();
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).expect("Failed to create key dir");
+            fs::create_dir_all(parent).expect("Failed to create key directory");
         }
         fs::write(path, hex::encode(secp256k1_key.secret().to_bytes()))
             .expect("Failed to write private key");
@@ -1585,17 +1596,17 @@ mod tests {
                 let node_index = i + 1;
                 let node_id = format!("node{node_index}");
 
-                let ream_dir =
+                let ream_directory =
                     temp_dir().join(format!("{APP_NAME}_{test_name}_node_{node_index}"));
 
-                if ream_dir.exists()
-                    && let Err(err) = fs::remove_dir_all(&ream_dir)
+                if ream_directory.exists()
+                    && let Err(err) = fs::remove_dir_all(&ream_directory)
                 {
                     warn!("Failed to remove ream directory: {err}");
                 }
-                fs::create_dir_all(&ream_dir).expect("Failed to create data dir");
+                fs::create_dir_all(&ream_directory).expect("Failed to create data directory");
 
-                let key_path = ream_dir.join("node_key");
+                let key_path = ream_directory.join("node_key");
                 let peer_id = generate_node_identity(&key_path);
 
                 let port_offset = (test_name.len() as u16) % 100;
@@ -1609,7 +1620,7 @@ mod tests {
                     info!("BOOTNODE ADDRESS: {address}");
                 }
 
-                db_instances.push(ReamDB::new(ream_dir.clone()).unwrap());
+                db_instances.push(ReamDB::new(ream_directory.clone()).unwrap());
 
                 let mut bootnode_arguments: Vec<String> = Vec::new();
                 for &target_idx in node_boot_config {
@@ -1796,17 +1807,17 @@ mod tests {
             for (i, _) in topology.iter().enumerate() {
                 let node_index = i + 1;
 
-                let ream_dir =
+                let ream_directory =
                     temp_dir().join(format!("{APP_NAME}_{test_name}_node_{node_index}"));
 
-                if ream_dir.exists()
-                    && let Err(err) = fs::remove_dir_all(&ream_dir)
+                if ream_directory.exists()
+                    && let Err(err) = fs::remove_dir_all(&ream_directory)
                 {
                     warn!("Failed to remove ream directory: {err}");
                 }
-                fs::create_dir_all(&ream_dir).expect("Failed to create data dir");
+                fs::create_dir_all(&ream_directory).expect("Failed to create data directory");
 
-                let key_path = ream_dir.join("node_key");
+                let key_path = ream_directory.join("node_key");
                 let peer_id = generate_node_identity(&key_path);
 
                 let port_offset = (test_name.len() as u16) % 100;
@@ -1815,7 +1826,7 @@ mod tests {
                 let address = format!("/ip4/127.0.0.1/udp/{p2p_port}/quic-v1/p2p/{peer_id}");
                 node_addresses.push(address.clone());
 
-                db_instances[i] = Some(ReamDB::new(ream_dir.clone()).unwrap());
+                db_instances[i] = Some(ReamDB::new(ream_directory.clone()).unwrap());
             }
 
             for (i, node_boot_config) in topology.iter().enumerate() {
@@ -2127,7 +2138,7 @@ mod tests {
             {
                 warn!("Failed to remove ream data directory: {err}");
             }
-            fs::create_dir_all(&ream_data_directory).expect("Failed to create data dir");
+            fs::create_dir_all(&ream_data_directory).expect("Failed to create data directory");
 
             let key_path = ream_data_directory.join("node_key");
             let peer_id = generate_node_identity(&key_path);

--- a/crates/common/api_types/common/src/id.rs
+++ b/crates/common/api_types/common/src/id.rs
@@ -38,14 +38,20 @@ impl<'de> Deserialize<'de> for ID {
             _ => {
                 if string.starts_with("0x") {
                     B256::from_str(&string).map(ID::Root).map_err(|err| {
-                        serde::de::Error::custom(format!("Invalid hex root: {string}, error: {err}"))
+                        serde::de::Error::custom(format!(
+                            "Invalid hex root: {string}, error: {err}"
+                        ))
                     })
                 } else if string.chars().all(|c| c.is_ascii_digit()) {
                     string.parse::<u64>().map(ID::Slot).map_err(|err| {
-                        serde::de::Error::custom(format!("Invalid slot number: {string}, error: {err}"))
+                        serde::de::Error::custom(format!(
+                            "Invalid slot number: {string}, error: {err}"
+                        ))
                     })
                 } else {
-                    Err(serde::de::Error::custom(format!("Invalid state ID: {string}")))
+                    Err(serde::de::Error::custom(format!(
+                        "Invalid state ID: {string}"
+                    )))
                 }
             }
         }

--- a/crates/common/api_types/common/src/id.rs
+++ b/crates/common/api_types/common/src/id.rs
@@ -29,23 +29,23 @@ impl<'de> Deserialize<'de> for ID {
     where
         D: serde::Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
-        match s.to_lowercase().as_str() {
+        let string = String::deserialize(deserializer)?;
+        match string.to_lowercase().as_str() {
             "finalized" => Ok(ID::Finalized),
             "genesis" => Ok(ID::Genesis),
             "head" => Ok(ID::Head),
             "justified" => Ok(ID::Justified),
             _ => {
-                if s.starts_with("0x") {
-                    B256::from_str(&s).map(ID::Root).map_err(|err| {
-                        serde::de::Error::custom(format!("Invalid hex root: {s}, error: {err}"))
+                if string.starts_with("0x") {
+                    B256::from_str(&string).map(ID::Root).map_err(|err| {
+                        serde::de::Error::custom(format!("Invalid hex root: {string}, error: {err}"))
                     })
-                } else if s.chars().all(|c| c.is_ascii_digit()) {
-                    s.parse::<u64>().map(ID::Slot).map_err(|err| {
-                        serde::de::Error::custom(format!("Invalid slot number: {s}, error: {err}"))
+                } else if string.chars().all(|c| c.is_ascii_digit()) {
+                    string.parse::<u64>().map(ID::Slot).map_err(|err| {
+                        serde::de::Error::custom(format!("Invalid slot number: {string}, error: {err}"))
                     })
                 } else {
-                    Err(serde::de::Error::custom(format!("Invalid state ID: {s}")))
+                    Err(serde::de::Error::custom(format!("Invalid state ID: {string}")))
                 }
             }
         }

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -41,6 +41,7 @@ use tree_hash::TreeHash;
 
 use crate::{
     clock::{create_lean_clock_interval, get_initial_tick_count},
+    service::LeanP2PRequest::{GossipBlock, GossipAttestation, GossipAggregatedAttestation, Request, Response, EndOfStream, InvalidRequest},
     messages::{LeanChainServiceMessage, ServiceResponse},
     p2p_request::{LeanP2PRequest, P2PCallbackRequest},
     slot::get_current_slot,
@@ -439,7 +440,7 @@ impl LeanChainService {
                                 warn!("Failed to handle process block message: {err:?}");
                             }
 
-                            if need_gossip && let Err(err) = self.outbound_p2p.send(LeanP2PRequest::GossipBlock(signed_block)) {
+                            if need_gossip && let Err(err) = self.outbound_p2p.send(GossipBlock(signed_block)) {
                                 warn!("Failed to send item to outbound gossip channel: {err:?}");
                             }
                         }
@@ -464,7 +465,7 @@ impl LeanChainService {
                                 warn!("Failed to handle process attestation message: {err:?}");
                             }
 
-                            if need_gossip && let Err(err) = self.outbound_p2p.send(LeanP2PRequest::GossipAttestation { subnet_id, attestation: signed_attestation }) {
+                            if need_gossip && let Err(err) = self.outbound_p2p.send(GossipAttestation { subnet_id, attestation: signed_attestation }) {
                                 warn!("Failed to send item to outbound gossip channel: {err:?}");
                             }
                         }
@@ -481,7 +482,7 @@ impl LeanChainService {
                                 warn!("Failed to handle process aggregated attestation message: {err:?}");
                             }
 
-                            if need_gossip && let Err(err) = self.outbound_p2p.send(LeanP2PRequest::GossipAggregatedAttestation(aggregated_attestation)) {
+                            if need_gossip && let Err(err) = self.outbound_p2p.send(GossipAggregatedAttestation(aggregated_attestation)) {
                                 warn!("Failed to send aggregated attestation to outbound gossip channel: {err:?}");
                             }
                         }
@@ -982,7 +983,7 @@ impl LeanChainService {
 
     fn request_block_by_root_from_peer(&mut self, peer_id: PeerId, root: B256) -> bool {
         let (callback, rx) = mpsc::channel(100);
-        if let Err(err) = self.outbound_p2p.send(LeanP2PRequest::Request {
+        if let Err(err) = self.outbound_p2p.send(Request {
             peer_id,
             callback,
             message: P2PCallbackRequest::BlocksByRoot { roots: vec![root] },
@@ -2126,7 +2127,7 @@ impl LeanChainService {
                 for root in blocks_by_root_v1_request.roots {
                     match block_provider.get(root) {
                         Ok(Some(block)) => {
-                            if let Err(err) = self.outbound_p2p.send(LeanP2PRequest::Response {
+                            if let Err(err) = self.outbound_p2p.send(Response {
                                 peer_id,
                                 stream_id,
                                 connection_id,
@@ -2143,7 +2144,7 @@ impl LeanChainService {
                         }
                     }
                 }
-                if let Err(err) = self.outbound_p2p.send(LeanP2PRequest::EndOfStream {
+                if let Err(err) = self.outbound_p2p.send(EndOfStream {
                     peer_id,
                     stream_id,
                     connection_id,
@@ -2151,18 +2152,18 @@ impl LeanChainService {
                     warn!("Failed to send end of stream: {err:?}");
                 }
             }
-            LeanRequestMessage::BlocksByRange(req) => {
-                if req.count == 0
-                    || req.count > MAX_REQUEST_BLOCKS
-                    || req.start_slot.checked_add(req.count).is_none()
+            LeanRequestMessage::BlocksByRange(request) => {
+                if request.count == 0
+                    || request.count > MAX_REQUEST_BLOCKS
+                    || request.start_slot.checked_add(request.count).is_none()
                 {
-                    if let Err(err) = self.outbound_p2p.send(LeanP2PRequest::InvalidRequest {
+                    if let Err(err) = self.outbound_p2p.send(InvalidRequest {
                         peer_id,
                         stream_id,
                         connection_id,
                         reason: format!(
                             "invalid BlocksByRange count {} from start_slot {}",
-                            req.count, req.start_slot
+                            request.count, request.start_slot
                         ),
                     }) {
                         warn!(
@@ -2177,10 +2178,10 @@ impl LeanChainService {
                     (store.slot_index_provider(), store.block_provider())
                 };
 
-                for slot in (req.start_slot..).take(req.count as usize) {
+                for slot in (request.start_slot..).take(request.count as usize) {
                     if let Ok(Some(root)) = slot_index_provider.get(slot)
                         && let Ok(Some(block)) = block_provider.get(root)
-                        && let Err(err) = self.outbound_p2p.send(LeanP2PRequest::Response {
+                        && let Err(err) = self.outbound_p2p.send(Response {
                             peer_id,
                             stream_id,
                             connection_id,
@@ -2190,7 +2191,7 @@ impl LeanChainService {
                         warn!("Failed to send block to peer {peer_id}: {err:?}");
                     }
                 }
-                if let Err(err) = self.outbound_p2p.send(LeanP2PRequest::EndOfStream {
+                if let Err(err) = self.outbound_p2p.send(EndOfStream {
                     peer_id,
                     stream_id,
                     connection_id,
@@ -2707,7 +2708,11 @@ mod tests {
     use ream_storage::tables::{field::REDBField, table::REDBTable};
     use ream_sync::rwlock::Writer;
     use ream_test_utils::store::sample_store;
-    use tokio::sync::{mpsc, oneshot};
+    use tokio::{
+        sync::{mpsc, oneshot},
+        time::sleep,
+    };
+
     use tree_hash::TreeHash;
 
     use super::{InflightRootRequest, LeanChainService, SyncBlockSource};
@@ -2935,7 +2940,7 @@ complete(start=60, fetched_through=57, jobs=0)"
 
         assert!(!service.should_run_backfill_sync().await);
 
-        tokio::time::sleep(
+        sleep(
             super::SYNCED_BACKFILL_GAP_PERSISTENCE_THRESHOLD + Duration::from_millis(50),
         )
         .await;

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -41,9 +41,12 @@ use tree_hash::TreeHash;
 
 use crate::{
     clock::{create_lean_clock_interval, get_initial_tick_count},
-    service::LeanP2PRequest::{GossipBlock, GossipAttestation, GossipAggregatedAttestation, Request, Response, EndOfStream, InvalidRequest},
     messages::{LeanChainServiceMessage, ServiceResponse},
     p2p_request::{LeanP2PRequest, P2PCallbackRequest},
+    service::LeanP2PRequest::{
+        EndOfStream, GossipAggregatedAttestation, GossipAttestation, GossipBlock, InvalidRequest,
+        Request, Response,
+    },
     slot::get_current_slot,
     sync::{
         BackfillState, QueueRecovery, SyncStatus,
@@ -2712,7 +2715,6 @@ mod tests {
         sync::{mpsc, oneshot},
         time::sleep,
     };
-
     use tree_hash::TreeHash;
 
     use super::{InflightRootRequest, LeanChainService, SyncBlockSource};
@@ -2940,10 +2942,7 @@ complete(start=60, fetched_through=57, jobs=0)"
 
         assert!(!service.should_run_backfill_sync().await);
 
-        sleep(
-            super::SYNCED_BACKFILL_GAP_PERSISTENCE_THRESHOLD + Duration::from_millis(50),
-        )
-        .await;
+        sleep(super::SYNCED_BACKFILL_GAP_PERSISTENCE_THRESHOLD + Duration::from_millis(50)).await;
 
         assert!(service.should_run_backfill_sync().await);
     }

--- a/crates/common/checkpoint_sync/lean/src/lib.rs
+++ b/crates/common/checkpoint_sync/lean/src/lib.rs
@@ -185,7 +185,7 @@ mod tests {
 
     fn spawn_checkpoint_server(mode: ResponseMode) -> (Url, actix_web::dev::ServerHandle) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
-        let addr = listener.local_addr().expect("Failed to get local addr");
+        let address = listener.local_addr().expect("Failed to get local address");
 
         let server = HttpServer::new(move || {
             App::new().app_data(Data::new(mode.clone())).service(
@@ -201,15 +201,15 @@ mod tests {
         tokio::spawn(server);
 
         (
-            Url::parse(&format!("http://{addr}")).expect("Failed to parse base URL"),
+            Url::parse(&format!("http://{address}")).expect("Failed to parse base URL"),
             server_handle,
         )
     }
 
     fn spawn_redirect_checkpoint_server(state: LeanState) -> (Url, actix_web::dev::ServerHandle) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
-        let addr = listener.local_addr().expect("Failed to get local addr");
-        let redirect_target = format!("http://{addr}/redirected-finalized");
+        let address = listener.local_addr().expect("Failed to get local address");
+        let redirect_target = format!("http://{address}/redirected-finalized");
 
         let server = HttpServer::new(move || {
             let state = state.clone();
@@ -247,7 +247,7 @@ mod tests {
         tokio::spawn(server);
 
         (
-            Url::parse(&format!("http://{addr}")).expect("Failed to parse base URL"),
+            Url::parse(&format!("http://{address}")).expect("Failed to parse base URL"),
             server_handle,
         )
     }
@@ -340,10 +340,10 @@ mod tests {
     #[tokio::test]
     async fn test_client_returns_transport_error_when_server_is_unreachable() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
-        let addr = listener.local_addr().expect("Failed to get local addr");
+        let address = listener.local_addr().expect("Failed to get local address");
         drop(listener);
 
-        let base_url = Url::parse(&format!("http://{addr}")).expect("Failed to parse base URL");
+        let base_url = Url::parse(&format!("http://{address}")).expect("Failed to parse base URL");
 
         LeanCheckpointClient::new()
             .fetch_finalized_state(&base_url)
@@ -513,7 +513,7 @@ mod tests {
         signed_block: SignedBlock,
     ) -> (Url, actix_web::dev::ServerHandle) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
-        let addr = listener.local_addr().expect("Failed to get local addr");
+        let address = listener.local_addr().expect("Failed to get local address");
 
         let server = HttpServer::new(move || {
             let state = state.clone();
@@ -552,7 +552,7 @@ mod tests {
         tokio::spawn(server);
 
         (
-            Url::parse(&format!("http://{addr}")).expect("Failed to parse base URL"),
+            Url::parse(&format!("http://{address}")).expect("Failed to parse base URL"),
             server_handle,
         )
     }
@@ -579,7 +579,7 @@ mod tests {
     async fn test_client_finalized_block_returns_http_error_context() {
         // Spawn a server that returns 404 on /blocks/finalized but a valid state.
         let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
-        let addr = listener.local_addr().expect("Failed to get local addr");
+        let address = listener.local_addr().expect("Failed to get local address");
 
         let server = HttpServer::new(move || {
             App::new().service(web::scope("/lean/v0").route(
@@ -596,7 +596,7 @@ mod tests {
         let server_handle = server.handle();
         tokio::spawn(server);
 
-        let base_url = Url::parse(&format!("http://{addr}")).expect("Failed to parse base URL");
+        let base_url = Url::parse(&format!("http://{address}")).expect("Failed to parse base URL");
 
         let err = LeanCheckpointClient::new()
             .fetch_finalized_block(&base_url)
@@ -614,7 +614,7 @@ mod tests {
     async fn test_client_finalized_block_returns_decode_error_for_malformed_ssz() {
         // Spawn a server that returns garbage bytes on /blocks/finalized.
         let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
-        let addr = listener.local_addr().expect("Failed to get local addr");
+        let address = listener.local_addr().expect("Failed to get local address");
 
         let server = HttpServer::new(move || {
             App::new().service(web::scope("/lean/v0").route(
@@ -633,7 +633,7 @@ mod tests {
         let server_handle = server.handle();
         tokio::spawn(server);
 
-        let base_url = Url::parse(&format!("http://{addr}")).expect("Failed to parse base URL");
+        let base_url = Url::parse(&format!("http://{address}")).expect("Failed to parse base URL");
 
         let err = LeanCheckpointClient::new()
             .fetch_finalized_block(&base_url)

--- a/crates/common/execution/rpc_types/src/transaction.rs
+++ b/crates/common/execution/rpc_types/src/transaction.rs
@@ -33,8 +33,8 @@ impl Encodable for ToAddress {
             ToAddress::Empty => {
                 out.put_u8(EMPTY_STRING_CODE);
             }
-            ToAddress::Exists(addr) => {
-                addr.0.encode(out);
+            ToAddress::Exists(address) => {
+                address.0.encode(out);
             }
         }
     }

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -611,10 +611,10 @@ impl Store {
             }
 
             let xmss_keys: Vec<_> = raw_entries.iter().map(|err| err.1).collect();
-            let xmss_sigs: Vec<_> = raw_entries.iter().map(|err| err.2).collect();
+            let xmss_signatures: Vec<_> = raw_entries.iter().map(|err| err.2).collect();
 
             let aggregated_signature =
-                aggregate_signatures(&xmss_keys, &xmss_sigs, &data_root.0, data.slot as u32)?;
+                aggregate_signatures(&xmss_keys, &xmss_signatures, &data_root.0, data.slot as u32)?;
 
             let proof = AggregatedSignatureProof {
                 participants: bits.clone(),

--- a/crates/crypto/keystore/src/hex_serde.rs
+++ b/crates/crypto/keystore/src/hex_serde.rs
@@ -13,6 +13,6 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    Vec::<u8>::from_hex(&s).map_err(|err| de::Error::custom(err.to_string()))
+    let string = String::deserialize(deserializer)?;
+    Vec::<u8>::from_hex(&string).map_err(|err| de::Error::custom(err.to_string()))
 }

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -57,7 +57,7 @@ impl NetworkManagerService {
         executor: ReamExecutor,
         config: ManagerConfig,
         ream_db: BeaconDB,
-        ream_dir: PathBuf,
+        ream_directory: PathBuf,
         beacon_chain: Arc<BeaconChain>,
         sync_committee_pool: Arc<SyncCommitteePool>,
         cached_db: Arc<BeaconCacheDB>,
@@ -88,7 +88,7 @@ impl NetworkManagerService {
         let network_config = NetworkConfig {
             discv5_config,
             gossipsub_config,
-            data_dir: ream_dir,
+            data_dir: ream_directory,
         };
 
         let (manager_sender, manager_receiver) = mpsc::unbounded_channel();

--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -69,6 +69,7 @@ use tracing::{error, info, trace, warn};
 
 use crate::{
     bootnodes::Bootnodes,
+    network::lean::LeanP2PRequest::{GossipBlock, GossipAttestation, GossipAggregatedAttestation, Request, Response, InvalidRequest, EndOfStream},
     gossipsub::{
         GossipsubBehaviour,
         lean::{
@@ -581,7 +582,7 @@ impl LeanNetworkService {
                 }
                 Some(item) = self.outbound_p2p_request.recv() => {
                     match item {
-                        LeanP2PRequest::GossipBlock(block) => {
+                        GossipBlock(block) => {
                             self.publish_gossip(
                                 |topic| matches!(topic, LeanGossipTopicKind::Block),
                                 block.as_ssz_bytes(),
@@ -589,7 +590,7 @@ impl LeanNetworkService {
                                 "block"
                             );
                         }
-                        LeanP2PRequest::GossipAttestation { subnet_id, attestation } => {
+                        GossipAttestation { subnet_id, attestation } => {
                             let slot = attestation.message.slot;
                             self.publish_gossip_to_subnet(
                                 subnet_id,
@@ -598,7 +599,7 @@ impl LeanNetworkService {
                                 "attestation"
                             );
                         }
-                        LeanP2PRequest::GossipAggregatedAttestation(aggregated) => {
+                        GossipAggregatedAttestation(aggregated) => {
                             let slot = aggregated.data.slot;
                             self.publish_gossip(
                                 |topic| matches!(topic, LeanGossipTopicKind::AggregatedAttestation),
@@ -607,7 +608,7 @@ impl LeanNetworkService {
                                 "aggregated_attestation"
                             );
                         }
-                        LeanP2PRequest::Request { peer_id, callback, message } => {
+                        Request { peer_id, callback, message } => {
                             let message = match message {
                                 P2PCallbackRequest::BlocksByRoot { roots } => {
                                     LeanRequestMessage::BlocksByRoot(BlocksByRootV1Request::new(roots))
@@ -627,13 +628,13 @@ impl LeanNetworkService {
                                 },
                             }
                         }
-                        LeanP2PRequest::Response { peer_id, stream_id, connection_id, message } => {
+                       Response { peer_id, stream_id, connection_id, message } => {
                             self.send_response(peer_id, connection_id, stream_id, message);
                         }
-                        LeanP2PRequest::InvalidRequest { peer_id, stream_id, connection_id, reason } => {
+                        InvalidRequest { peer_id, stream_id, connection_id, reason } => {
                             self.send_invalid_request(peer_id, connection_id, stream_id, reason);
                         }
-                        LeanP2PRequest::EndOfStream { peer_id, stream_id, connection_id } => {
+                        EndOfStream { peer_id, stream_id, connection_id } => {
                             self.send_end_of_stream(peer_id, connection_id, stream_id);
                         }
                     }
@@ -1392,7 +1393,10 @@ mod tests {
     use alloy_primitives::B256;
     use ream_consensus_lean::checkpoint::Checkpoint;
     use ream_network_spec::networks::initialize_lean_test_network_spec;
-    use tokio::sync::mpsc;
+    use tokio::{
+        sync::mpsc,
+        time::sleep,
+    };
     use tracing_test::traced_test;
 
     use super::*;
@@ -1459,14 +1463,14 @@ mod tests {
             node_1.start(bootnodes).await.unwrap();
         });
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(100)).await;
 
         let node_2_handle = tokio::spawn(async move {
             let bootnodes = Bootnodes::Multiaddr(vec![node_1_addr]);
             node_2.start(bootnodes).await.unwrap();
         });
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        sleep(Duration::from_secs(2)).await;
 
         node_1_handle.abort();
         node_2_handle.abort();
@@ -1515,23 +1519,23 @@ mod tests {
             node_1.start(bootnodes).await.unwrap();
         });
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(100)).await;
 
         let node_2_handle = tokio::spawn(async move {
             let bootnodes = Bootnodes::Multiaddr(vec![node_1_addr]);
             node_2.start(bootnodes).await.unwrap();
         });
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        sleep(Duration::from_secs(2)).await;
 
         let (callback, _) = mpsc::channel(5);
-        p2p_sender_1.send(LeanP2PRequest::Request {
+        p2p_sender_1.send(Request {
             peer_id: peer_id_2,
             callback,
             message: P2PCallbackRequest::Status,
         })?;
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1)).await;
 
         let peer_2_state = network_state_1
             .cached_peer(&peer_id_2)
@@ -1722,46 +1726,46 @@ mod tests {
     }
 
     fn test_multiaddr(peer_id: PeerId, port: u16) -> Multiaddr {
-        let mut addr: Multiaddr = Ipv4Addr::new(127, 0, 0, 1).into();
-        addr.push(Protocol::Udp(port));
-        addr.push(Protocol::QuicV1);
-        addr.push(Protocol::P2p(peer_id));
-        addr
+        let mut address: Multiaddr = Ipv4Addr::new(127, 0, 0, 1).into();
+        address.push(Protocol::Udp(port));
+        address.push(Protocol::QuicV1);
+        address.push(Protocol::P2p(peer_id));
+        address
     }
 
     #[test]
     fn test_dedupe_retry_addresses_preserves_first_occurrence() {
         let peer_id = PeerId::random();
-        let addr_1 = test_multiaddr(peer_id, 9004);
-        let addr_2 = test_multiaddr(peer_id, 9005);
+        let address_1 = test_multiaddr(peer_id, 9004);
+        let address_2 = test_multiaddr(peer_id, 9005);
         let mut addresses = vec![
-            addr_1.clone(),
-            addr_1.clone(),
-            addr_2.clone(),
-            addr_1.clone(),
-            addr_2.clone(),
+            address_1.clone(),
+            address_1.clone(),
+            address_2.clone(),
+            address_1.clone(),
+            address_2.clone(),
         ];
 
         dedupe_retry_addresses(&mut addresses);
 
-        assert_eq!(addresses, vec![addr_1, addr_2]);
+        assert_eq!(addresses, vec![address_1, address_2]);
     }
 
     #[test]
     fn test_bootnode_retry_rotates_across_unique_addresses() {
         let peer_id = PeerId::random();
-        let addr_1 = test_multiaddr(peer_id, 9004);
-        let addr_2 = test_multiaddr(peer_id, 9005);
+        let address_1 = test_multiaddr(peer_id, 9004);
+        let address_2 = test_multiaddr(peer_id, 9005);
         let mut retry_state = BootnodeRetry::default();
 
-        retry_state.record_address(addr_1.clone());
-        retry_state.record_address(addr_1.clone());
-        retry_state.record_address(addr_2.clone());
+        retry_state.record_address(address_1.clone());
+        retry_state.record_address(address_1.clone());
+        retry_state.record_address(address_2.clone());
 
-        assert_eq!(retry_state.next_address(), Some(addr_1.clone()));
-        assert_eq!(retry_state.next_address(), Some(addr_2.clone()));
-        assert_eq!(retry_state.next_address(), Some(addr_1));
-        assert_eq!(retry_state.next_address(), Some(addr_2));
+        assert_eq!(retry_state.next_address(), Some(address_1.clone()));
+        assert_eq!(retry_state.next_address(), Some(address_2.clone()));
+        assert_eq!(retry_state.next_address(), Some(address_1));
+        assert_eq!(retry_state.next_address(), Some(address_2));
     }
 
     #[test]

--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -69,7 +69,6 @@ use tracing::{error, info, trace, warn};
 
 use crate::{
     bootnodes::Bootnodes,
-    network::lean::LeanP2PRequest::{GossipBlock, GossipAttestation, GossipAggregatedAttestation, Request, Response, InvalidRequest, EndOfStream},
     gossipsub::{
         GossipsubBehaviour,
         lean::{
@@ -78,7 +77,13 @@ use crate::{
         },
         snappy::SnappyTransform,
     },
-    network::misc::Executor,
+    network::{
+        lean::LeanP2PRequest::{
+            EndOfStream, GossipAggregatedAttestation, GossipAttestation, GossipBlock,
+            InvalidRequest, Request, Response,
+        },
+        misc::Executor,
+    },
 };
 
 const BOOTNODE_RETRY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -1393,10 +1398,7 @@ mod tests {
     use alloy_primitives::B256;
     use ream_consensus_lean::checkpoint::Checkpoint;
     use ream_network_spec::networks::initialize_lean_test_network_spec;
-    use tokio::{
-        sync::mpsc,
-        time::sleep,
-    };
+    use tokio::{sync::mpsc, time::sleep};
     use tracing_test::traced_test;
 
     use super::*;

--- a/crates/networking/req_resp/src/beacon/messages/mod.rs
+++ b/crates/networking/req_resp/src/beacon/messages/mod.rs
@@ -106,7 +106,9 @@ impl BeaconRequestMessage {
             | BeaconRequestMessage::Status(_)
             | BeaconRequestMessage::Ping(_) => 1,
 
-            BeaconRequestMessage::BeaconBlocksByRange(request) => request.count.min(MAX_REQUEST_BLOCKS),
+            BeaconRequestMessage::BeaconBlocksByRange(request) => {
+                request.count.min(MAX_REQUEST_BLOCKS)
+            }
             BeaconRequestMessage::BeaconBlocksByRoot(request) => request.inner.len() as u64,
             BeaconRequestMessage::BlobSidecarsByRange(request) => {
                 (request.count * MAX_BLOBS_PER_BLOCK).min(MAX_REQUEST_BLOB_SIDECARS)

--- a/crates/networking/req_resp/src/beacon/messages/mod.rs
+++ b/crates/networking/req_resp/src/beacon/messages/mod.rs
@@ -106,19 +106,19 @@ impl BeaconRequestMessage {
             | BeaconRequestMessage::Status(_)
             | BeaconRequestMessage::Ping(_) => 1,
 
-            BeaconRequestMessage::BeaconBlocksByRange(req) => req.count.min(MAX_REQUEST_BLOCKS),
-            BeaconRequestMessage::BeaconBlocksByRoot(req) => req.inner.len() as u64,
-            BeaconRequestMessage::BlobSidecarsByRange(req) => {
-                (req.count * MAX_BLOBS_PER_BLOCK).min(MAX_REQUEST_BLOB_SIDECARS)
+            BeaconRequestMessage::BeaconBlocksByRange(request) => request.count.min(MAX_REQUEST_BLOCKS),
+            BeaconRequestMessage::BeaconBlocksByRoot(request) => request.inner.len() as u64,
+            BeaconRequestMessage::BlobSidecarsByRange(request) => {
+                (request.count * MAX_BLOBS_PER_BLOCK).min(MAX_REQUEST_BLOB_SIDECARS)
             }
-            BeaconRequestMessage::BlobSidecarsByRoot(req) => req.inner.len() as u64,
-            BeaconRequestMessage::DataColumnSidecarsByRange(req) => {
-                let num_columns = req.columns.len() as u64;
-                (req.count * num_columns)
+            BeaconRequestMessage::BlobSidecarsByRoot(request) => request.inner.len() as u64,
+            BeaconRequestMessage::DataColumnSidecarsByRange(request) => {
+                let num_columns = request.columns.len() as u64;
+                (request.count * num_columns)
                     .min(MAX_REQUEST_DATA_COLUMN_SIDECARS_PER_COLUMN * num_columns)
             }
-            BeaconRequestMessage::DataColumnSidecarsByRoot(req) => {
-                req.inner.iter().map(|id| id.columns.len() as u64).sum()
+            BeaconRequestMessage::DataColumnSidecarsByRoot(request) => {
+                request.inner.iter().map(|id| id.columns.len() as u64).sum()
             }
         }
     }

--- a/crates/networking/req_resp/src/lean/messages/mod.rs
+++ b/crates/networking/req_resp/src/lean/messages/mod.rs
@@ -44,8 +44,8 @@ impl LeanRequestMessage {
     pub fn max_response_chunks(&self) -> u64 {
         match self {
             LeanRequestMessage::Status(_) => 1,
-            LeanRequestMessage::BlocksByRoot(req) => req.roots.len() as u64,
-            LeanRequestMessage::BlocksByRange(req) => req.count,
+            LeanRequestMessage::BlocksByRoot(request) => request.roots.len() as u64,
+            LeanRequestMessage::BlocksByRange(request) => request.count,
         }
     }
 }

--- a/crates/rpc/lean/src/handlers/block.rs
+++ b/crates/rpc/lean/src/handlers/block.rs
@@ -135,7 +135,9 @@ mod tests {
     use ssz::Decode;
     use tree_hash::TreeHash;
 
-    use super::get_finalized_signed_block;
+    use crate::handlers::state::get_state;
+
+use super::get_finalized_signed_block;
 
     #[tokio::test]
     async fn test_get_finalized_signed_block_returns_ssz() {
@@ -149,19 +151,19 @@ mod tests {
         )
         .await;
 
-        let req = test::TestRequest::get()
+        let request = test::TestRequest::get()
             .uri("/blocks/finalized")
             .insert_header(("Accept", "application/octet-stream"))
             .to_request();
 
-        let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            resp.headers().get("content-type").unwrap(),
+            response.headers().get("content-type").unwrap(),
             "application/octet-stream"
         );
 
-        let body = test::read_body(resp).await;
+        let body = test::read_body(response).await;
         SignedBlock::from_ssz_bytes(&body).expect("Failed to decode SSZ SignedBlock");
     }
 
@@ -177,18 +179,18 @@ mod tests {
         )
         .await;
 
-        let req = test::TestRequest::get()
+        let request = test::TestRequest::get()
             .uri("/blocks/finalized")
             .to_request();
 
-        let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            resp.headers().get("content-type").unwrap(),
+            response.headers().get("content-type").unwrap(),
             "application/octet-stream"
         );
 
-        let body = test::read_body(resp).await;
+        let body = test::read_body(response).await;
         SignedBlock::from_ssz_bytes(&body).expect("Failed to decode SSZ SignedBlock");
     }
 
@@ -204,19 +206,19 @@ mod tests {
         )
         .await;
 
-        let req = test::TestRequest::get()
+        let request = test::TestRequest::get()
             .uri("/blocks/finalized")
             .insert_header(("Accept", "application/json"))
             .to_request();
 
-        let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            resp.headers().get("content-type").unwrap(),
+            response.headers().get("content-type").unwrap(),
             "application/json"
         );
 
-        let body = test::read_body(resp).await;
+        let body = test::read_body(response).await;
         serde_json::from_slice::<serde_json::Value>(&body).expect("Failed to decode JSON block");
     }
 
@@ -224,8 +226,6 @@ mod tests {
     async fn test_finalized_signed_block_state_root_matches_finalized_state() {
         // Protocol invariant required by `Store::get_forkchoice_store`:
         // `anchor_block.state_root == hash_tree_root(state)`.
-        use crate::handlers::state::get_state;
-
         let store = sample_store(10).await;
         let (_writer, reader) = Writer::new(store);
 
@@ -237,21 +237,21 @@ mod tests {
         )
         .await;
 
-        let block_req = test::TestRequest::get()
+        let block_request = test::TestRequest::get()
             .uri("/blocks/finalized")
             .insert_header(("Accept", "application/octet-stream"))
             .to_request();
-        let block_resp = test::call_service(&app, block_req).await;
-        let block_body = test::read_body(block_resp).await;
+        let block_response = test::call_service(&app, block_request).await;
+        let block_body = test::read_body(block_response).await;
         let signed_block =
             SignedBlock::from_ssz_bytes(&block_body).expect("Failed to decode SignedBlock");
 
-        let state_req = test::TestRequest::get()
+        let state_request = test::TestRequest::get()
             .uri("/states/finalized")
             .insert_header(("Accept", "application/octet-stream"))
             .to_request();
-        let state_resp = test::call_service(&app, state_req).await;
-        let state_body = test::read_body(state_resp).await;
+        let state_response = test::call_service(&app, state_request).await;
+        let state_body = test::read_body(state_response).await;
         let state = LeanState::from_ssz_bytes(&state_body).expect("Failed to decode LeanState");
 
         assert_eq!(signed_block.block.state_root, state.tree_hash_root());

--- a/crates/rpc/lean/src/handlers/block.rs
+++ b/crates/rpc/lean/src/handlers/block.rs
@@ -135,9 +135,8 @@ mod tests {
     use ssz::Decode;
     use tree_hash::TreeHash;
 
+    use super::get_finalized_signed_block;
     use crate::handlers::state::get_state;
-
-use super::get_finalized_signed_block;
 
     #[tokio::test]
     async fn test_get_finalized_signed_block_returns_ssz() {

--- a/crates/rpc/lean/src/handlers/checkpoint.rs
+++ b/crates/rpc/lean/src/handlers/checkpoint.rs
@@ -51,7 +51,8 @@ mod tests {
         let response = test::call_service(&app, request).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert!(
-            response.headers()
+            response
+                .headers()
                 .get("content-type")
                 .unwrap()
                 .to_str()

--- a/crates/rpc/lean/src/handlers/checkpoint.rs
+++ b/crates/rpc/lean/src/handlers/checkpoint.rs
@@ -44,14 +44,14 @@ mod tests {
         )
         .await;
 
-        let req = test::TestRequest::get()
+        let request = test::TestRequest::get()
             .uri("/checkpoints/justified")
             .to_request();
 
-        let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
         assert!(
-            resp.headers()
+            response.headers()
                 .get("content-type")
                 .unwrap()
                 .to_str()
@@ -59,7 +59,7 @@ mod tests {
                 .contains("application/json")
         );
 
-        let body = test::read_body(resp).await;
+        let body = test::read_body(response).await;
         let checkpoint: Checkpoint = serde_json::from_slice(&body).expect("Failed to decode JSON");
         assert_eq!(checkpoint.slot, 0);
     }

--- a/crates/rpc/lean/src/handlers/state.rs
+++ b/crates/rpc/lean/src/handlers/state.rs
@@ -105,19 +105,19 @@ mod tests {
         let app =
             test::init_service(App::new().app_data(Data::new(reader)).service(get_state)).await;
 
-        let req = test::TestRequest::get()
+        let request = test::TestRequest::get()
             .uri("/states/finalized")
             .insert_header(("Accept", "application/octet-stream"))
             .to_request();
 
-        let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            resp.headers().get("content-type").unwrap(),
+            response.headers().get("content-type").unwrap(),
             "application/octet-stream"
         );
 
-        let body = test::read_body(resp).await;
+        let body = test::read_body(response).await;
         let state = LeanState::from_ssz_bytes(&body).expect("Failed to decode SSZ");
         assert!(!state.validators.is_empty());
     }
@@ -130,15 +130,15 @@ mod tests {
         let app =
             test::init_service(App::new().app_data(Data::new(reader)).service(get_state)).await;
 
-        let req = test::TestRequest::get()
+        let request = test::TestRequest::get()
             .uri("/states/finalized")
             .insert_header(("Accept", "application/json"))
             .to_request();
 
-        let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
         assert!(
-            resp.headers()
+            response.headers()
                 .get("content-type")
                 .unwrap()
                 .to_str()
@@ -155,14 +155,14 @@ mod tests {
         let app =
             test::init_service(App::new().app_data(Data::new(reader)).service(get_state)).await;
 
-        let req = test::TestRequest::get()
+        let request = test::TestRequest::get()
             .uri("/states/finalized")
             .to_request();
 
-        let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
         assert!(
-            resp.headers()
+            response.headers()
                 .get("content-type")
                 .unwrap()
                 .to_str()

--- a/crates/rpc/lean/src/handlers/state.rs
+++ b/crates/rpc/lean/src/handlers/state.rs
@@ -138,7 +138,8 @@ mod tests {
         let response = test::call_service(&app, request).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert!(
-            response.headers()
+            response
+                .headers()
                 .get("content-type")
                 .unwrap()
                 .to_str()
@@ -162,7 +163,8 @@ mod tests {
         let response = test::call_service(&app, request).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert!(
-            response.headers()
+            response
+                .headers()
                 .get("content-type")
                 .unwrap()
                 .to_str()

--- a/crates/rpc/lean/src/handlers/test_driver.rs
+++ b/crates/rpc/lean/src/handlers/test_driver.rs
@@ -188,9 +188,9 @@ fn driver_error(context: impl Into<String>, err: impl Display) -> ApiError {
 }
 
 fn new_test_db() -> Result<ream_storage::db::lean::LeanDB, ApiError> {
-    let dir = setup_data_dir("hive_lean_test_driver", None, true)
-        .map_err(|err| driver_error("failed to create test-driver data dir", err))?;
-    ReamDB::new(dir)
+    let directory = setup_data_dir("hive_lean_test_driver", None, true)
+        .map_err(|err| driver_error("failed to create test-driver data directory", err))?;
+    ReamDB::new(directory)
         .map_err(|err| driver_error("failed to create test-driver ReamDB", err))?
         .init_lean_db()
         .map_err(|err| driver_error("failed to initialize test-driver LeanDB", err))

--- a/testing/ef-tests/src/macros/fork_choice.rs
+++ b/testing/ef-tests/src/macros/fork_choice.rs
@@ -130,9 +130,9 @@ macro_rules! test_fork_choice {
                             utils::read_ssz_snappy(&case_dir.join("anchor_block.ssz_snappy"))
                                 .expect("Failed to read anchor_block.ssz_snappy");
 
-                        let ream_dir = setup_data_dir("ream", None, true).expect("Failed to create data dir");
+                        let ream_directory = setup_data_dir("ream", None, true).expect("Failed to create data directory");
 
-                        let ream_db = ReamDB::new(ream_dir).expect("unable to init Ream Database");
+                        let ream_db = ReamDB::new(ream_directory).expect("unable to init Ream Database");
                         let beacon_db = ream_db.init_beacon_db().expect("count not find reabdb");
                         let mut store = get_forkchoice_store(anchor_state, anchor_block, beacon_db)
                             .expect("get_forkchoice_store failed");


### PR DESCRIPTION
### What was wrong?

fixed abbreviations and imports in functions 
