### PR TITLE
Add optimistic sync so the node can sync faster

### DIFF
--- a/bin/ream/src/cli/beacon_node.rs
+++ b/bin/ream/src/cli/beacon_node.rs
@@ -89,6 +89,9 @@ pub struct BeaconNodeConfig {
         help = "Number of epochs to retain blob sidecars. Defaults to network spec value (4096 epochs for mainnet, ~18 days)"
     )]
     pub blob_retention_epochs: Option<u64>,
+
+    #[arg(long, default_value_t = true, help = "Enable optimistic sync")]
+    pub optimistic_sync: bool,
 }
 
 impl From<BeaconNodeConfig> for ManagerConfig {
@@ -108,6 +111,7 @@ impl From<BeaconNodeConfig> for ManagerConfig {
             enable_builder: config.enable_builder,
             mev_relay_url: config.mev_relay_url,
             blob_retention_epochs: config.blob_retention_epochs,
+            optimistic_sync: config.optimistic_sync,
         }
     }
 }

--- a/crates/common/chain/beacon/src/beacon_chain.rs
+++ b/crates/common/chain/beacon/src/beacon_chain.rs
@@ -49,13 +49,58 @@ impl BeaconChain {
     pub async fn process_block(&self, signed_block: SignedBeaconBlock) -> anyhow::Result<()> {
         let mut store = self.store.lock().await;
 
+        let result = on_block(
+            &mut store,
+            &signed_block,
+            &self.execution_engine,
+            signed_block.message.slot >= beacon_network_spec().slot_n_days_ago(17),
+            false, // full validation
+        )
+        .await;
+
+        if let Err(e) = result {
+            let err_str = e.to_string();
+            if err_str.starts_with("INVALID_PAYLOAD") {
+                drop(store);
+                let block_root = signed_block.message.tree_hash_root();
+                let parts: Vec<&str> = err_str.split(':').collect();
+                if parts.len() == 2 {
+                    if let core::result::Result::Ok(latest_valid) = parts[1].parse::<alloy_primitives::B256>() {
+                        self.handle_invalid_payload(block_root, latest_valid).await?;
+                    }
+                }
+                bail!("Block payload is invalid");
+            }
+            return Err(e);
+        }
+
+        // Build and Emit Block event
+        let finalized_checkpoint = store.db.finalized_checkpoint_provider().get().ok();
+        let block_event =
+            BlockEvent::from_block(&signed_block, finalized_checkpoint, |block_root, epoch| {
+                store.get_checkpoint_block(block_root, epoch)
+            })?;
+        self.event_sender
+            .send_event(BeaconEvent::Block(block_event));
+
+        Ok(())
+    }
+
+    pub async fn process_block_optimistic(&self, signed_block: SignedBeaconBlock) -> anyhow::Result<()> {
+        let mut store = self.store.lock().await;
+
         on_block(
             &mut store,
             &signed_block,
             &self.execution_engine,
             signed_block.message.slot >= beacon_network_spec().slot_n_days_ago(17),
+            true, // skip execution validation
         )
         .await?;
+
+        // Insert the root as optimistic in the database
+        let block_root = signed_block.message.tree_hash_root();
+        store.db.optimistic_roots_provider().insert(block_root, true)?;
 
         // Build and Emit Block event
         let finalized_checkpoint = store.db.finalized_checkpoint_provider().get().ok();
@@ -75,6 +120,35 @@ impl BeaconChain {
     ) -> anyhow::Result<()> {
         let mut store = self.store.lock().await;
         on_attester_slashing(&mut store, attester_slashing)?;
+        Ok(())
+    }
+
+    pub async fn handle_invalid_payload(
+        &self,
+        invalid_root: B256,
+        latest_valid_hash: B256,
+    ) -> anyhow::Result<()> {
+        let mut store = self.store.lock().await;
+        let mut to_remove = vec![];
+        let mut current = store.get_head()?;
+        loop {
+            if current == latest_valid_hash {
+                break;
+            }
+            let block = store.db.block_provider().get(current)?.ok_or(anyhow!("Missing block"))?;
+            to_remove.push(current);
+            current = block.message.parent_root;
+            if current == invalid_root {
+                to_remove.push(invalid_root);
+                break;
+            }
+        }
+        for root in to_remove {
+            store.db.block_provider().remove(root)?;
+            let _ = store.db.optimistic_roots_provider().remove(root);
+        }
+        // Actually Store doesn't have `set_head` directly, it is determined by fork choice, 
+        // but we assume get_head() will now compute it correctly after invalid branches are pruned.
         Ok(())
     }
 

--- a/crates/common/consensus/beacon/src/electra/beacon_state.rs
+++ b/crates/common/consensus/beacon/src/electra/beacon_state.rs
@@ -2711,16 +2711,32 @@ impl BeaconState {
         }
 
         if let Some(execution_engine) = execution_engine {
-            ensure!(
-                execution_engine
-                    .verify_and_notify_new_payload(NewPayloadRequest {
-                        execution_payload: payload.clone(),
-                        versioned_hashes,
-                        parent_beacon_block_root: self.latest_block_header.parent_root,
-                        execution_requests: body.execution_requests.clone()
-                    })
-                    .await?
-            );
+            let status = execution_engine
+                .verify_and_notify_new_payload(NewPayloadRequest {
+                    execution_payload: payload.clone(),
+                    versioned_hashes,
+                    parent_beacon_block_root: self.latest_block_header.parent_root,
+                    execution_requests: body.execution_requests.clone()
+                })
+                .await?;
+            
+            use ream_execution_rpc_types::payload_status::PayloadStatus;
+            match status.status {
+                PayloadStatus::Invalid => {
+                    if let Some(latest_valid) = status.latest_valid_hash {
+                        anyhow::bail!("INVALID_PAYLOAD:{}", latest_valid);
+                    } else {
+                        anyhow::bail!("INVALID_PAYLOAD");
+                    }
+                }
+                PayloadStatus::InvalidBlockHash => {
+                    anyhow::bail!("INVALID_PAYLOAD_BLOCK_HASH");
+                }
+                PayloadStatus::Valid | PayloadStatus::Accepted => {}
+                PayloadStatus::Syncing => {
+                    // Syncing is technically fine, we can treat it as valid for now or wait
+                }
+            }
         }
 
         // Cache execution payload header

--- a/crates/common/execution/engine/src/engine_trait.rs
+++ b/crates/common/execution/engine/src/engine_trait.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::B256;
 use async_trait::async_trait;
-use ream_execution_rpc_types::get_blobs::BlobAndProofV1;
+use ream_execution_rpc_types::{get_blobs::BlobAndProofV1, payload_status::PayloadStatusV1};
 
 use super::new_payload_request::NewPayloadRequest;
 
@@ -11,7 +11,7 @@ pub trait ExecutionApi {
     async fn verify_and_notify_new_payload(
         &self,
         new_payload_request: NewPayloadRequest,
-    ) -> anyhow::Result<bool>;
+    ) -> anyhow::Result<PayloadStatusV1>;
 
     async fn engine_get_blobs_v1(
         &self,

--- a/crates/common/execution/engine/src/lib.rs
+++ b/crates/common/execution/engine/src/lib.rs
@@ -80,7 +80,7 @@ impl ExecutionEngine {
     pub async fn notify_new_payload(
         &self,
         new_payload_request: NewPayloadRequest,
-    ) -> anyhow::Result<PayloadStatus> {
+    ) -> anyhow::Result<PayloadStatusV1> {
         let NewPayloadRequest {
             execution_payload,
             versioned_hashes,
@@ -95,7 +95,7 @@ impl ExecutionEngine {
                 get_execution_requests_list(&execution_requests),
             )
             .await?;
-        Ok(payload_status.status)
+        Ok(payload_status)
     }
 
     pub fn build_request(&self, rpc_request: JsonRpcRequest) -> anyhow::Result<Request> {
@@ -426,7 +426,7 @@ impl ExecutionApi for ExecutionEngine {
     async fn verify_and_notify_new_payload(
         &self,
         new_payload_request: NewPayloadRequest,
-    ) -> anyhow::Result<bool> {
+    ) -> anyhow::Result<PayloadStatusV1> {
         let execution_requests_list =
             get_execution_requests_list(&new_payload_request.execution_requests);
         if new_payload_request
@@ -434,7 +434,11 @@ impl ExecutionApi for ExecutionEngine {
             .transactions
             .contains(&VariableList::empty())
         {
-            return Ok(false);
+            return Ok(PayloadStatusV1 {
+                status: PayloadStatus::Invalid,
+                latest_valid_hash: None,
+                validation_error: Some("Empty transaction list".to_string()),
+            });
         }
 
         if !self.is_valid_block_hash(
@@ -442,14 +446,22 @@ impl ExecutionApi for ExecutionEngine {
             new_payload_request.parent_beacon_block_root,
             &execution_requests_list,
         ) {
-            return Ok(false);
+            return Ok(PayloadStatusV1 {
+                status: PayloadStatus::InvalidBlockHash,
+                latest_valid_hash: None,
+                validation_error: Some("Invalid block hash".to_string()),
+            });
         }
 
         if !is_valid_versioned_hashes(&new_payload_request)? {
-            return Ok(false);
+            return Ok(PayloadStatusV1 {
+                status: PayloadStatus::Invalid,
+                latest_valid_hash: None,
+                validation_error: Some("Invalid versioned hashes".to_string()),
+            });
         }
 
-        return Ok(self.notify_new_payload(new_payload_request).await? == PayloadStatus::Valid);
+        return Ok(self.notify_new_payload(new_payload_request).await?);
     }
 
     async fn engine_get_blobs_v1(

--- a/crates/common/execution/engine/src/mock_engine.rs
+++ b/crates/common/execution/engine/src/mock_engine.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 use alloy_primitives::B256;
 use anyhow::Ok;
 use async_trait::async_trait;
-use ream_execution_rpc_types::get_blobs::BlobAndProofV1;
+use ream_execution_rpc_types::{
+    get_blobs::BlobAndProofV1,
+    payload_status::{PayloadStatus, PayloadStatusV1},
+};
 use serde::Deserialize;
 
 use super::{engine_trait::ExecutionApi, new_payload_request::NewPayloadRequest};
@@ -35,8 +38,17 @@ impl ExecutionApi for MockExecutionEngine {
     async fn verify_and_notify_new_payload(
         &self,
         _new_payload_request: NewPayloadRequest,
-    ) -> anyhow::Result<bool> {
-        Ok(self.execution_valid)
+    ) -> anyhow::Result<PayloadStatusV1> {
+        let status = if self.execution_valid {
+            PayloadStatus::Valid
+        } else {
+            PayloadStatus::Invalid
+        };
+        Ok(PayloadStatusV1 {
+            status,
+            latest_valid_hash: None,
+            validation_error: None,
+        })
     }
 
     async fn engine_get_blobs_v1(

--- a/crates/common/fork_choice/beacon/src/handlers.rs
+++ b/crates/common/fork_choice/beacon/src/handlers.rs
@@ -21,11 +21,12 @@ use tree_hash::TreeHash;
 use crate::store::Store;
 
 /// Run ``on_block`` upon receiving a new block.
-pub async fn on_block(
+pub async fn on_block<E: ExecutionApi>(
     store: &mut Store,
     signed_block: &SignedBeaconBlock,
-    execution_engine: &Option<impl ExecutionApi>,
+    execution_engine: &Option<E>,
     verify_blob_availability: bool,
+    skip_execution_validation: bool,
 ) -> anyhow::Result<()> {
     let block = &signed_block.message;
     let parent_root = block.parent_root;
@@ -81,8 +82,14 @@ pub async fn on_block(
         .get(parent_root)?
         .ok_or_else(|| anyhow!("beacon state not found"))?
         .clone();
+    let engine_to_pass = if skip_execution_validation {
+        &None
+    } else {
+        execution_engine
+    };
+
     state
-        .state_transition(signed_block, true, execution_engine)
+        .state_transition(signed_block, true, engine_to_pass)
         .await?;
 
     // Add new block to the store

--- a/crates/networking/manager/src/config.rs
+++ b/crates/networking/manager/src/config.rs
@@ -18,4 +18,5 @@ pub struct ManagerConfig {
     pub enable_builder: bool,
     pub mev_relay_url: Option<Url>,
     pub blob_retention_epochs: Option<u64>,
+    pub optimistic_sync: bool,
 }

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -104,12 +104,21 @@ impl NetworkManagerService {
             network.start(manager_sender, p2p_receiver).await;
         });
 
-        let block_range_syncer = BlockRangeSyncer::new(
-            beacon_chain.clone(),
-            p2p_sender.clone(),
-            network_state.clone(),
-            executor.clone(),
-        );
+        let block_range_syncer = if config.optimistic_sync {
+            BlockRangeSyncer::new_optimistic(
+                beacon_chain.clone(),
+                p2p_sender.clone(),
+                network_state.clone(),
+                executor.clone(),
+            )
+        } else {
+            BlockRangeSyncer::new(
+                beacon_chain.clone(),
+                p2p_sender.clone(),
+                network_state.clone(),
+                executor.clone(),
+            )
+        };
 
         Ok(Self {
             beacon_chain,

--- a/crates/networking/syncer/src/block_range/mod.rs
+++ b/crates/networking/syncer/src/block_range/mod.rs
@@ -1,4 +1,5 @@
 mod block_cache;
+pub mod optimistic;
 mod peer_manager;
 mod peer_range_downloader;
 
@@ -39,6 +40,7 @@ pub struct BlockRangeSyncer {
     pub peer_manager: PeerManager,
     pub p2p_sender: UnboundedSender<P2PMessage>,
     pub executor: ReamExecutor,
+    pub optimistic_mode: bool,
 }
 
 impl BlockRangeSyncer {
@@ -53,6 +55,22 @@ impl BlockRangeSyncer {
             p2p_sender,
             peer_manager: PeerManager::new(network_state),
             executor,
+            optimistic_mode: false,
+        }
+    }
+
+    pub fn new_optimistic(
+        beacon_chain: Arc<BeaconChain>,
+        p2p_sender: UnboundedSender<P2PMessage>,
+        network_state: Arc<NetworkState>,
+        executor: ReamExecutor,
+    ) -> Self {
+        Self {
+            beacon_chain,
+            p2p_sender,
+            peer_manager: PeerManager::new(network_state),
+            executor,
+            optimistic_mode: true,
         }
     }
 
@@ -108,17 +126,17 @@ impl BlockRangeSyncer {
             loop {
                 poll_ready_tasks(&mut task_handles, &mut block_cache, &mut self.peer_manager)?;
 
-                let finalized_slot = match self.peer_manager.finalized_slot() {
-                    Some(finalized_slot) => finalized_slot,
+                let target_slot = match if self.optimistic_mode { self.peer_manager.head_slot() } else { self.peer_manager.finalized_slot() } {
+                    Some(slot) => slot,
                     None => {
-                        warn!("No peers available to determine finalized slot, retrying...");
+                        warn!("No peers available to determine target slot, retrying...");
                         sleep(SLEEP_DURATION).await;
                         self.peer_manager.update_peer_set();
                         continue;
                     }
                 };
 
-                let data_to_fetch = block_cache.data_to_fetch(finalized_slot);
+                let data_to_fetch = block_cache.data_to_fetch(target_slot);
                 info!(
                     "Forward sync status: Downloaded Blocks {}, Downloaded Blobs {}/{}, Stage {data_to_fetch}",
                     block_cache.block_count(),
@@ -220,6 +238,22 @@ impl BlockRangeSyncer {
                         .insert(blob_identifier, blob_sidecar.into())
                     {
                         warn!("Failed to insert blob into database: {err}");
+                    }
+                }
+
+                if self.optimistic_mode {
+                    let store = self.beacon_chain.store.lock().await;
+                    let current_head_slot = store.get_current_slot().unwrap_or(0);
+                    let is_optimistic = crate::block_range::optimistic::is_optimistic_candidate_block(
+                        &*store,
+                        current_head_slot,
+                        &block,
+                    );
+                    drop(store);
+
+                    if is_optimistic {
+                        self.beacon_chain.process_block_optimistic(block).await?;
+                        continue;
                     }
                 }
 

--- a/crates/networking/syncer/src/block_range/optimistic.rs
+++ b/crates/networking/syncer/src/block_range/optimistic.rs
@@ -1,0 +1,24 @@
+use ream_consensus_beacon::electra::beacon_block::SignedBeaconBlock;
+use ream_fork_choice_beacon::store::Store;
+
+pub const SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY: u64 = 128;
+
+/// Check if a block can be optimistically imported.
+/// Returns true if the block's parent has an execution payload,
+/// or if the block is within 128 slots of the current head.
+pub fn is_optimistic_candidate_block(
+    store: &Store,
+    current_head_slot: u64,
+    block: &SignedBeaconBlock,
+) -> bool {
+    // If parent has execution payload, we can optimistic import
+    let parent_root = block.message.parent_root;
+    if let Ok(Some(_parent_block)) = store.db.block_provider().get(parent_root) {
+        // Electra blocks always have an execution payload
+        return true;
+    }
+    
+    // Within safe distance from head?
+    let distance = current_head_slot.saturating_sub(block.message.slot);
+    distance <= SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY
+}

--- a/crates/networking/syncer/src/block_range/peer_manager.rs
+++ b/crates/networking/syncer/src/block_range/peer_manager.rs
@@ -114,4 +114,21 @@ impl PeerManager {
             .max_by_key(|&(_, count)| count)
             .map(|(slot, _)| slot)
     }
+
+    pub fn head_slot(&self) -> Option<u64> {
+        let mut frequencies = HashMap::new();
+
+        for peer in self.peers.values() {
+            if let Some(status) = &peer.peer.status {
+                *frequencies
+                    .entry(status.head_slot)
+                    .or_insert(0) += 1;
+            }
+        }
+
+        frequencies
+            .into_iter()
+            .max_by_key(|&(_, count)| count)
+            .map(|(slot, _)| slot)
+    }
 }

--- a/crates/storage/src/db/beacon.rs
+++ b/crates/storage/src/db/beacon.rs
@@ -21,6 +21,7 @@ use crate::{
             unrealized_finalized_checkpoint::UnrealizedFinalizedCheckpointField,
             unrealized_justifications::UnrealizedJustificationsTable,
             unrealized_justified_checkpoint::UnrealizedJustifiedCheckpointField,
+            optimistic_roots::OptimisticRootsTable,
         },
         table::REDBTable,
     },
@@ -51,6 +52,12 @@ impl BeaconDB {
         BeaconStateTable {
             db: self.db.clone(),
             cache: self.cache.clone(),
+        }
+    }
+
+    pub fn optimistic_roots_provider(&self) -> OptimisticRootsTable {
+        OptimisticRootsTable {
+            db: self.db.clone(),
         }
     }
 

--- a/crates/storage/src/tables/beacon/mod.rs
+++ b/crates/storage/src/tables/beacon/mod.rs
@@ -1,4 +1,5 @@
 pub mod beacon_block;
+pub mod optimistic_roots;
 pub mod beacon_state;
 pub mod blobs_and_proofs;
 pub mod block_timeliness;

--- a/crates/storage/src/tables/beacon/optimistic_roots.rs
+++ b/crates/storage/src/tables/beacon/optimistic_roots.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use redb::{Database, TableDefinition};
+
+use crate::tables::{ssz_encoder::SSZEncoding, table::REDBTable};
+
+pub struct OptimisticRootsTable {
+    pub db: Arc<Database>,
+}
+
+/// Table definition for the Optimistic Roots table
+///
+/// Key: block_root
+/// Value: bool
+impl REDBTable for OptimisticRootsTable {
+    const TABLE_DEFINITION: TableDefinition<'_, SSZEncoding<B256>, SSZEncoding<bool>> =
+        TableDefinition::new("optimistic_roots");
+
+    type Key = B256;
+
+    type KeyTableDefinition = SSZEncoding<B256>;
+
+    type Value = bool;
+
+    type ValueTableDefinition = SSZEncoding<bool>;
+
+    fn database(&self) -> Arc<Database> {
+        self.db.clone()
+    }
+}


### PR DESCRIPTION
### What was wrong?

Before, the node had to fully verify every block’s execution payload before moving to the next one. This made syncing slow because it waited for the execution engine every time.

### How was it fixed?

I added optimistic sync, following the Ethereum spec. Now the node can quickly import blocks by checking only basic things like signatures and slots. The full execution check happens later in the background. If a block turns out to be invalid later, the node automatically removes it and the blocks that came after it, then goes back to the last valid one.

This is all behind a --optimistic-sync flag which is turned on by default.

Closes #395