### PR TITLE
fix: clippy useless_conversion errors from Rust 1.95 toolchain bump

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1229,11 +1229,7 @@ impl Store {
                 for (key, _) in latest_new_aggregated_payloads_provider
                     .iter()?
                     .into_iter()
-                    .chain(
-                        latest_known_aggregated_payloads_provider
-                            .iter()?
-                            .into_iter(),
-                    )
+                    .chain(latest_known_aggregated_payloads_provider.iter()?)
                 {
                     if key.validator_id != validator || key.data_root == data_root {
                         continue;
@@ -1632,7 +1628,7 @@ fn compact_aggregated_proofs(
     let mut out_attestations = Vec::with_capacity(order.len());
     let mut out_proofs = Vec::with_capacity(order.len());
 
-    for (data, indices) in order.into_iter().zip(groups.into_iter()) {
+    for (data, indices) in order.into_iter().zip(groups) {
         if let [single_index] = indices.as_slice() {
             out_attestations.push(
                 remaining_attestations


### PR DESCRIPTION
## Summary

Rust 1.95.0 tightened `clippy::useless_conversion` to flag explicit `.into_iter()` calls on values already being passed into functions that accept `IntoIterator` (e.g. `Iterator::chain`, `Iterator::zip`). The CI runs clippy under `-D warnings`, so these were silently warnings on a previous toolchain and are now hard errors after the latest stable bump pulled into `dtolnay/rust-toolchain@stable`.

This affects two pre-existing sites in `crates/common/fork_choice/lean/src/store.rs`:

- `store.rs:1233-1235` — `.into_iter()` inside `.chain(...)` (introduced in `2fd18f5`)
- `store.rs:1635` — `groups.into_iter()` inside `.zip(...)` (introduced in `3fc4024`)

The first commit in this PR is intentionally empty — it's there so CI can demonstrate the failure on a clean branch off `master`. The follow-up commit applies clippy's suggested fix in both spots.

## Test plan

- [ ] First CI run (empty commit) reproduces the `cargo-clippy` failure with the two `useless_conversion` errors in `store.rs`.
- [ ] Second CI run (fix commit) passes `cargo-clippy`.
- [ ] Local: `cargo clippy -p ream-fork-choice-lean --all-targets -- -D warnings` passes.