### PR TITLE
feat: Implement attestation aggregate coverage gauges with subnet labels metrics

### DIFF
--- a/crates/common/metrics/src/lib.rs
+++ b/crates/common/metrics/src/lib.rs
@@ -8,6 +8,20 @@ use prometheus_exporter::prometheus::{
 
 use crate::timer::DiscardOnDropHistogramTimer;
 
+pub const ATTESTATION_AGGREGATE_COVERAGE_SECTIONS: &[&str] = &[
+    "timely",
+    "late",
+    "block",
+    "combined",
+    "agg_start_new",
+    "proposal_payloads",
+    "proposal_gossip",
+    "proposal_combined",
+];
+
+pub const ATTESTATION_AGGREGATE_COVERAGE_DIFFERENT_DIRECTIONS: &[&str] =
+    &["block_only", "timely_only"];
+
 // Provisioning each metrics
 lazy_static::lazy_static! {
     // Node Info Metrics
@@ -515,6 +529,46 @@ lazy_static::lazy_static! {
             default_registry()
         ).expect("failed to create LEAN_TICK_INTERVAL_DURATION_SECONDS histogram vec")
     };
+
+    pub static ref LEAN_ATTESTATION_AGGREGATE_VALIDATORS: IntGaugeVec = register_int_gauge_vec_with_registry!(
+        "lean_attestation_aggregate_coverage_validators",
+        "Validator's is_aggregator status. True=1, False=0",
+        &["section", "subnet"],
+        default_registry()
+    ).expect("failed to create IS_AGGREGATOR int gauge vec");
+
+    pub static ref LEAN_ATTESTATION_AGGREGATE_SUBNETS: IntGaugeVec = register_int_gauge_vec_with_registry!(
+        "lean_attestation_aggregate_coverage_subnets",
+        "Validator's is_aggregator status. True=1, False=0",
+        &["section"],
+        default_registry()
+    ).expect("failed to create IS_AGGREGATOR int gauge vec");
+
+    pub static ref LEAN_ATTESTATION_AGGREGATE_DIFFERENT_VALIDATORS: IntGaugeVec = register_int_gauge_vec_with_registry!(
+        "lean_attestation_aggregate_coverage_different_validators",
+        "Validator's is_aggregator status. True=1, False=0",
+        &["direction"],
+        default_registry()
+    ).expect("failed to create IS_AGGREGATOR int gauge vec");
+}
+
+pub fn init_aggregate_coverage_metrics() {
+    for &section in ATTESTATION_AGGREGATE_COVERAGE_SECTIONS {
+        set_int_gauge_vec(&LEAN_ATTESTATION_AGGREGATE_SUBNETS, 0, &[section]);
+        set_int_gauge_vec(
+            &LEAN_ATTESTATION_AGGREGATE_VALIDATORS,
+            0,
+            &[section, "combined"],
+        );
+    }
+
+    for &direction in ATTESTATION_AGGREGATE_COVERAGE_DIFFERENT_DIRECTIONS {
+        set_int_gauge_vec(
+            &LEAN_ATTESTATION_AGGREGATE_DIFFERENT_VALIDATORS,
+            0,
+            &[direction],
+        );
+    }
 }
 
 /// Set the value of a gauge metric

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::anyhow;
 use ream_chain_lean::{
     clock::{create_lean_clock_interval, get_initial_tick_count},
@@ -11,7 +13,8 @@ use ream_consensus_misc::constants::lean::{INTERVALS_PER_SLOT, attestation_commi
 use ream_fork_choice_lean::store::compute_subnet_id;
 use ream_keystore::lean_keystore::ValidatorKeystore;
 use ream_metrics::{
-    ATTESTATIONS_PRODUCTION_TIME, PQ_SIG_ATTESTATION_SIGNATURES_TOTAL,
+    ATTESTATIONS_PRODUCTION_TIME, LEAN_ATTESTATION_AGGREGATE_SUBNETS,
+    LEAN_ATTESTATION_AGGREGATE_VALIDATORS, PQ_SIG_ATTESTATION_SIGNATURES_TOTAL,
     PQ_SIG_ATTESTATION_SIGNING_TIME, VALIDATORS_COUNT, inc_int_counter_vec, set_int_gauge_vec,
     start_timer, stop_timer,
 };
@@ -185,12 +188,34 @@ impl ValidatorService {
                                 });
                             }
 
-                            for signed_attestation in signed_attestations {
+                            let section = "timely";
+                            let mut unique_subnets = HashSet::new();
+
+                            for signed_attestation in &signed_attestations {
                                 let subnet_id = compute_subnet_id(signed_attestation.validator_id, attestation_committee_count());
+                                unique_subnets.insert(subnet_id);
+
                                 self.chain_sender
-                                    .send(LeanChainServiceMessage::ProcessAttestation { signed_attestation: Box::new(signed_attestation), subnet_id, need_gossip: true })
+                                    .send(LeanChainServiceMessage::ProcessAttestation {
+                                        signed_attestation: Box::new(signed_attestation.clone()),
+                                        subnet_id,
+                                        need_gossip: true
+                                    })
                                     .map_err(|err| anyhow!("Failed to send attestation to LeanChainService: {err:?}"))?;
                             }
+
+                            set_int_gauge_vec(
+                                &LEAN_ATTESTATION_AGGREGATE_VALIDATORS,
+                                signed_attestations.len() as i64,
+                                &[section, "combined"]
+                            );
+
+                            set_int_gauge_vec(
+                                &LEAN_ATTESTATION_AGGREGATE_SUBNETS,
+                                unique_subnets.len() as i64,
+                                &[section]
+                            );
+
                             stop_timer(attestation_production_timer);
                         }
                         _ => {


### PR DESCRIPTION
### What was wrong?

 Fixes: https://github.com/ReamLabs/ream/issues/1389

### How was it fixed?

Implements attestation aggregate coverage gauges with subnet labels metrics
