### PR TITLE
feat: implement block production and gossip metrics

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -19,7 +19,8 @@ use ream_consensus_lean::{
 use ream_consensus_misc::constants::lean::{INTERVALS_PER_SLOT, attestation_committee_count};
 use ream_fork_choice_lean::store::LeanStoreWriter;
 use ream_metrics::{
-    ATTESTATION_COMMITTEE_COUNT as ATTESTATION_COMMITTEE_COUNT_METRIC, CURRENT_SLOT, IS_AGGREGATOR,
+    ATTESTATION_COMMITTEE_COUNT as ATTESTATION_COMMITTEE_COUNT_METRIC,
+    BLOCK_BUILDING_FAILURES_TOTAL, CURRENT_SLOT, IS_AGGREGATOR, inc_int_counter_vec,
     set_int_gauge_vec,
 };
 use ream_network_spec::networks::lean_network_spec;
@@ -2593,6 +2594,7 @@ impl LeanChainService {
             Ok(block) => block,
             Err(err) => {
                 warn!("Failed to produce block for slot {slot}: {err}");
+                inc_int_counter_vec(&BLOCK_BUILDING_FAILURES_TOTAL, &[]);
                 if let Err(err) = response.send(ServiceResponse::Err(err)) {
                     warn!("Failed to send error response for ProduceBlock: {err:?}");
                 }

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -25,17 +25,16 @@ use ream_metrics::{
     ATTESTATION_COMMITTEE_SUBNET, ATTESTATION_VALIDATION_TIME, ATTESTATIONS_INVALID_TOTAL,
     ATTESTATIONS_VALID_TOTAL, BLOCK_AGGREGATED_PAYLOADS, BLOCK_BUILDING_PAYLOAD_AGGREGATION_TIME,
     BLOCK_BUILDING_SUCCESS_TOTAL, BLOCK_BUILDING_TIME, COMMITTEE_SIGNATURES_AGGREGATION_TIME,
-    FINALIZATIONS_TOTAL, FINALIZED_SLOT, FORK_CHOICE_BLOCK_PROCESSING_TIME,
-    FORK_CHOICE_REORG_DEPTH, FORK_CHOICE_REORGS_TOTAL, GOSSIP_SIGNATURES, HEAD_SLOT,
-    JUSTIFIED_SLOT, LATEST_FINALIZED_SLOT, LATEST_JUSTIFIED_SLOT, LATEST_KNOWN_AGGREGATED_PAYLOADS,
-    LATEST_NEW_AGGREGATED_PAYLOADS, LEAN_TICK_INTERVAL_DURATION_SECONDS,
-    PQ_SIG_AGGREGATED_SIGNATURES_BUILDING_TIME, PQ_SIG_AGGREGATED_SIGNATURES_INVALID_TOTAL,
-    PQ_SIG_AGGREGATED_SIGNATURES_TOTAL, PQ_SIG_AGGREGATED_SIGNATURES_VALID_TOTAL,
-    PQ_SIG_AGGREGATED_SIGNATURES_VERIFICATION_TIME, PQ_SIG_ATTESTATION_SIGNATURES_INVALID_TOTAL,
-    PQ_SIG_ATTESTATION_SIGNATURES_VALID_TOTAL, PQ_SIG_ATTESTATION_VERIFICATION_TIME,
-    PQ_SIG_ATTESTATIONS_IN_AGGREGATED_SIGNATURES_TOTAL, PROPOSE_BLOCK_TIME, SAFE_TARGET_SLOT,
-    inc_int_counter_vec, inc_int_counter_vec_by, observe_histogram_vec, set_int_gauge_vec,
-    start_timer, stop_timer,
+    FINALIZATIONS_TOTAL, FINALIZED_SLOT, FORK_CHOICE_BLOCK_PROCESSING_TIME, GOSSIP_SIGNATURES,
+    HEAD_SLOT, JUSTIFIED_SLOT, LATEST_FINALIZED_SLOT, LATEST_JUSTIFIED_SLOT,
+    LATEST_KNOWN_AGGREGATED_PAYLOADS, LATEST_NEW_AGGREGATED_PAYLOADS,
+    LEAN_TICK_INTERVAL_DURATION_SECONDS, PQ_SIG_AGGREGATED_SIGNATURES_BUILDING_TIME,
+    PQ_SIG_AGGREGATED_SIGNATURES_INVALID_TOTAL, PQ_SIG_AGGREGATED_SIGNATURES_TOTAL,
+    PQ_SIG_AGGREGATED_SIGNATURES_VALID_TOTAL, PQ_SIG_AGGREGATED_SIGNATURES_VERIFICATION_TIME,
+    PQ_SIG_ATTESTATION_SIGNATURES_INVALID_TOTAL, PQ_SIG_ATTESTATION_SIGNATURES_VALID_TOTAL,
+    PQ_SIG_ATTESTATION_VERIFICATION_TIME, PQ_SIG_ATTESTATIONS_IN_AGGREGATED_SIGNATURES_TOTAL,
+    PROPOSE_BLOCK_TIME, SAFE_TARGET_SLOT, inc_int_counter_vec, inc_int_counter_vec_by,
+    observe_histogram_vec, set_int_gauge_vec, start_timer, stop_timer,
 };
 use ream_network_spec::networks::lean_network_spec;
 use ream_network_state_lean::NetworkState;
@@ -394,22 +393,14 @@ impl Store {
 
     /// Done upon processing new attestations or a new block
     pub async fn update_head(&self) -> anyhow::Result<()> {
-        let (
-            latest_justified_provider,
-            head_provider,
-            latest_known_aggregated_payloads_provider,
-            block_provider,
-        ) = {
+        let (latest_justified_provider, head_provider, latest_known_aggregated_payloads_provider) = {
             let db = self.store.lock().await;
             (
                 db.latest_justified_provider(),
                 db.head_provider(),
                 db.latest_known_aggregated_payloads_provider(),
-                db.block_provider(),
             )
         };
-
-        let old_head = head_provider.get()?;
 
         let attestations = {
             let entries = latest_known_aggregated_payloads_provider.iter()?;
@@ -434,27 +425,6 @@ impl Store {
                 0,
             )
             .await?;
-
-        // Detect fork-choice reorgs: a reorg occurs when the old head is not
-        // an ancestor of the new head (i.e., the canonical chain switched branches).
-        if new_head != old_head {
-            let mut is_forward_progress = false;
-            let mut current = new_head;
-            for _ in 0..100u64 {
-                if current == old_head {
-                    is_forward_progress = true;
-                    break;
-                }
-                match block_provider.get(current)? {
-                    Some(block) => current = block.block.parent_root,
-                    None => break,
-                }
-            }
-            if !is_forward_progress {
-                inc_int_counter_vec(&FORK_CHOICE_REORGS_TOTAL, &[]);
-                FORK_CHOICE_REORG_DEPTH.with_label_values(&[]).observe(1.0);
-            }
-        }
 
         set_int_gauge_vec(&HEAD_SLOT, new_head_slot as i64, &[]);
         *self.network_state.head_checkpoint.write() = Checkpoint {

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -23,15 +23,19 @@ use ream_consensus_misc::constants::lean::{
 };
 use ream_metrics::{
     ATTESTATION_COMMITTEE_SUBNET, ATTESTATION_VALIDATION_TIME, ATTESTATIONS_INVALID_TOTAL,
-    ATTESTATIONS_VALID_TOTAL, FINALIZATIONS_TOTAL, FINALIZED_SLOT,
-    FORK_CHOICE_BLOCK_PROCESSING_TIME, HEAD_SLOT, JUSTIFIED_SLOT, LATEST_FINALIZED_SLOT,
-    LATEST_JUSTIFIED_SLOT, LATEST_KNOWN_AGGREGATED_PAYLOADS, LATEST_NEW_AGGREGATED_PAYLOADS,
-    LEAN_TICK_INTERVAL_DURATION_SECONDS, PQ_SIG_AGGREGATED_SIGNATURES_BUILDING_TIME,
-    PQ_SIG_AGGREGATED_SIGNATURES_INVALID_TOTAL, PQ_SIG_AGGREGATED_SIGNATURES_TOTAL,
-    PQ_SIG_AGGREGATED_SIGNATURES_VALID_TOTAL, PQ_SIG_AGGREGATED_SIGNATURES_VERIFICATION_TIME,
-    PQ_SIG_ATTESTATION_SIGNATURES_INVALID_TOTAL, PQ_SIG_ATTESTATION_SIGNATURES_VALID_TOTAL,
-    PQ_SIG_ATTESTATION_VERIFICATION_TIME, PROPOSE_BLOCK_TIME, SAFE_TARGET_SLOT,
-    inc_int_counter_vec, set_int_gauge_vec, start_timer, stop_timer,
+    ATTESTATIONS_VALID_TOTAL, BLOCK_AGGREGATED_PAYLOADS, BLOCK_BUILDING_PAYLOAD_AGGREGATION_TIME,
+    BLOCK_BUILDING_SUCCESS_TOTAL, BLOCK_BUILDING_TIME, COMMITTEE_SIGNATURES_AGGREGATION_TIME,
+    FINALIZATIONS_TOTAL, FINALIZED_SLOT, FORK_CHOICE_BLOCK_PROCESSING_TIME,
+    FORK_CHOICE_REORG_DEPTH, FORK_CHOICE_REORGS_TOTAL, GOSSIP_SIGNATURES, HEAD_SLOT,
+    JUSTIFIED_SLOT, LATEST_FINALIZED_SLOT, LATEST_JUSTIFIED_SLOT, LATEST_KNOWN_AGGREGATED_PAYLOADS,
+    LATEST_NEW_AGGREGATED_PAYLOADS, LEAN_TICK_INTERVAL_DURATION_SECONDS,
+    PQ_SIG_AGGREGATED_SIGNATURES_BUILDING_TIME, PQ_SIG_AGGREGATED_SIGNATURES_INVALID_TOTAL,
+    PQ_SIG_AGGREGATED_SIGNATURES_TOTAL, PQ_SIG_AGGREGATED_SIGNATURES_VALID_TOTAL,
+    PQ_SIG_AGGREGATED_SIGNATURES_VERIFICATION_TIME, PQ_SIG_ATTESTATION_SIGNATURES_INVALID_TOTAL,
+    PQ_SIG_ATTESTATION_SIGNATURES_VALID_TOTAL, PQ_SIG_ATTESTATION_VERIFICATION_TIME,
+    PQ_SIG_ATTESTATIONS_IN_AGGREGATED_SIGNATURES_TOTAL, PROPOSE_BLOCK_TIME, SAFE_TARGET_SLOT,
+    inc_int_counter_vec, inc_int_counter_vec_by, observe_histogram_vec, set_int_gauge_vec,
+    start_timer, stop_timer,
 };
 use ream_network_spec::networks::lean_network_spec;
 use ream_network_state_lean::NetworkState;
@@ -390,14 +394,22 @@ impl Store {
 
     /// Done upon processing new attestations or a new block
     pub async fn update_head(&self) -> anyhow::Result<()> {
-        let (latest_justified_provider, head_provider, latest_known_aggregated_payloads_provider) = {
+        let (
+            latest_justified_provider,
+            head_provider,
+            latest_known_aggregated_payloads_provider,
+            block_provider,
+        ) = {
             let db = self.store.lock().await;
             (
                 db.latest_justified_provider(),
                 db.head_provider(),
                 db.latest_known_aggregated_payloads_provider(),
+                db.block_provider(),
             )
         };
+
+        let old_head = head_provider.get()?;
 
         let attestations = {
             let entries = latest_known_aggregated_payloads_provider.iter()?;
@@ -422,6 +434,27 @@ impl Store {
                 0,
             )
             .await?;
+
+        // Detect fork-choice reorgs: a reorg occurs when the old head is not
+        // an ancestor of the new head (i.e., the canonical chain switched branches).
+        if new_head != old_head {
+            let mut is_forward_progress = false;
+            let mut current = new_head;
+            for _ in 0..100u64 {
+                if current == old_head {
+                    is_forward_progress = true;
+                    break;
+                }
+                match block_provider.get(current)? {
+                    Some(block) => current = block.block.parent_root,
+                    None => break,
+                }
+            }
+            if !is_forward_progress {
+                inc_int_counter_vec(&FORK_CHOICE_REORGS_TOTAL, &[]);
+                FORK_CHOICE_REORG_DEPTH.with_label_values(&[]).observe(1.0);
+            }
+        }
 
         set_int_gauge_vec(&HEAD_SLOT, new_head_slot as i64, &[]);
         *self.network_state.head_checkpoint.write() = Checkpoint {
@@ -621,6 +654,11 @@ impl Store {
             stop_timer(building_timer);
             let aggregated_signature = aggregated_signature_bytes?;
             inc_int_counter_vec(&PQ_SIG_AGGREGATED_SIGNATURES_TOTAL, &[]);
+            inc_int_counter_vec_by(
+                &PQ_SIG_ATTESTATIONS_IN_AGGREGATED_SIGNATURES_TOTAL,
+                raw_entries.len() as u64,
+                &[],
+            );
 
             let proof = AggregatedSignatureProof {
                 participants: bits.clone(),
@@ -919,6 +957,7 @@ impl Store {
 
         let attestations_vec: Vec<_> = attestations.to_vec();
 
+        let payload_aggregation_timer = start_timer(&BLOCK_BUILDING_PAYLOAD_AGGREGATION_TIME, &[]);
         let (aggregated_attestations, aggregated_proofs) =
             self.select_aggregated_proofs(&attestations_vec).await?;
 
@@ -927,6 +966,12 @@ impl Store {
             aggregated_proofs,
             &head_state.validators,
         )?;
+        stop_timer(payload_aggregation_timer);
+        observe_histogram_vec(
+            &BLOCK_AGGREGATED_PAYLOADS,
+            aggregated_proofs.len() as f64,
+            &[],
+        );
 
         let attestations_list =
             VariableList::new(aggregated_attestations).map_err(|err| anyhow!("{err:?}"))?;
@@ -973,6 +1018,7 @@ impl Store {
         };
 
         let head_root = self.get_proposal_head(slot).await?;
+        let building_timer = start_timer(&BLOCK_BUILDING_TIME, &[]);
         let initialize_block_timer = start_timer(&PROPOSE_BLOCK_TIME, &["initialize_block"]);
 
         let head_state = state_provider
@@ -1031,6 +1077,9 @@ impl Store {
         if finalized_advanced {
             self.prune_stale_attestation_data().await?;
         }
+
+        stop_timer(building_timer);
+        inc_int_counter_vec(&BLOCK_BUILDING_SUCCESS_TOTAL, &[]);
 
         Ok(BlockWithSignatures {
             block: candidate_block,
@@ -1168,7 +1217,7 @@ impl Store {
         &self,
         signed_attestation: &SignedAttestation,
     ) -> anyhow::Result<()> {
-        let _timer = start_timer(&ATTESTATION_VALIDATION_TIME, &[]);
+        let timer = start_timer(&ATTESTATION_VALIDATION_TIME, &[]);
         let data = &signed_attestation.message;
 
         let (block_provider, time_provider) = {
@@ -1231,6 +1280,7 @@ impl Store {
             "Attestation too far in future"
         );
 
+        stop_timer(timer);
         Ok(())
     }
 
@@ -1413,8 +1463,11 @@ impl Store {
             .get(head_root)?
             .ok_or_else(|| anyhow!("Head state not found"))?;
 
+        let signature_keys = attestation_signatures_provider.get_keys()?;
+        set_int_gauge_vec(&GOSSIP_SIGNATURES, signature_keys.len() as i64, &[]);
+
         let mut attestation_signatures = Vec::new();
-        for signature_key in attestation_signatures_provider.get_keys()? {
+        for signature_key in signature_keys {
             if let Some(attestation_data) =
                 attestation_data_by_root_provider.get(signature_key.data_root)?
             {
@@ -1451,6 +1504,7 @@ impl Store {
             }
         }
 
+        let aggregation_timer = start_timer(&COMMITTEE_SIGNATURES_AGGREGATION_TIME, &[]);
         let signed_attestations = self.state_aggregate(
             &head_state,
             &attestation_signatures,
@@ -1459,6 +1513,7 @@ impl Store {
             Some(&known_payloads),
             true,
         )?;
+        stop_timer(aggregation_timer);
 
         let mut aggregated_data_roots = HashSet::new();
         let mut next_new_payloads: HashMap<SignatureKey, Vec<AggregatedSignatureProof>> =

--- a/crates/common/metrics/src/lib.rs
+++ b/crates/common/metrics/src/lib.rs
@@ -386,6 +386,107 @@ lazy_static::lazy_static! {
         ).expect("failed to create COMMITTEE_SIGNATURES_AGGREGATION_TIME histogram vec")
     };
 
+    // Block Production Metrics
+    pub static ref BLOCK_AGGREGATED_PAYLOADS: HistogramVec = {
+        let opts = HistogramOpts::new(
+            "lean_block_aggregated_payloads",
+            "Number of aggregated_payloads in a block"
+        ).buckets(vec![1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0]);
+        register_histogram_vec_with_registry!(
+            opts,
+            &[],
+            default_registry()
+        ).expect("failed to create BLOCK_AGGREGATED_PAYLOADS histogram vec")
+    };
+
+    pub static ref BLOCK_BUILDING_PAYLOAD_AGGREGATION_TIME: HistogramVec = {
+        let opts = HistogramOpts::new(
+            "lean_block_building_payload_aggregation_time_seconds",
+            "Time taken to build aggregated_payloads during block building"
+        ).buckets(vec![0.1, 0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0]);
+        register_histogram_vec_with_registry!(
+            opts,
+            &[],
+            default_registry()
+        ).expect("failed to create BLOCK_BUILDING_PAYLOAD_AGGREGATION_TIME histogram vec")
+    };
+
+    pub static ref BLOCK_BUILDING_TIME: HistogramVec = {
+        let opts = HistogramOpts::new(
+            "lean_block_building_time_seconds",
+            "Time taken to build a block"
+        ).buckets(vec![0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0]);
+        register_histogram_vec_with_registry!(
+            opts,
+            &[],
+            default_registry()
+        ).expect("failed to create BLOCK_BUILDING_TIME histogram vec")
+    };
+
+    pub static ref BLOCK_BUILDING_SUCCESS_TOTAL: IntCounterVec = register_int_counter_vec_with_registry!(
+        "lean_block_building_success_total",
+        "Successful block builds",
+        &[],
+        default_registry()
+    ).expect("failed to create BLOCK_BUILDING_SUCCESS_TOTAL int counter vec");
+
+    pub static ref BLOCK_BUILDING_FAILURES_TOTAL: IntCounterVec = register_int_counter_vec_with_registry!(
+        "lean_block_building_failures_total",
+        "Failed block builds",
+        &[],
+        default_registry()
+    ).expect("failed to create BLOCK_BUILDING_FAILURES_TOTAL int counter vec");
+
+    // Gossip Message Size Metrics
+    pub static ref GOSSIP_BLOCK_SIZE_BYTES: HistogramVec = {
+        let opts = HistogramOpts::new(
+            "lean_gossip_block_size_bytes",
+            "Bytes size of a gossip block message"
+        ).buckets(vec![10000.0, 50000.0, 100000.0, 250000.0, 500000.0, 1000000.0, 2000000.0, 5000000.0]);
+        register_histogram_vec_with_registry!(
+            opts,
+            &[],
+            default_registry()
+        ).expect("failed to create GOSSIP_BLOCK_SIZE_BYTES histogram vec")
+    };
+
+    pub static ref GOSSIP_ATTESTATION_SIZE_BYTES: HistogramVec = {
+        let opts = HistogramOpts::new(
+            "lean_gossip_attestation_size_bytes",
+            "Bytes size of a gossip attestation message"
+        ).buckets(vec![512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0]);
+        register_histogram_vec_with_registry!(
+            opts,
+            &[],
+            default_registry()
+        ).expect("failed to create GOSSIP_ATTESTATION_SIZE_BYTES histogram vec")
+    };
+
+    pub static ref GOSSIP_AGGREGATION_SIZE_BYTES: HistogramVec = {
+        let opts = HistogramOpts::new(
+            "lean_gossip_aggregation_size_bytes",
+            "Bytes size of a gossip aggregated attestation message"
+        ).buckets(vec![1024.0, 4096.0, 16384.0, 65536.0, 131072.0, 262144.0, 524288.0, 1048576.0]);
+        register_histogram_vec_with_registry!(
+            opts,
+            &[],
+            default_registry()
+        ).expect("failed to create GOSSIP_AGGREGATION_SIZE_BYTES histogram vec")
+    };
+
+    // Validator Attestation Production Metrics
+    pub static ref ATTESTATIONS_PRODUCTION_TIME: HistogramVec = {
+        let opts = HistogramOpts::new(
+            "lean_attestations_production_time_seconds",
+            "Time taken to produce attestation"
+        ).buckets(vec![0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0]);
+        register_histogram_vec_with_registry!(
+            opts,
+            &[],
+            default_registry()
+        ).expect("failed to create ATTESTATIONS_PRODUCTION_TIME histogram vec")
+    };
+
     // State Transition Additional Metrics
     pub static ref IS_AGGREGATOR: IntGaugeVec = register_int_gauge_vec_with_registry!(
         "lean_is_aggregator",
@@ -446,4 +547,14 @@ pub fn stop_timer_discard_on_drop(timer: DiscardOnDropHistogramTimer) {
 /// Increment a counter metric
 pub fn inc_int_counter_vec(counter_vec: &IntCounterVec, label_values: &[&str]) {
     counter_vec.with_label_values(label_values).inc();
+}
+
+/// Increment a counter metric by a given amount
+pub fn inc_int_counter_vec_by(counter_vec: &IntCounterVec, amount: u64, label_values: &[&str]) {
+    counter_vec.with_label_values(label_values).inc_by(amount);
+}
+
+/// Observe a value on a histogram metric
+pub fn observe_histogram_vec(histogram_vec: &HistogramVec, value: f64, label_values: &[&str]) {
+    histogram_vec.with_label_values(label_values).observe(value);
 }

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -11,8 +11,9 @@ use ream_consensus_misc::constants::lean::{INTERVALS_PER_SLOT, attestation_commi
 use ream_fork_choice_lean::store::compute_subnet_id;
 use ream_keystore::lean_keystore::ValidatorKeystore;
 use ream_metrics::{
-    PQ_SIG_ATTESTATION_SIGNATURES_TOTAL, PQ_SIG_ATTESTATION_SIGNING_TIME, VALIDATORS_COUNT,
-    inc_int_counter_vec, set_int_gauge_vec, start_timer, stop_timer,
+    ATTESTATIONS_PRODUCTION_TIME, PQ_SIG_ATTESTATION_SIGNATURES_TOTAL,
+    PQ_SIG_ATTESTATION_SIGNING_TIME, VALIDATORS_COUNT, inc_int_counter_vec, set_int_gauge_vec,
+    start_timer, stop_timer,
 };
 use ream_network_spec::networks::lean_network_spec;
 use tokio::sync::{mpsc, oneshot};
@@ -126,6 +127,8 @@ impl ValidatorService {
                             // Second tick (t=1/4): Attestation.
                             info!(slot, tick = tick_count, "Starting attestation phase: {} validator(s) voting", self.keystores.len());
 
+                            let attestation_production_timer =
+                                start_timer(&ATTESTATIONS_PRODUCTION_TIME, &[]);
                             let (tx, rx) = oneshot::channel();
                             self.chain_sender
                                 .send(LeanChainServiceMessage::BuildAttestationData { slot, sender: tx })
@@ -188,6 +191,7 @@ impl ValidatorService {
                                     .send(LeanChainServiceMessage::ProcessAttestation { signed_attestation: Box::new(signed_attestation), subnet_id, need_gossip: true })
                                     .map_err(|err| anyhow!("Failed to send attestation to LeanChainService: {err:?}"))?;
                             }
+                            stop_timer(attestation_production_timer);
                         }
                         _ => {
                             // Other ticks (t=2/4, t=3/4): Do nothing.

--- a/crates/networking/p2p/src/network/lean/mod.rs
+++ b/crates/networking/p2p/src/network/lean/mod.rs
@@ -40,8 +40,9 @@ use ream_chain_lean::{
 };
 use ream_executor::ReamExecutor;
 use ream_metrics::{
+    GOSSIP_AGGREGATION_SIZE_BYTES, GOSSIP_ATTESTATION_SIZE_BYTES, GOSSIP_BLOCK_SIZE_BYTES,
     LEAN_CONNECTION_EVENT_TOTAL, LEAN_DISCONNECTION_EVENT_TOTAL, LEAN_GOSSIP_MESH_PEERS,
-    LEAN_PEER_COUNT, inc_int_counter_vec, set_int_gauge_vec,
+    LEAN_PEER_COUNT, inc_int_counter_vec, observe_histogram_vec, set_int_gauge_vec,
 };
 use ream_network_state_lean::{NetworkState, cached_peer::CachedPeer};
 use ream_peer::{ConnectionState, Direction};
@@ -879,6 +880,11 @@ impl LeanNetworkService {
             GossipsubEvent::Message { message, .. } => {
                 match LeanGossipsubMessage::decode(&message.topic, &message.data) {
                     Ok(LeanGossipsubMessage::Block(signed_block)) => {
+                        observe_histogram_vec(
+                            &GOSSIP_BLOCK_SIZE_BYTES,
+                            message.data.len() as f64,
+                            &[],
+                        );
                         let slot = signed_block.block.slot;
 
                         if let Err(err) =
@@ -895,6 +901,11 @@ impl LeanNetworkService {
                         subnet_id,
                         attestation: signed_attestation,
                     }) => {
+                        observe_histogram_vec(
+                            &GOSSIP_ATTESTATION_SIZE_BYTES,
+                            message.data.len() as f64,
+                            &[],
+                        );
                         let slot = signed_attestation.message.slot;
 
                         if let Err(err) = self.chain_message_sender.send(
@@ -910,6 +921,11 @@ impl LeanNetworkService {
                         }
                     }
                     Ok(LeanGossipsubMessage::AggregatedAttestation(aggregated_attestation)) => {
+                        observe_histogram_vec(
+                            &GOSSIP_AGGREGATION_SIZE_BYTES,
+                            message.data.len() as f64,
+                            &[],
+                        );
                         let slot = aggregated_attestation.data.slot;
 
                         if let Err(err) = self.chain_message_sender.send(


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
Implements the following metrics:

- `lean_block_aggregated_payloads`
- `lean_block_building_payload_aggregation_time_seconds`
- `lean_block_building_time_seconds`
- `lean_block_building_success_total`
- `lean_block_building_failures_total`
- `lean_gossip_block_size_bytes`
- `lean_gossip_attestation_size_bytes`
- `lean_gossip_aggregation_size_bytes`
- `lean_attestations_production_time_seconds`

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
