### PR TITLE
feat(da): introduce minimal PeerDAS Data Availability client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6099,6 +6099,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "ream-da"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "clap",
+ "discv5",
+ "futures",
+ "libp2p",
+ "ream-consensus-misc",
+ "ream-da-beacon",
+ "ream-da-errors",
+ "ream-da-networking",
+ "ream-da-storage",
+ "ream-executor",
+ "ream-network-spec",
+ "ream-p2p",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "ream-da-beacon"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "futures",
+ "ream-da-errors",
+ "ream-events-beacon",
+ "ream-validator-beacon",
+ "reqwest",
+]
+
+[[package]]
+name = "ream-da-errors"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ream-da-networking"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "discv5",
+ "ethereum_ssz",
+ "libp2p",
+ "ream-consensus-beacon",
+ "ream-consensus-misc",
+ "ream-da-storage",
+ "ream-discv5",
+ "ream-executor",
+ "ream-network-manager",
+ "ream-network-spec",
+ "ream-p2p",
+ "ream-polynomial-commitments",
+ "ream-req-resp",
+ "rust_eth_kzg",
+ "sha2",
+ "tokio",
+ "tracing",
+ "tree_hash",
+ "tree_hash_derive",
+]
+
+[[package]]
+name = "ream-da-storage"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "delay_map",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "ream-consensus-beacon",
+ "ream-consensus-misc",
+ "ream-da-errors",
+ "redb",
+ "snap",
+ "ssz_types",
+ "tempdir",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ream-discv5"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 default-members = ["bin/ream"]
 members = [
     "bin/ream",
+    "bin/ream-da",
     "crates/common/account_manager",
     "crates/common/api_types/beacon",
     "crates/common/api_types/common",
@@ -33,6 +34,10 @@ members = [
     "crates/crypto/keystore",
     "crates/crypto/merkle",
     "crates/crypto/post_quantum",
+    "crates/da/errors",
+    "crates/da/storage",
+    "crates/da/networking",
+    "crates/da/beacon",
     "crates/networking/discv5",
     "crates/networking/manager",
     "crates/networking/network_state/lean",
@@ -151,6 +156,10 @@ ream-checkpoint-sync-lean = { path = "crates/common/checkpoint_sync/lean", defau
 ream-consensus-beacon = { path = "crates/common/consensus/beacon" }
 ream-consensus-lean = { path = "crates/common/consensus/lean", default-features = false }
 ream-consensus-misc = { path = "crates/common/consensus/misc", default-features = false }
+ream-da-beacon = { path = "crates/da/beacon" }
+ream-da-errors = { path = "crates/da/errors" }
+ream-da-networking = { path = "crates/da/networking" }
+ream-da-storage = { path = "crates/da/storage" }
 ream-discv5 = { path = "crates/networking/discv5" }
 ream-events-beacon = { path = "crates/common/events/beacon" }
 ream-execution-engine = { path = "crates/common/execution/engine" }

--- a/bin/ream-da/Cargo.toml
+++ b/bin/ream-da/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "ream-da"
+description = "A Rust implementation of PeerDAS Availabilty Client"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[[bin]]
+name = "ream-da"
+path = "src/main.rs"
+
+[features]
+default = ["devnet4"]
+devnet4 = [
+    "ream-p2p/devnet4",
+]
+devnet5 = [
+    "ream-p2p/devnet5",
+]
+
+[dependencies]
+alloy-primitives.workspace = true
+anyhow.workspace = true
+clap.workspace = true
+discv5.workspace = true
+futures.workspace = true
+libp2p.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+# ream dependencies
+ream-consensus-misc.workspace = true
+ream-da-beacon.workspace = true
+ream-da-errors.workspace = true
+ream-da-networking.workspace = true
+ream-da-storage.workspace = true
+ream-executor.workspace = true
+ream-network-spec.workspace = true
+ream-p2p.workspace = true
+
+[lints]
+workspace = true

--- a/bin/ream-da/src/cli.rs
+++ b/bin/ream-da/src/cli.rs
@@ -1,0 +1,56 @@
+use std::{net::IpAddr, path::PathBuf};
+
+use alloy_primitives::B256;
+use clap::Parser;
+use libp2p::Multiaddr;
+use ream_p2p::bootnodes::Bootnodes;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "ream-da",
+    about = "Ream PeerDAS Data Availability Node — custodies and serves all 128 data columns",
+    version
+)]
+pub struct Cli {
+    /// URL of the beacon node's Beacon API (for canonical head events)
+    #[arg(long, default_value = "http://localhost:5052")]
+    pub beacon_url: String,
+
+    /// Directory for storing column sidecar data and slot index
+    #[arg(long, default_value = "./da-data")]
+    pub data_dir: PathBuf,
+
+    /// Ethereum network to connect to
+    #[arg(long, default_value = "mainnet")]
+    pub network: String,
+
+    /// IP address to listen on for P2P connections
+    #[arg(long, default_value = "0.0.0.0")]
+    pub p2p_host: IpAddr,
+
+    /// TCP port for libp2p connections
+    #[arg(long, default_value_t = 9100)]
+    pub p2p_port: u16,
+
+    /// UDP port for discv5 discovery
+    #[arg(long, default_value_t = 9101)]
+    pub discovery_port: u16,
+
+    /// Bootnodes to connect to on startup
+    /// Accepts: "default", "none", comma-separated ENRs, or path to YAML file
+    #[arg(long, default_value = "default")]
+    pub bootnodes: Bootnodes,
+
+    /// Direct libp2p multiaddr peers to dial on startup, bypassing discv5
+    /// e.g. /ip4/172.16.0.13/tcp/33000/p2p/16Uiu2HAmVok6ZGmqT9dbBmQzSxmiy8ASE8hwEBKcGBJxfkxST6fm
+    #[arg(long, value_delimiter = ',')]
+    pub static_peers: Vec<Multiaddr>,
+
+    /// Disable peer discovery (useful for local testing)
+    #[arg(long, default_value_t = false)]
+    pub disable_discovery: bool,
+
+    /// Optional genesis validators root to use for network spec (overrides default for selected network)
+    #[arg(long)]
+    pub genesis_validators_root: Option<B256>,
+}

--- a/bin/ream-da/src/main.rs
+++ b/bin/ream-da/src/main.rs
@@ -1,0 +1,365 @@
+use std::{path::Path, str::FromStr, sync::Arc};
+
+use alloy_primitives::{B256, U256, address, aliases::B32};
+use clap::Parser;
+use ream_consensus_misc::constants::beacon::set_genesis_validator_root;
+use ream_da_beacon::DaConsensusClient;
+use ream_da_errors::{DaError, DaResult};
+use ream_da_networking::{DaNetworkService, blob_schedule::set_blob_schedule};
+use ream_da_storage::DaStore;
+use ream_executor::ReamExecutor;
+use ream_network_spec::networks::{
+    BeaconNetworkSpec, DEV, HOODI, MAINNET, Network, SEPOLIA, beacon_network_spec,
+    set_beacon_network_spec,
+};
+use reqwest::Url;
+use tracing::info;
+use tracing_subscriber::{EnvFilter, fmt};
+
+mod cli;
+mod node;
+
+use cli::Cli;
+use node::DaNode;
+
+#[tokio::main]
+async fn main() -> DaResult<()> {
+    fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("info,ream_da=debug")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    info!(
+        beacon_url = %cli.beacon_url,
+        network = %cli.network,
+        "Starting ream-da node"
+    );
+
+    let beacon_url =
+        Url::parse(&cli.beacon_url).map_err(|e| DaError::InvalidBeaconUrl(e.to_string()))?;
+
+    let network_spec = match cli.network.as_str() {
+        "mainnet" => MAINNET.clone(),
+        "sepolia" => SEPOLIA.clone(),
+        "hoodi" => HOODI.clone(),
+        "dev" => DEV.clone(),
+        _ => {
+            info!(
+                "Custom network '{}', fetching spec from beacon API",
+                cli.network
+            );
+            fetch_network_spec(&beacon_url).await?
+        }
+    };
+    set_beacon_network_spec(network_spec);
+
+    let store = Arc::new(DaStore::new(cli.data_dir.clone())?);
+
+    let (finalized_root, finalized_epoch) = fetch_finalized_checkpoint(&beacon_url)
+        .await
+        .unwrap_or((B256::ZERO, 0));
+    let genesis_validators_root =
+        resolve_genesis_validators_root(cli.genesis_validators_root, &beacon_url, &cli.data_dir)
+            .await?;
+    set_genesis_validator_root(genesis_validators_root);
+
+    let blob_schedule = fetch_blob_schedule(&beacon_url).await?;
+    set_blob_schedule(blob_schedule);
+
+    let fork_digest = fetch_fork_digest(&beacon_url).await?;
+
+    let consensus = DaConsensusClient::new(beacon_url)?;
+
+    let bootnodes = cli
+        .bootnodes
+        .to_enrs_beacon(beacon_network_spec().network.clone());
+
+    let static_peers = cli.static_peers.clone();
+
+    let executor = ReamExecutor::new()
+        .map_err(|e| DaError::Internal(format!("Failed to create executor: {}", e)))?;
+
+    info!(finalized_epoch, %finalized_root, "Fetched initial finalized checkpoint");
+
+    let network = DaNetworkService::new(
+        executor.clone(),
+        cli.p2p_host,
+        cli.p2p_port,
+        cli.discovery_port,
+        bootnodes,
+        static_peers,
+        cli.data_dir.clone(),
+        store.clone(),
+        cli.disable_discovery,
+        finalized_root,
+        finalized_epoch,
+        fork_digest,
+    )
+    .await?;
+
+    info!(
+        p2p_host = %cli.p2p_host,
+        p2p_port = cli.p2p_port,
+        discovery_port = cli.discovery_port,
+        "P2P network initialized"
+    );
+
+    let node = DaNode::new(store, consensus, network);
+
+    info!("ream-da node running — custodying 128 columns");
+
+    node.run().await
+}
+
+async fn resolve_genesis_validators_root(
+    cli_value: Option<B256>,
+    beacon_url: &Url,
+    data_dir: &Path,
+) -> DaResult<B256> {
+    if let Some(root) = cli_value {
+        info!("Using genesis validators root from CLI flag");
+        return Ok(root);
+    }
+
+    let cache_path = data_dir.join("genesis_validators_root");
+    if cache_path.exists() {
+        let hex = std::fs::read_to_string(&cache_path)
+            .map_err(|e| DaError::Internal(format!("Failed to read genesis cache: {e}")))?;
+        let root = hex
+            .trim()
+            .parse::<B256>()
+            .map_err(|e| DaError::Internal(format!("Invalid cached genesis root: {e}")))?;
+        info!(%root, "Using cached genesis validators root");
+        return Ok(root);
+    }
+
+    info!("Fetching genesis validators root from beacon API");
+    let root = fetch_genesis_validators_root(beacon_url).await?;
+
+    std::fs::write(&cache_path, root.to_string())
+        .map_err(|e| DaError::Internal(format!("Failed to cache genesis root: {e}")))?;
+
+    info!(%root, "Genesis validators root fetched and cached");
+    Ok(root)
+}
+
+async fn fetch_genesis_validators_root(beacon_url: &Url) -> DaResult<B256> {
+    let url = beacon_url
+        .join("/eth/v1/beacon/genesis")
+        .map_err(|e| DaError::InvalidBeaconUrl(e.to_string()))?;
+
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to fetch genesis: {e}")))?;
+
+    let body: serde_json::Value = response.json().await.map_err(|e| {
+        DaError::EventStreamFailed(format!("Failed to parse genesis response: {e}"))
+    })?;
+
+    let root_str = body["data"]["genesis_validators_root"]
+        .as_str()
+        .ok_or_else(|| DaError::EventStreamFailed("Missing genesis_validators_root".to_string()))?;
+
+    root_str
+        .parse::<B256>()
+        .map_err(|e| DaError::EventStreamFailed(format!("Invalid genesis_validators_root: {e}")))
+}
+
+async fn fetch_network_spec(beacon_url: &Url) -> DaResult<Arc<BeaconNetworkSpec>> {
+    let url = beacon_url
+        .join("/eth/v1/config/spec")
+        .map_err(|e| DaError::InvalidBeaconUrl(e.to_string()))?;
+
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to fetch config spec: {e}")))?;
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to parse config spec: {e}")))?;
+
+    let data = &body["data"];
+
+    let parse_b32 = |key: &str| -> DaResult<B32> {
+        data[key]
+            .as_str()
+            .ok_or_else(|| DaError::Internal(format!("Missing field: {key}")))?
+            .parse::<B32>()
+            .map_err(|e| DaError::Internal(format!("Invalid {key}: {e}")))
+    };
+
+    let parse_u64 = |key: &str| -> DaResult<u64> {
+        data[key]
+            .as_str()
+            .ok_or_else(|| DaError::Internal(format!("Missing field: {key}")))?
+            .parse::<u64>()
+            .map_err(|e| DaError::Internal(format!("Invalid {key}: {e}")))
+    };
+
+    Ok(Arc::new(BeaconNetworkSpec {
+        preset_base: "minimal".to_string(),
+        network: Network::Custom(beacon_url.host_str().unwrap_or_default().to_string()),
+        terminal_total_difficulty: U256::from_str("58750000000000000000000")
+            .expect("Could not get U256"),
+        terminal_block_hash: B256::ZERO,
+        terminal_block_hash_activation_epoch: u64::MAX,
+        min_genesis_active_validator_count: parse_u64("MIN_GENESIS_ACTIVE_VALIDATOR_COUNT")?,
+        min_genesis_time: parse_u64("MIN_GENESIS_TIME")?,
+        genesis_fork_version: parse_b32("GENESIS_FORK_VERSION")?,
+        genesis_delay: parse_u64("GENESIS_DELAY")?,
+        altair_fork_version: parse_b32("ALTAIR_FORK_VERSION")?,
+        altair_fork_epoch: parse_u64("ALTAIR_FORK_EPOCH")?,
+        bellatrix_fork_version: parse_b32("BELLATRIX_FORK_VERSION")?,
+        bellatrix_fork_epoch: parse_u64("BELLATRIX_FORK_EPOCH")?,
+        capella_fork_version: parse_b32("CAPELLA_FORK_VERSION")?,
+        capella_fork_epoch: parse_u64("CAPELLA_FORK_EPOCH")?,
+        deneb_fork_version: parse_b32("DENEB_FORK_VERSION")?,
+        deneb_fork_epoch: parse_u64("DENEB_FORK_EPOCH")?,
+        electra_fork_version: parse_b32("ELECTRA_FORK_VERSION")?,
+        electra_fork_epoch: parse_u64("ELECTRA_FORK_EPOCH")?,
+        fulu_fork_version: parse_b32("FULU_FORK_VERSION")?,
+        fulu_fork_epoch: parse_u64("FULU_FORK_EPOCH")?,
+        seconds_per_slot: parse_u64("SECONDS_PER_SLOT")?,
+        seconds_per_eth1_block: 14,
+        min_validator_withdrawability_delay: parse_u64("MIN_VALIDATOR_WITHDRAWABILITY_DELAY")?,
+        shard_committee_period: parse_u64("SHARD_COMMITTEE_PERIOD")?,
+        eth1_follow_distance: parse_u64("ETH1_FOLLOW_DISTANCE")?,
+        inactivity_score_bias: parse_u64("INACTIVITY_SCORE_BIAS")?,
+        inactivity_score_recovery_rate: parse_u64("INACTIVITY_SCORE_RECOVERY_RATE")?,
+        ejection_balance: parse_u64("EJECTION_BALANCE")?,
+        min_per_epoch_churn_limit: parse_u64("MIN_PER_EPOCH_CHURN_LIMIT")?,
+        churn_limit_quotient: parse_u64("CHURN_LIMIT_QUOTIENT")?,
+        max_per_epoch_activation_churn_limit: parse_u64("MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT")?,
+        proposer_score_boost: parse_u64("PROPOSER_SCORE_BOOST")?,
+        reorg_head_weight_threshold: parse_u64("REORG_HEAD_WEIGHT_THRESHOLD")?,
+        reorg_parent_weight_threshold: parse_u64("REORG_PARENT_WEIGHT_THRESHOLD")?,
+        reorg_max_epochs_since_finalization: parse_u64("REORG_MAX_EPOCHS_SINCE_FINALIZATION")?,
+        deposit_chain_id: 1,
+        deposit_network_id: 1,
+        deposit_contract_address: address!("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
+        max_payload_size: 10485760,
+        max_request_blocks: parse_u64("MAX_REQUEST_BLOCKS")?,
+        epochs_per_subnet_subscription: parse_u64("EPOCHS_PER_SUBNET_SUBSCRIPTION")?,
+        min_epochs_for_block_requests: parse_u64("MIN_EPOCHS_FOR_BLOCK_REQUESTS")?,
+        ttfb_timeout: 5,
+        resp_timeout: 10,
+        attestation_propagation_slot_range: parse_u64("ATTESTATION_PROPAGATION_SLOT_RANGE")?,
+        maximum_gossip_clock_disparity: parse_u64("MAXIMUM_GOSSIP_CLOCK_DISPARITY")?,
+        message_domain_invalid_snappy: parse_b32("MESSAGE_DOMAIN_INVALID_SNAPPY")?,
+        message_domain_valid_snappy: parse_b32("MESSAGE_DOMAIN_VALID_SNAPPY")?,
+        subnets_per_node: parse_u64("SUBNETS_PER_NODE")?,
+        attestation_subnet_count: parse_u64("ATTESTATION_SUBNET_COUNT")?,
+        attestation_subnet_extra_bits: parse_u64("ATTESTATION_SUBNET_EXTRA_BITS")?,
+        attestation_subnet_prefix_bits: parse_u64("ATTESTATION_SUBNET_PREFIX_BITS")?,
+        max_request_blocks_deneb: parse_u64("MAX_REQUEST_BLOCKS_DENEB")?,
+        max_request_blob_sidecars: parse_u64("MAX_REQUEST_BLOB_SIDECARS")?,
+        min_epochs_for_blob_sidecars_requests: parse_u64("MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS")?,
+        blob_sidecar_subnet_count: parse_u64("BLOB_SIDECAR_SUBNET_COUNT")?,
+        min_per_epoch_churn_limit_electra: parse_u64("MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA")?,
+        max_per_epoch_activation_exit_churn_limit: parse_u64(
+            "MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT",
+        )?,
+        blob_sidecar_subnet_count_electra: parse_u64("BLOB_SIDECAR_SUBNET_COUNT_ELECTRA")?,
+        max_blobs_per_block_electra: parse_u64("MAX_BLOBS_PER_BLOCK_ELECTRA")?,
+        max_request_blob_sidecars_electra: parse_u64("MAX_REQUEST_BLOB_SIDECARS_ELECTRA")?,
+    }))
+}
+
+async fn fetch_blob_schedule(beacon_url: &Url) -> DaResult<Vec<(u64, u64)>> {
+    let url = beacon_url
+        .join("/eth/v1/config/spec")
+        .map_err(|e| DaError::InvalidBeaconUrl(e.to_string()))?;
+
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to fetch spec: {e}")))?;
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to parse spec: {e}")))?;
+
+    let schedule = body["data"]["BLOB_SCHEDULE"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|entry| {
+            let epoch = entry["EPOCH"].as_str()?.parse::<u64>().ok()?;
+            let max_blobs = entry["MAX_BLOBS_PER_BLOCK"].as_str()?.parse::<u64>().ok()?;
+            Some((epoch, max_blobs))
+        })
+        .collect();
+
+    Ok(schedule)
+}
+
+async fn fetch_finalized_checkpoint(beacon_url: &Url) -> DaResult<(B256, u64)> {
+    let url = beacon_url
+        .join("/eth/v1/beacon/states/head/finality_checkpoints")
+        .map_err(|e| DaError::InvalidBeaconUrl(e.to_string()))?;
+
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to fetch finality: {e}")))?;
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to parse finality: {e}")))?;
+
+    let root = body["data"]["finalized"]["root"]
+        .as_str()
+        .unwrap_or_default()
+        .parse::<B256>()
+        .unwrap_or_default();
+
+    let epoch = body["data"]["finalized"]["epoch"]
+        .as_str()
+        .unwrap_or("0")
+        .parse::<u64>()
+        .unwrap_or(0);
+
+    Ok((root, epoch))
+}
+
+async fn fetch_fork_digest(beacon_url: &Url) -> DaResult<alloy_primitives::aliases::B32> {
+    let identity_url = beacon_url
+        .join("/eth/v1/node/identity")
+        .map_err(|e| DaError::InvalidBeaconUrl(e.to_string()))?;
+
+    let identity_response = reqwest::get(identity_url)
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to fetch identity: {e}")))?;
+
+    let identity_body: serde_json::Value = identity_response
+        .json()
+        .await
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to parse identity: {e}")))?;
+
+    let enr_str = identity_body["data"]["enr"]
+        .as_str()
+        .ok_or_else(|| DaError::EventStreamFailed("Missing enr".to_string()))?;
+
+    let enr: discv5::Enr = enr_str
+        .parse()
+        .map_err(|e| DaError::EventStreamFailed(format!("Failed to parse ENR: {e}")))?;
+
+    let eth2_bytes = enr
+        .get_raw_rlp("eth2")
+        .ok_or_else(|| DaError::EventStreamFailed("Missing eth2 field in ENR".to_string()))?;
+
+    if eth2_bytes.len() < 5 {
+        return Err(DaError::EventStreamFailed(
+            "eth2 field too short".to_string(),
+        ));
+    }
+
+    let fork_digest = alloy_primitives::aliases::B32::from_slice(&eth2_bytes[1..5]);
+    info!("Fetched fork digest from beacon ENR: {fork_digest:#x}");
+    Ok(fork_digest)
+}

--- a/bin/ream-da/src/node.rs
+++ b/bin/ream-da/src/node.rs
@@ -1,0 +1,145 @@
+use std::{sync::Arc, time::Duration};
+
+use futures::StreamExt;
+use ream_da_beacon::{
+    DaConsensusClient,
+    iface::{ConsensusClient, ConsensusEvent},
+};
+use ream_da_errors::DaResult;
+use ream_da_networking::DaNetworkService;
+use ream_da_storage::DaStore;
+use ream_p2p::network::beacon::network_state::NetworkState;
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+// MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS = 4096
+// SLOTS_PER_EPOCH = 32
+const RETENTION_SLOTS: u64 = 4096 * 32;
+const RECONNECT_BASE_SECS: u64 = 2;
+const RECONNECT_MAX_SECS: u64 = 30;
+
+pub struct DaNode {
+    store: Arc<DaStore>,
+    consensus: DaConsensusClient,
+    network: DaNetworkService,
+}
+
+impl DaNode {
+    pub fn new(
+        store: Arc<DaStore>,
+        consensus: DaConsensusClient,
+        network: DaNetworkService,
+    ) -> Self {
+        Self {
+            store,
+            consensus,
+            network,
+        }
+    }
+
+    pub async fn run(self) -> DaResult<()> {
+        let DaNode {
+            store,
+            consensus,
+            network,
+        } = self;
+
+        let network_state = network.network_state();
+        let consensus_handle = tokio::spawn(async move {
+            run_consensus_loop(consensus, store, network_state).await;
+        });
+
+        let network_handle = tokio::spawn(async move {
+            network.start().await;
+        });
+
+        tokio::select! {
+            result = consensus_handle => {
+                error!("Consensus loop exited unexpectedly: {result:?}");
+            }
+            result = network_handle => {
+                error!("Network service exited unexpectedly: {result:?}");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+async fn run_consensus_loop(
+    consensus: DaConsensusClient,
+    store: Arc<DaStore>,
+    network_state: Arc<NetworkState>,
+) {
+    let mut backoff = RECONNECT_BASE_SECS;
+    loop {
+        match consensus.try_events() {
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    retry_in = backoff,
+                    "Failed to open beacon SSE stream, retrying"
+                );
+                sleep(Duration::from_secs(backoff)).await;
+                backoff = (backoff * 2).min(RECONNECT_MAX_SECS);
+                continue;
+            }
+            Ok(mut events) => {
+                backoff = RECONNECT_BASE_SECS;
+                info!("Beacon SSE stream connected");
+
+                while let Some(event) = events.next().await {
+                    match event {
+                        Ok(ConsensusEvent::Head(head)) => {
+                            if let Err(e) = store.record_slot(head.slot, head.block_root) {
+                                error!(slot = head.slot, "Failed to record slot: {e}");
+                            } else {
+                                let mut status = network_state.status.write();
+                                status.head_slot = head.slot;
+                                status.head_root = head.block_root;
+                                info!(slot = head.slot, block_root = %head.block_root, "New head");
+                            }
+                        }
+
+                        Ok(ConsensusEvent::Reorg(reorg)) => {
+                            if let Err(e) = store.record_slot(reorg.slot, reorg.new_head_block) {
+                                error!(slot = reorg.slot, "Failed to update slot after reorg: {e}");
+                            }
+                            warn!(
+                                slot = reorg.slot,
+                                depth = reorg.depth,
+                                old = %reorg.old_head_block,
+                                new = %reorg.new_head_block,
+                                "Chain reorg — slot index updated"
+                            );
+                        }
+
+                        Ok(ConsensusEvent::Finalized(epoch)) => {
+                            let finalized_slot = epoch * 32;
+                            let min_slot = finalized_slot.saturating_sub(RETENTION_SLOTS);
+
+                            match store.prune_before_slot(min_slot).await {
+                                Ok(n) if n > 0 => {
+                                    info!(pruned = n, min_slot, epoch, "Pruned stale columns");
+                                }
+                                Err(e) => error!("Pruning failed at epoch {epoch}: {e}"),
+                                _ => {}
+                            }
+
+                            let mut status = network_state.status.write();
+                            status.finalized_epoch = epoch;
+                        }
+
+                        Err(e) => {
+                            warn!(error = %e, "Consensus event error");
+                        }
+                    }
+                }
+
+                warn!(retry_in = backoff, "Beacon SSE stream ended, reconnecting");
+                sleep(Duration::from_secs(backoff)).await;
+                backoff = (backoff * 2).min(RECONNECT_MAX_SECS);
+            }
+        }
+    }
+}

--- a/crates/common/consensus/beacon/src/matrix_entry.rs
+++ b/crates/common/consensus/beacon/src/matrix_entry.rs
@@ -17,6 +17,33 @@ pub struct MatrixEntry {
     row_index: u64,
 }
 
+impl MatrixEntry {
+    pub fn new(cell: Cell, kzg_proof: KZGProof, column_index: u64, row_index: u64) -> Self {
+        Self {
+            cell,
+            kzg_proof,
+            column_index,
+            row_index,
+        }
+    }
+
+    pub fn cell(&self) -> &Cell {
+        &self.cell
+    }
+
+    pub fn column_index(&self) -> u64 {
+        self.column_index
+    }
+
+    pub fn row_index(&self) -> u64 {
+        self.row_index
+    }
+
+    pub fn kzg_proof(&self) -> &KZGProof {
+        &self.kzg_proof
+    }
+}
+
 pub fn compute_matrix(blobs: Vec<Blob>, das_context: &DASContext) -> Result<Vec<MatrixEntry>> {
     let mut matrix = Vec::new();
 
@@ -60,8 +87,8 @@ pub fn recover_matrix(
             matrix.push(MatrixEntry {
                 cell,
                 kzg_proof,
-                column_index: blob_index,
-                row_index: cell_index as u64,
+                column_index: cell_index as u64,
+                row_index: blob_index as u64,
             });
         }
     }

--- a/crates/da/beacon/Cargo.toml
+++ b/crates/da/beacon/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ream-da-beacon"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+alloy-primitives.workspace = true
+anyhow.workspace = true
+futures.workspace = true
+reqwest.workspace = true
+
+# ream dependencies
+ream-da-errors.workspace = true
+ream-events-beacon.workspace = true
+ream-validator-beacon.workspace = true
+
+[lints]
+workspace = true

--- a/crates/da/beacon/src/client.rs
+++ b/crates/da/beacon/src/client.rs
@@ -1,0 +1,62 @@
+use std::{pin::Pin, time::Duration};
+
+use futures::{Stream, StreamExt};
+use ream_da_errors::{DaError, DaResult};
+use ream_events_beacon::{BeaconEvent, EventTopic};
+use ream_validator_beacon::beacon_api_client::BeaconApiClient;
+use reqwest::Url;
+
+use crate::iface::{ConsensusClient, ConsensusEvent, HeadEvent, ReorgEvent};
+
+pub struct DaConsensusClient {
+    inner: BeaconApiClient,
+}
+
+impl DaConsensusClient {
+    pub fn new(beacon_url: Url) -> DaResult<Self> {
+        Ok(Self {
+            inner: BeaconApiClient::new(beacon_url, Duration::from_secs(30))?,
+        })
+    }
+}
+
+impl ConsensusClient for DaConsensusClient {
+    fn try_events(&self) -> DaResult<Pin<Box<dyn Stream<Item = DaResult<ConsensusEvent>> + Send>>> {
+        let stream = self
+            .inner
+            .get_events_stream(
+                &[
+                    EventTopic::Head,
+                    EventTopic::ChainReorg,
+                    EventTopic::FinalizedCheckpoint,
+                ],
+                "da-node",
+            )
+            .map_err(|e| DaError::EventStreamFailed(e.to_string()))?;
+
+        let mapped_stream = stream
+            .filter_map(|event| async move {
+                match event {
+                    BeaconEvent::Head(h) => Some(Ok(ConsensusEvent::Head(HeadEvent {
+                        slot: h.slot,
+                        block_root: h.block,
+                    }))),
+
+                    BeaconEvent::ChainReorg(r) => Some(Ok(ConsensusEvent::Reorg(ReorgEvent {
+                        slot: r.slot,
+                        depth: r.depth,
+                        old_head_block: r.old_head_block,
+                        new_head_block: r.new_head_block,
+                    }))),
+
+                    BeaconEvent::FinalizedCheckpoint(f) => {
+                        Some(Ok(ConsensusEvent::Finalized(f.epoch)))
+                    }
+                    _ => None,
+                }
+            })
+            .boxed();
+
+        Ok(mapped_stream)
+    }
+}

--- a/crates/da/beacon/src/iface.rs
+++ b/crates/da/beacon/src/iface.rs
@@ -1,0 +1,28 @@
+use alloy_primitives::B256;
+use futures::Stream;
+use ream_da_errors::DaResult;
+use std::pin::Pin;
+
+pub struct HeadEvent {
+    pub slot: u64,
+    pub block_root: B256,
+}
+
+pub struct ReorgEvent {
+    pub slot: u64,
+    pub depth: u64,
+    pub old_head_block: B256,
+    pub new_head_block: B256,
+}
+
+pub enum ConsensusEvent {
+    Head(HeadEvent),
+    Reorg(ReorgEvent),
+    /// Finalized epoch from FinalizedCheckpointEvent.
+    /// Used by the consensus loop to trigger pruning.
+    Finalized(u64),
+}
+
+pub trait ConsensusClient: Send + Sync {
+    fn try_events(&self) -> DaResult<Pin<Box<dyn Stream<Item = DaResult<ConsensusEvent>> + Send>>>;
+}

--- a/crates/da/beacon/src/lib.rs
+++ b/crates/da/beacon/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod client;
+pub mod iface;
+
+pub use client::DaConsensusClient;
+pub use iface::{ConsensusClient, ConsensusEvent, HeadEvent, ReorgEvent};

--- a/crates/da/errors/Cargo.toml
+++ b/crates/da/errors/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ream-da-errors"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+reqwest.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/da/errors/src/lib.rs
+++ b/crates/da/errors/src/lib.rs
@@ -1,0 +1,54 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DaError {
+    /// The URL provided for the beacon API is not valid.
+    #[error("invalid beacon URL: {0}")]
+    InvalidBeaconUrl(String),
+
+    /// The SSE event stream could not be established or was lost.
+    #[error("beacon event stream error: {0}")]
+    EventStreamFailed(String),
+
+    /// A consensus event was received but could not be decoded.
+    #[error("failed to decode consensus event: {0}")]
+    EventDecodeFailed(String),
+
+    /// A column sidecar could not be written to disk.
+    #[error("failed to store column (block_root={block_root}, index={index}): {source}")]
+    ColumnWriteFailed {
+        block_root: String,
+        index: u64,
+        source: anyhow::Error,
+    },
+
+    /// A column sidecar could not be read from disk.
+    #[error("failed to read column (block_root={block_root}, index={index}): {source}")]
+    ColumnReadFailed {
+        block_root: String,
+        index: u64,
+        source: anyhow::Error,
+    },
+
+    /// The slot index database returned an error.
+    #[error("slot index error: {0}")]
+    SlotIndexFailed(#[from] anyhow::Error),
+
+    /// A gossip message could not be decoded.
+    #[error("gossip decode error: {0}")]
+    GossipDecodeFailed(String),
+
+    /// KZG proof verification failed.
+    #[error("KZG verification failed: {0}")]
+    KzgVerificationFailed(String),
+
+    /// Reconstruction of missing columns from partial data failed.
+    #[error("column reconstruction failed: {0}")]
+    ReconstructionFailed(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+/// Shorthand Result alias used across DA crates.
+pub type DaResult<T> = std::result::Result<T, DaError>;

--- a/crates/da/networking/Cargo.toml
+++ b/crates/da/networking/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "ream-da-networking"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+alloy-primitives.workspace = true
+discv5.workspace = true
+ethereum_ssz.workspace = true
+libp2p.workspace = true
+rust_eth_kzg.workspace = true
+sha2.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tree_hash.workspace = true
+tree_hash_derive.workspace = true
+
+# ream dependencies
+ream-consensus-beacon.workspace = true
+ream-consensus-misc.workspace = true
+ream-da-storage.workspace = true
+ream-discv5.workspace = true
+ream-executor.workspace = true
+ream-network-manager.workspace = true
+ream-network-spec.workspace = true
+ream-p2p.workspace = true
+ream-polynomial-commitments.workspace = true
+ream-req-resp.workspace = true
+
+[lints]
+workspace = true

--- a/crates/da/networking/src/blob_schedule.rs
+++ b/crates/da/networking/src/blob_schedule.rs
@@ -1,0 +1,9 @@
+use std::sync::OnceLock;
+
+static BLOB_SCHEDULE: OnceLock<Vec<(u64, u64)>> = OnceLock::new();
+
+pub fn set_blob_schedule(schedule: Vec<(u64, u64)>) {
+    BLOB_SCHEDULE
+        .set(schedule)
+        .expect("BLOB_SCHEDULE should only be set once");
+}

--- a/crates/da/networking/src/gossip.rs
+++ b/crates/da/networking/src/gossip.rs
@@ -1,0 +1,122 @@
+use std::sync::Arc;
+
+use alloy_primitives::aliases::B32;
+use libp2p::gossipsub::Message;
+use ream_consensus_beacon::data_column_sidecar::{
+    DATA_COLUMN_SIDECAR_SUBNET_COUNT, NUMBER_OF_COLUMNS,
+};
+use ream_da_storage::DaStore;
+use ream_network_manager::p2p_sender::P2PSender;
+use ream_p2p::gossipsub::beacon::{
+    configurations::GossipsubConfig,
+    message::GossipsubMessage,
+    topics::{GossipTopic, GossipTopicKind},
+};
+use ream_polynomial_commitments::handlers::verify_data_column_sidecar_kzg_proofs;
+use tracing::{error, info};
+use tree_hash::TreeHash;
+
+use crate::reconstruct::maybe_reconstruct;
+
+/// Build a gossipsub config that only subscribes to the 128 column subnets.
+pub fn da_gossipsub_config(fork_digest: B32) -> GossipsubConfig {
+    let mut config = GossipsubConfig::default();
+
+    let topics: Vec<GossipTopic> = (0..DATA_COLUMN_SIDECAR_SUBNET_COUNT)
+        .map(|subnet_id| GossipTopic {
+            fork: fork_digest,
+            kind: GossipTopicKind::DataColumnSidecar(subnet_id),
+        })
+        .collect();
+
+    config.set_topics(topics);
+    config
+}
+
+pub async fn handle_da_gossip_message(
+    message: Message,
+    store: &Arc<DaStore>,
+    p2p_sender: &P2PSender,
+    fork_digest: B32,
+) {
+    let sidecar = match GossipsubMessage::decode(&message.topic, &message.data) {
+        Ok(GossipsubMessage::DataColumnSidecar(sidecar)) => sidecar,
+        Ok(_) => return,
+        Err(err) => {
+            error!(topic = %message.topic, err = ?err, "Failed to decode gossip message");
+            return;
+        }
+    };
+
+    let subnet_id = match GossipTopic::from_topic_hash(&message.topic) {
+        Ok(topic) => match topic.kind {
+            GossipTopicKind::DataColumnSidecar(id) => id,
+            _ => return,
+        },
+        Err(_) => return,
+    };
+
+    if !sidecar.verify() {
+        error!(
+            column = sidecar.index,
+            "Column sidecar failed basic verification"
+        );
+        return;
+    }
+
+    if subnet_id != sidecar.compute_subnet() {
+        error!(column = sidecar.index, "Column sidecar on wrong subnet");
+        return;
+    }
+
+    if !sidecar.verify_inclusion_proof() {
+        error!(
+            column = sidecar.index,
+            "Column sidecar inclusion proof invalid"
+        );
+        return;
+    }
+
+    match verify_data_column_sidecar_kzg_proofs(&sidecar) {
+        Ok(true) => {}
+        Ok(false) => {
+            error!(column = sidecar.index, "Column sidecar KZG proofs invalid");
+            return;
+        }
+        Err(err) => {
+            error!(column = sidecar.index, err = ?err, "KZG verification error");
+            return;
+        }
+    }
+
+    let block_root = sidecar.signed_block_header.message.tree_hash_root();
+    let column_index = sidecar.index;
+
+    if let Err(err) = store.put_column(block_root, *sidecar).await {
+        error!(column = column_index, err = ?err, "Failed to store column sidecar");
+        return;
+    }
+
+    let count = store.column_count(block_root).await;
+
+    // p2p_sender.send_gossip(GossipMessage {
+    //     topic: GossipTopic::from_topic_hash(&message.topic).expect("valid topic"),
+    //     data: sidecar_bytes,
+    // });
+
+    if count == 64 {
+        info!(
+            column = column_index,
+            count,
+            %block_root,
+            "Reconstruction threshold reached, attempting reconstruction"
+        );
+        let store = store.clone();
+        let p2p_sender = p2p_sender.clone();
+        tokio::spawn(async move {
+            maybe_reconstruct(block_root, &store, &p2p_sender, fork_digest).await;
+        });
+    } else if count == NUMBER_OF_COLUMNS as usize {
+        info!(%block_root, "All 128 columns stored");
+    }
+}

--- a/crates/da/networking/src/lib.rs
+++ b/crates/da/networking/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod blob_schedule;
+pub mod gossip;
+pub mod reconstruct;
+pub mod req_resp;
+pub mod service;
+
+pub use service::DaNetworkService;

--- a/crates/da/networking/src/reconstruct.rs
+++ b/crates/da/networking/src/reconstruct.rs
@@ -1,0 +1,118 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use alloy_primitives::aliases::B32;
+use ream_consensus_beacon::data_column_sidecar::{NUMBER_OF_COLUMNS, get_column_data_sidecars};
+use ream_consensus_beacon::matrix_entry::{MatrixEntry, recover_matrix};
+use ream_network_manager::p2p_sender::P2PSender;
+use ream_p2p::{
+    gossipsub::beacon::topics::{GossipTopic, GossipTopicKind},
+    network::beacon::channel::GossipMessage,
+};
+use rust_eth_kzg::{DASContext, TrustedSetup, UsePrecomp};
+use ssz::Encode;
+use tracing::{error, info};
+
+use ream_da_storage::DaStore;
+
+pub async fn maybe_reconstruct(
+    block_root: B256,
+    store: &Arc<DaStore>,
+    p2p_sender: &P2PSender,
+    fork_digest: B32,
+) {
+    let held = match store.get_all_columns(block_root).await {
+        Ok(h) => h,
+        Err(e) => {
+            error!(%block_root, err = %e, "Failed to load columns for reconstruction");
+            return;
+        }
+    };
+
+    if held.len() < 64 || held.len() == NUMBER_OF_COLUMNS as usize {
+        return;
+    }
+
+    let das_context = DASContext::new(&TrustedSetup::default(), UsePrecomp::No);
+
+    let blob_count = held[0].kzg_commitments.len() as u64;
+
+    let partial_matrix = held
+        .iter()
+        .flat_map(|sidecar| {
+            sidecar.column.iter().enumerate().map(|(row_index, cell)| {
+                MatrixEntry::new(
+                    cell.clone(),
+                    sidecar.kzg_proofs[row_index],
+                    sidecar.index,
+                    row_index as u64,
+                )
+            })
+        })
+        .collect();
+
+    let full_matrix = match recover_matrix(partial_matrix, blob_count, &das_context) {
+        Ok(m) => m,
+        Err(e) => {
+            error!(%block_root, err = %e, "Reconstruction failed");
+            return;
+        }
+    };
+
+    let mut per_blob: Vec<(Vec<_>, Vec<_>)> = vec![(vec![], vec![]); blob_count as usize];
+
+    for entry in &full_matrix {
+        let i = entry.row_index() as usize;
+        if i >= per_blob.len() {
+            error!(%block_root, row_index = i, blob_count = blob_count, "row_index out of bounds");
+            return;
+        }
+        per_blob[i].0.push(entry.cell().clone());
+        per_blob[i].1.push(*entry.kzg_proof());
+    }
+
+    let signed_block_header = held[0].signed_block_header.clone();
+    let kzg_commitments = held[0].kzg_commitments.clone();
+    let inclusion_proof = held[0].kzg_commitments_inclusion_proof.clone();
+
+    let all_sidecars = match get_column_data_sidecars(
+        signed_block_header,
+        kzg_commitments,
+        inclusion_proof,
+        per_blob,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            error!(%block_root, err = ?e, "Failed to assemble recovered sidecars");
+            return;
+        }
+    };
+
+    let held_indices: HashSet<u64> = held.iter().map(|s| s.index).collect();
+
+    info!(
+        block_root = %block_root,
+        recovered = all_sidecars.len(),
+        "Reconstruction succeeded"
+    );
+
+    for sidecar in all_sidecars {
+        if held_indices.contains(&sidecar.index) {
+            continue;
+        }
+
+        if let Err(e) = store.put_column(block_root, sidecar.clone()).await {
+            error!(%block_root, column = sidecar.index, err = ?e, "Failed to store recovered column");
+            continue;
+        }
+
+        p2p_sender.send_gossip(GossipMessage {
+            topic: GossipTopic {
+                fork: fork_digest,
+                kind: GossipTopicKind::DataColumnSidecar(sidecar.index),
+            },
+            data: sidecar.as_ssz_bytes(),
+        });
+    }
+}

--- a/crates/da/networking/src/req_resp.rs
+++ b/crates/da/networking/src/req_resp.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+
+use libp2p::{PeerId, swarm::ConnectionId};
+use ream_req_resp::beacon::messages::{
+    BeaconRequestMessage, BeaconResponseMessage,
+    data_column_sidecars::{DataColumnSidecarsByRangeV1Request, DataColumnSidecarsByRootV1Request},
+};
+use tracing::{trace, warn};
+
+use ream_da_storage::DaStore;
+use ream_network_manager::p2p_sender::P2PSender;
+
+pub async fn handle_da_req_resp_message(
+    peer_id: PeerId,
+    stream_id: u64,
+    connection_id: ConnectionId,
+    message: BeaconRequestMessage,
+    p2p_sender: &P2PSender,
+    store: &Arc<DaStore>,
+) {
+    match message {
+        BeaconRequestMessage::DataColumnSidecarsByRange(DataColumnSidecarsByRangeV1Request {
+            start_slot,
+            count,
+            columns,
+        }) => {
+            match store.slots_in_range(start_slot, count) {
+                Ok(slot_roots) => {
+                    for (_, block_root) in slot_roots {
+                        for &column_index in &columns {
+                            match store.get_column_owned(block_root, column_index).await {
+                                Ok(Some(sidecar)) => {
+                                    p2p_sender.send_response(
+                                        peer_id,
+                                        connection_id,
+                                        stream_id,
+                                        BeaconResponseMessage::DataColumnSidecarsByRange(sidecar),
+                                    );
+                                }
+                                Ok(None) => {
+                                    trace!(
+                                        %block_root,
+                                        column = column_index,
+                                        "Column not found for range request"
+                                    );
+                                }
+                                Err(err) => {
+                                    warn!("Storage error: {err}");
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!("Failed to query slot range: {err}");
+                }
+            }
+
+            p2p_sender.send_end_of_stream_response(peer_id, connection_id, stream_id);
+        }
+
+        BeaconRequestMessage::DataColumnSidecarsByRoot(DataColumnSidecarsByRootV1Request {
+            inner,
+        }) => {
+            for identifier in inner {
+                for &column_index in &identifier.columns {
+                    match store
+                        .get_column_owned(identifier.block_root, column_index)
+                        .await
+                    {
+                        Ok(Some(sidecar)) => {
+                            p2p_sender.send_response(
+                                peer_id,
+                                connection_id,
+                                stream_id,
+                                BeaconResponseMessage::DataColumnSidecarsByRoot(sidecar),
+                            );
+                        }
+                        Ok(None) => {
+                            trace!(
+                                block_root = %identifier.block_root,
+                                column = column_index,
+                                "Column not found for root request"
+                            );
+                        }
+                        Err(err) => {
+                            warn!("Storage error: {err}");
+                        }
+                    }
+                }
+            }
+
+            p2p_sender.send_end_of_stream_response(peer_id, connection_id, stream_id);
+        }
+
+        other => {
+            trace!("DA node ignoring non-column request: {other:?}");
+        }
+    }
+}

--- a/crates/da/networking/src/service.rs
+++ b/crates/da/networking/src/service.rs
@@ -1,0 +1,155 @@
+use std::sync::Arc;
+
+use alloy_primitives::{B256, aliases::B32};
+use anyhow::Result;
+use ream_consensus_misc::constants::beacon::NUM_CUSTODY_GROUPS;
+use ream_discv5::{
+    config::DiscoveryConfig,
+    subnet::{AttestationSubnets, CustodyGroupCount, SyncCommitteeSubnets},
+};
+use ream_executor::ReamExecutor;
+use ream_network_manager::p2p_sender::P2PSender;
+use ream_p2p::{
+    config::NetworkConfig,
+    network::beacon::{
+        Network, ReamNetworkEvent, network_state::NetworkState, utils::META_DATA_FILE_NAME,
+    },
+};
+use ream_req_resp::beacon::messages::{meta_data::GetMetaDataV3, status::Status};
+use ssz::Encode;
+use tokio::sync::mpsc;
+use tracing::{error, info};
+
+use crate::{gossip::handle_da_gossip_message, req_resp::handle_da_req_resp_message};
+use ream_da_storage::DaStore;
+
+pub struct DaNetworkService {
+    network_receiver: mpsc::UnboundedReceiver<ReamNetworkEvent>,
+    p2p_sender: P2PSender,
+    store: Arc<DaStore>,
+    network_state: Arc<NetworkState>,
+}
+
+impl DaNetworkService {
+    pub async fn new(
+        executor: ReamExecutor,
+        socket_address: std::net::IpAddr,
+        socket_port: u16,
+        discovery_port: u16,
+        bootnodes: Vec<discv5::Enr>,
+        static_peers: Vec<libp2p::Multiaddr>,
+        data_dir: std::path::PathBuf,
+        store: Arc<DaStore>,
+        disable_discovery: bool,
+        finalized_root: B256,
+        finalized_epoch: u64,
+        fork_digest: B32,
+    ) -> Result<Self> {
+        let discv5_config = discv5::ConfigBuilder::new(discv5::ListenConfig::from_ip(
+            socket_address,
+            discovery_port,
+        ))
+        .build();
+
+        let discv5_config = DiscoveryConfig {
+            discv5_config,
+            bootnodes,
+            socket_address,
+            socket_port,
+            discovery_port,
+            disable_discovery,
+            attestation_subnets: AttestationSubnets::new(),
+            sync_committee_subnets: SyncCommitteeSubnets::new(),
+            // Supernode: advertise custody of all 128 groups
+            custody_group_count: CustodyGroupCount(NUM_CUSTODY_GROUPS),
+            fork_digest_override: Some(fork_digest),
+        };
+
+        let gossipsub_config = crate::gossip::da_gossipsub_config(fork_digest);
+
+        let network_config = NetworkConfig {
+            discv5_config,
+            gossipsub_config,
+            data_dir: data_dir.clone(),
+        };
+
+        let status = Status {
+            fork_digest,
+            finalized_root,
+            finalized_epoch,
+            ..Default::default()
+        };
+
+        let (manager_sender, manager_receiver) = mpsc::unbounded_channel();
+        let (p2p_sender_tx, p2p_receiver) = mpsc::unbounded_channel();
+
+        let da_meta_data = GetMetaDataV3 {
+            seq_number: 0,
+            custody_group_count: NUM_CUSTODY_GROUPS as u64,
+            ..Default::default()
+        };
+
+        let meta_data_path = data_dir.join(META_DATA_FILE_NAME);
+        std::fs::create_dir_all(&data_dir)?;
+        std::fs::write(&meta_data_path, da_meta_data.as_ssz_bytes())?;
+
+        let mut network = Network::init(executor.clone(), &network_config, status).await?;
+
+        for addr in static_peers {
+            network.dial_multiaddr(addr);
+        }
+
+        let network_state = network.network_state();
+
+        executor.spawn(async move {
+            network.start(manager_sender, p2p_receiver).await;
+        });
+
+        Ok(Self {
+            network_receiver: manager_receiver,
+            p2p_sender: P2PSender(p2p_sender_tx),
+            store,
+            network_state,
+        })
+    }
+
+    pub async fn start(mut self) {
+        info!("DaNetworkService::start() running");
+        loop {
+            match self.network_receiver.recv().await {
+                Some(ReamNetworkEvent::GossipsubMessage { message }) => {
+                    let fork_digest = self.network_state.status.read().fork_digest;
+                    handle_da_gossip_message(message, &self.store, &self.p2p_sender, fork_digest)
+                        .await;
+                }
+                Some(ReamNetworkEvent::RequestMessage {
+                    peer_id,
+                    stream_id,
+                    connection_id,
+                    message,
+                }) => {
+                    handle_da_req_resp_message(
+                        peer_id,
+                        stream_id,
+                        connection_id,
+                        message,
+                        &self.p2p_sender,
+                        &self.store,
+                    )
+                    .await;
+                }
+                Some(e) => {
+                    info!("Ignoring network event: {e:?}");
+                } // ignore other events (peer connect/disconnect etc)
+                None => {
+                    error!("Network receiver closed");
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn network_state(&self) -> Arc<NetworkState> {
+        self.network_state.clone()
+    }
+}

--- a/crates/da/storage/Cargo.toml
+++ b/crates/da/storage/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "ream-da-storage"
+authors.workspace = true
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+alloy-primitives.workspace = true
+anyhow.workspace = true
+delay_map.workspace = true
+ethereum_ssz.workspace = true
+ethereum_ssz_derive.workspace = true
+snap.workspace = true
+ssz_types.workspace = true
+tempdir.workspace = true
+tempfile.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+redb.workspace = true
+
+# ream dependencies
+ream-consensus-beacon.workspace = true
+ream-consensus-misc.workspace = true
+ream-da-errors.workspace = true
+
+[lints]
+workspace = true

--- a/crates/da/storage/src/cache.rs
+++ b/crates/da/storage/src/cache.rs
@@ -1,0 +1,81 @@
+use std::{collections::HashMap, sync::Arc};
+
+use alloy_primitives::B256;
+use ream_consensus_beacon::data_column_sidecar::DataColumnSidecar;
+use tokio::sync::RwLock;
+
+/// In-memory cache for recently accessed column sidecars.
+///
+/// Keyed by (block_root, column_index). Values are Arc-wrapped so callers
+/// get a cheap clone of the pointer rather than a 131 KB blob copy.
+///
+/// The cache is intentionally unbounded — the DA node custodies all 128
+/// columns per block, and the retention window is pruned by the consensus
+/// loop. At ~131 KB per column × 128 columns × ~4096 slots retained, the
+/// theoretical max is ~68 GB, so this is a hot-block cache only, not a
+/// full retention cache. Callers should insert on write and remove on prune.
+pub struct DaColumnCache {
+    inner: RwLock<HashMap<(B256, u64), Arc<DataColumnSidecar>>>,
+}
+
+impl DaColumnCache {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Insert a sidecar into the cache, wrapping it in Arc.
+    pub async fn insert(&self, block_root: B256, index: u64, sidecar: DataColumnSidecar) {
+        let mut guard = self.inner.write().await;
+        guard.insert((block_root, index), Arc::new(sidecar));
+    }
+
+    /// Get a single column. Returns a cheap Arc clone — no blob copy.
+    pub async fn get(&self, block_root: B256, index: u64) -> Option<Arc<DataColumnSidecar>> {
+        let guard = self.inner.read().await;
+        guard.get(&(block_root, index)).cloned()
+    }
+
+    /// Get all held columns for a block root without 128 sequential file reads.
+    /// Returns only entries that are present — holes are skipped.
+    pub async fn get_all_for_block(&self, block_root: B256) -> Vec<Arc<DataColumnSidecar>> {
+        let guard = self.inner.read().await;
+        // Single lock acquisition, single pass — O(cache_entries_for_block)
+        // rather than O(128) file opens.
+        guard
+            .iter()
+            .filter_map(|((root, _), sidecar)| {
+                if *root == block_root {
+                    Some(sidecar.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// How many columns are cached for a given block root.
+    pub async fn count(&self, block_root: B256) -> usize {
+        let guard = self.inner.read().await;
+        guard.keys().filter(|(root, _)| *root == block_root).count()
+    }
+
+    /// Remove a single entry — called by prune.
+    pub async fn remove(&self, block_root: B256, index: u64) {
+        let mut guard = self.inner.write().await;
+        guard.remove(&(block_root, index));
+    }
+
+    /// Remove all entries for a block root — called by prune.
+    pub async fn remove_all_for_block(&self, block_root: B256) {
+        let mut guard = self.inner.write().await;
+        guard.retain(|(root, _), _| *root != block_root);
+    }
+}
+
+impl Default for DaColumnCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/da/storage/src/column.rs
+++ b/crates/da/storage/src/column.rs
@@ -1,0 +1,161 @@
+use std::{
+    fs::{self, File, remove_file},
+    io::{Read, Write},
+    path::PathBuf,
+};
+
+use alloy_primitives::B256;
+use anyhow::{Context, Result};
+use ream_consensus_beacon::data_column_sidecar::DataColumnSidecar;
+use snap::raw::{Decoder, Encoder};
+use ssz::{Decode, Encode};
+
+const COLUMN_FOLDER_NAME: &str = "da_columns";
+
+pub struct DaColumnStore {
+    data_dir: PathBuf,
+}
+
+impl DaColumnStore {
+    pub fn new(data_dir: PathBuf) -> Result<Self> {
+        fs::create_dir_all(data_dir.join(COLUMN_FOLDER_NAME))?;
+        Ok(Self { data_dir })
+    }
+
+    fn file_path(&self, block_root: B256, index: u64) -> PathBuf {
+        self.data_dir
+            .join(COLUMN_FOLDER_NAME)
+            .join(format!("{block_root}_{index}.ssz_snappy"))
+    }
+
+    pub fn get(&self, block_root: B256, index: u64) -> Result<Option<DataColumnSidecar>> {
+        let path = self.file_path(block_root, index);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let mut bytes = Vec::new();
+        File::open(&path)
+            .context("opening column file")?
+            .read_to_end(&mut bytes)
+            .context("reading column file")?;
+
+        let decoded = Decoder::new()
+            .decompress_vec(&bytes)
+            .context("snappy decompression")?;
+
+        DataColumnSidecar::from_ssz_bytes(&decoded)
+            .map(Some)
+            .map_err(|e| anyhow::anyhow!("SSZ decode: {e:?}"))
+    }
+
+    pub fn insert(&self, block_root: B256, sidecar: DataColumnSidecar) -> Result<()> {
+        let path = self.file_path(block_root, sidecar.index);
+        let encoded = Encoder::new()
+            .compress_vec(&sidecar.as_ssz_bytes())
+            .context("snappy compression")?;
+
+        File::create(&path)
+            .context("creating column file")?
+            .write_all(&encoded)
+            .context("writing column file")?;
+
+        Ok(())
+    }
+
+    pub fn remove(&self, block_root: B256, index: u64) -> Result<()> {
+        let path = self.file_path(block_root, index);
+        if path.exists() {
+            remove_file(&path).context("removing column file")?;
+        }
+        Ok(())
+    }
+
+    pub fn count(&self, block_root: B256) -> usize {
+        let dir = self.data_dir.join(COLUMN_FOLDER_NAME);
+        let prefix = format!("{block_root}_");
+        fs::read_dir(dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.file_name().to_string_lossy().starts_with(&prefix))
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    pub fn remove_all_for_block(&self, block_root: B256) -> Result<usize> {
+        let dir = self.data_dir.join(COLUMN_FOLDER_NAME);
+        let prefix = format!("{block_root}_");
+        let mut removed = 0;
+
+        for entry in fs::read_dir(&dir).context("reading column dir")? {
+            let entry = entry?;
+            if entry.file_name().to_string_lossy().starts_with(&prefix) {
+                remove_file(entry.path())?;
+                removed += 1;
+            }
+        }
+
+        Ok(removed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ream_consensus_misc::beacon_block_header::SignedBeaconBlockHeader;
+    use ssz_types::{FixedVector, VariableList};
+    use tempdir::TempDir;
+
+    fn make_sidecar(index: u64) -> DataColumnSidecar {
+        let mut sidecar = DataColumnSidecar {
+            index: 0,
+            column: VariableList::empty(),
+            kzg_commitments: VariableList::empty(),
+            kzg_proofs: VariableList::empty(),
+            signed_block_header: SignedBeaconBlockHeader::default(),
+            kzg_commitments_inclusion_proof: FixedVector::default(),
+        };
+        sidecar.index = index;
+        sidecar
+    }
+
+    #[test]
+    fn test_insert_and_get() {
+        let tmp = TempDir::new("da_col").unwrap();
+        let store = DaColumnStore::new(tmp.path().to_path_buf()).unwrap();
+        let root = B256::ZERO;
+
+        store.insert(root, make_sidecar(0)).unwrap();
+        assert!(store.get(root, 0).unwrap().is_some());
+        assert!(store.get(root, 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_count() {
+        let tmp = TempDir::new("da_count").unwrap();
+        let store = DaColumnStore::new(tmp.path().to_path_buf()).unwrap();
+        let root = B256::ZERO;
+
+        assert_eq!(store.count(root), 0);
+        for i in 0..5 {
+            store.insert(root, make_sidecar(i)).unwrap();
+        }
+        assert_eq!(store.count(root), 5);
+    }
+
+    #[test]
+    fn test_remove_all_for_block() {
+        let tmp = TempDir::new("da_remove").unwrap();
+        let store = DaColumnStore::new(tmp.path().to_path_buf()).unwrap();
+        let root = B256::ZERO;
+
+        for i in 0..5 {
+            store.insert(root, make_sidecar(i)).unwrap();
+        }
+        let removed = store.remove_all_for_block(root).unwrap();
+        assert_eq!(removed, 5);
+        assert_eq!(store.count(root), 0);
+    }
+}

--- a/crates/da/storage/src/lib.rs
+++ b/crates/da/storage/src/lib.rs
@@ -1,0 +1,167 @@
+pub mod cache;
+pub mod column;
+pub mod prune;
+pub mod slot_index;
+
+pub use cache::DaColumnCache;
+pub use column::DaColumnStore;
+pub use slot_index::DaSlotIndex;
+
+use std::{collections::HashSet, path::PathBuf, sync::Arc};
+
+use alloy_primitives::B256;
+use ream_consensus_beacon::data_column_sidecar::{DataColumnSidecar, NUMBER_OF_COLUMNS};
+use ream_da_errors::{DaError, DaResult};
+
+pub struct DaStore {
+    pub columns: DaColumnStore,
+    pub slot_index: DaSlotIndex,
+    cache: DaColumnCache,
+}
+
+impl DaStore {
+    pub fn new(data_dir: PathBuf) -> DaResult<Self> {
+        std::fs::create_dir_all(&data_dir).map_err(|e| DaError::Internal(e.to_string()))?;
+        Ok(Self {
+            columns: DaColumnStore::new(data_dir.clone())?,
+            slot_index: DaSlotIndex::new(data_dir)?,
+            cache: DaColumnCache::new(),
+        })
+    }
+
+    /// Store a validated column sidecar — writes to disk and populates cache.
+    pub async fn put_column(&self, block_root: B256, sidecar: DataColumnSidecar) -> DaResult<()> {
+        let index = sidecar.index;
+        self.columns
+            .insert(block_root, sidecar.clone())
+            .map_err(|e| DaError::ColumnWriteFailed {
+                block_root: block_root.to_string(),
+                index,
+                source: e,
+            })?;
+        self.cache.insert(block_root, index, sidecar).await;
+        Ok(())
+    }
+
+    pub fn record_slot(&self, slot: u64, block_root: B256) -> DaResult<()> {
+        self.slot_index.put(slot, block_root)
+    }
+
+    /// Get a single column as `Arc` — cache-first, disk fallback.
+    /// Preferred for reconstruction and gossip paths where cloning is expensive.
+    pub async fn get_column(
+        &self,
+        block_root: B256,
+        index: u64,
+    ) -> DaResult<Option<Arc<DataColumnSidecar>>> {
+        if let Some(cached) = self.cache.get(block_root, index).await {
+            return Ok(Some(cached));
+        }
+        let sidecar =
+            self.columns
+                .get(block_root, index)
+                .map_err(|e| DaError::ColumnReadFailed {
+                    block_root: block_root.to_string(),
+                    index,
+                    source: e,
+                })?;
+        if let Some(sidecar) = sidecar {
+            self.cache.insert(block_root, index, sidecar.clone()).await;
+            return Ok(Some(Arc::new(sidecar)));
+        }
+        Ok(None)
+    }
+
+    /// Get a single column as an owned value — for req/resp handlers that
+    /// need to pass `DataColumnSidecar` directly into `BeaconResponseMessage`.
+    ///
+    /// Uses `Arc::unwrap_or_clone`: free move-out when refcount is 1 (the
+    /// common case immediately after a cache miss), clone only when shared.
+    pub async fn get_column_owned(
+        &self,
+        block_root: B256,
+        index: u64,
+    ) -> DaResult<Option<DataColumnSidecar>> {
+        Ok(self
+            .get_column(block_root, index)
+            .await?
+            .map(Arc::unwrap_or_clone))
+    }
+
+    /// Count — cache-first (avoids dir scan when cache is warm).
+    pub async fn column_count(&self, block_root: B256) -> usize {
+        let cached = self.cache.count(block_root).await;
+        if cached > 0 {
+            return cached;
+        }
+        self.columns.count(block_root)
+    }
+
+    /// Get all columns as `Arc` — cache-first, disk fallback for missing indices.
+    ///
+    /// Once gossip has delivered all 128 columns this is a single RwLock
+    /// acquisition + Vec allocation instead of 128 sequential file opens.
+    pub async fn get_all_columns(&self, block_root: B256) -> DaResult<Vec<Arc<DataColumnSidecar>>> {
+        let cached = self.cache.get_all_for_block(block_root).await;
+
+        if cached.len() == NUMBER_OF_COLUMNS as usize {
+            return Ok(cached);
+        }
+
+        let cached_indices: HashSet<u64> = cached.iter().map(|s| s.index).collect();
+        let mut result = cached;
+
+        for i in 0..NUMBER_OF_COLUMNS {
+            if cached_indices.contains(&i) {
+                continue;
+            }
+            let sidecar =
+                self.columns
+                    .get(block_root, i)
+                    .map_err(|e| DaError::ColumnReadFailed {
+                        block_root: block_root.to_string(),
+                        index: i,
+                        source: e,
+                    })?;
+            if let Some(sidecar) = sidecar {
+                self.cache.insert(block_root, i, sidecar.clone()).await;
+                result.push(Arc::new(sidecar));
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn block_root_for_slot(&self, slot: u64) -> DaResult<Option<B256>> {
+        self.slot_index.get(slot)
+    }
+
+    pub fn slots_in_range(&self, start_slot: u64, count: u64) -> DaResult<Vec<(u64, B256)>> {
+        self.slot_index.get_range(start_slot, count)
+    }
+
+    /// Prune — removes from disk, slot index, and cache.
+    pub async fn prune_before_slot(&self, min_slot: u64) -> DaResult<usize> {
+        prune::prune_before_slot(&self.columns, &self.slot_index, &self.cache, min_slot).await
+    }
+
+    pub fn get_columns_for_block(
+        &self,
+        block_root: B256,
+        indices: &[u64],
+    ) -> DaResult<Vec<DataColumnSidecar>> {
+        indices
+            .iter()
+            .filter_map(|&index| {
+                self.columns
+                    .get(block_root, index)
+                    .map_err(|e| DaError::ColumnReadFailed {
+                        block_root: block_root.to_string(),
+                        index: index,
+                        source: e,
+                    })
+                    .transpose()
+            })
+            .collect()
+    }
+}

--- a/crates/da/storage/src/prune.rs
+++ b/crates/da/storage/src/prune.rs
@@ -1,0 +1,46 @@
+use tracing::info;
+
+use ream_da_errors::{DaError, DaResult};
+
+use crate::{DaColumnCache, DaColumnStore, DaSlotIndex};
+
+/// Prune all column data for slots older than `min_slot`.
+///
+/// Removes from three places in order:
+/// 1. Column files on disk (`DaColumnStore`)
+/// 2. Slot → block_root index (`DaSlotIndex`)
+/// 3. In-memory cache (`DaColumnCache`)
+///
+/// Called every epoch with:
+///   `finalized_slot - MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS * 32`
+pub async fn prune_before_slot(
+    columns: &DaColumnStore,
+    slot_index: &DaSlotIndex,
+    cache: &DaColumnCache,
+    min_slot: u64,
+) -> DaResult<usize> {
+    let stale = slot_index.get_slots_before(min_slot)?;
+    let mut total_removed = 0;
+
+    for (slot, block_root) in stale {
+        let removed = columns
+            .remove_all_for_block(block_root)
+            .map_err(|e| DaError::SlotIndexFailed(e))?;
+
+        slot_index.remove(slot)?;
+        cache.remove_all_for_block(block_root).await;
+
+        total_removed += removed;
+
+        if removed > 0 {
+            info!(
+                slot,
+                %block_root,
+                columns_removed = removed,
+                "Pruned stale column data"
+            );
+        }
+    }
+
+    Ok(total_removed)
+}

--- a/crates/da/storage/src/slot_index.rs
+++ b/crates/da/storage/src/slot_index.rs
@@ -1,0 +1,160 @@
+use std::{path::PathBuf, sync::Arc};
+
+use alloy_primitives::B256;
+use ream_da_errors::{DaError, DaResult};
+use redb::{Database, ReadableDatabase, TableDefinition};
+
+const SLOT_INDEX_TABLE: TableDefinition<u64, [u8; 32]> = TableDefinition::new("da_slot_index");
+
+pub struct DaSlotIndex {
+    db: Arc<Database>,
+}
+
+impl DaSlotIndex {
+    pub fn new(data_dir: PathBuf) -> DaResult<Self> {
+        let db = Database::create(data_dir.join("da_slot_index.redb"))
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+
+        let txn = db
+            .begin_write()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        txn.open_table(SLOT_INDEX_TABLE)
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        txn.commit()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+
+        Ok(Self { db: Arc::new(db) })
+    }
+
+    pub fn put(&self, slot: u64, block_root: B256) -> DaResult<()> {
+        let txn = self
+            .db
+            .begin_write()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        {
+            let mut table = txn
+                .open_table(SLOT_INDEX_TABLE)
+                .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+            table
+                .insert(slot, block_root.0)
+                .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        }
+        txn.commit()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        Ok(())
+    }
+
+    pub fn get(&self, slot: u64) -> DaResult<Option<B256>> {
+        let txn = self
+            .db
+            .begin_read()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        let table = txn
+            .open_table(SLOT_INDEX_TABLE)
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        Ok(table
+            .get(slot)
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?
+            .map(|v| B256::from(v.value())))
+    }
+
+    pub fn get_range(&self, start_slot: u64, count: u64) -> DaResult<Vec<(u64, B256)>> {
+        let txn = self
+            .db
+            .begin_read()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        let table = txn
+            .open_table(SLOT_INDEX_TABLE)
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+
+        table
+            .range(start_slot..start_slot + count)
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?
+            .map(|item| {
+                let (slot, root) = item.map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+                Ok((slot.value(), B256::from(root.value())))
+            })
+            .collect()
+    }
+
+    pub fn get_slots_before(&self, min_slot: u64) -> DaResult<Vec<(u64, B256)>> {
+        let txn = self
+            .db
+            .begin_read()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        let table = txn
+            .open_table(SLOT_INDEX_TABLE)
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+
+        table
+            .range(..min_slot)
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?
+            .map(|item| {
+                let (slot, root) = item.map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+                Ok((slot.value(), B256::from(root.value())))
+            })
+            .collect()
+    }
+
+    pub fn remove(&self, slot: u64) -> DaResult<()> {
+        let txn = self
+            .db
+            .begin_write()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        {
+            let mut table = txn
+                .open_table(SLOT_INDEX_TABLE)
+                .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+            table
+                .remove(slot)
+                .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        }
+        txn.commit()
+            .map_err(|e| DaError::SlotIndexFailed(e.into()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempdir::TempDir;
+
+    #[test]
+    fn test_put_and_get() {
+        let tmp = TempDir::new("da_slot").unwrap();
+        let index = DaSlotIndex::new(tmp.path().to_path_buf()).unwrap();
+
+        index.put(100, B256::ZERO).unwrap();
+        assert_eq!(index.get(100).unwrap(), Some(B256::ZERO));
+        assert_eq!(index.get(101).unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_range() {
+        let tmp = TempDir::new("da_range").unwrap();
+        let index = DaSlotIndex::new(tmp.path().to_path_buf()).unwrap();
+
+        for slot in 100..110 {
+            index.put(slot, B256::ZERO).unwrap();
+        }
+
+        let range = index.get_range(102, 5).unwrap();
+        assert_eq!(range.len(), 5);
+        assert_eq!(range[0].0, 102);
+        assert_eq!(range[4].0, 106);
+    }
+
+    #[test]
+    fn test_get_slots_before() {
+        let tmp = TempDir::new("da_before").unwrap();
+        let index = DaSlotIndex::new(tmp.path().to_path_buf()).unwrap();
+
+        for slot in 100..110 {
+            index.put(slot, B256::ZERO).unwrap();
+        }
+
+        let stale = index.get_slots_before(105).unwrap();
+        assert_eq!(stale.len(), 5);
+    }
+}

--- a/crates/networking/discv5/src/config.rs
+++ b/crates/networking/discv5/src/config.rs
@@ -1,5 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr};
 
+use alloy_primitives::aliases::B32;
 use discv5::{ConfigBuilder, Enr, ListenConfig};
 
 use crate::subnet::{AttestationSubnets, CustodyGroupCount, SyncCommitteeSubnets};
@@ -15,6 +16,7 @@ pub struct DiscoveryConfig {
     pub attestation_subnets: AttestationSubnets,
     pub sync_committee_subnets: SyncCommitteeSubnets,
     pub custody_group_count: CustodyGroupCount,
+    pub fork_digest_override: Option<B32>,
 }
 
 impl Default for DiscoveryConfig {
@@ -47,6 +49,7 @@ impl Default for DiscoveryConfig {
             attestation_subnets,
             sync_committee_subnets,
             custody_group_count: CustodyGroupCount::default(),
+            fork_digest_override: None,
         }
     }
 }

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -92,13 +92,19 @@ impl Discovery {
         let enr_local =
             convert_to_enr(local_key).map_err(|err| anyhow!("Failed to convert key: {err:?}"))?;
 
+        let enr_fork_id = if let Some(fork_digest) = config.fork_digest_override {
+            EnrForkId::fulu(fork_digest)
+        } else {
+            EnrForkId::electra(genesis_validators_root())
+        };
+
         let mut enr_builder = Enr::builder();
         enr_builder.ip(config.socket_address);
         enr_builder.tcp4(config.socket_port);
         enr_builder.udp4(config.discovery_port);
 
         let enr = enr_builder
-            .add_value(ENR_ETH2_KEY, &EnrForkId::electra(genesis_validators_root()))
+            .add_value(ENR_ETH2_KEY, &enr_fork_id)
             .add_value(ATTESTATION_BITFIELD_ENR_KEY, &config.attestation_subnets)
             .add_value(
                 SYNC_COMMITTEE_BITFIELD_ENR_KEY,

--- a/crates/networking/discv5/src/eth2.rs
+++ b/crates/networking/discv5/src/eth2.rs
@@ -37,6 +37,15 @@ impl EnrForkId {
             next_fork_epoch,
         }
     }
+
+    pub fn fulu(fork_digest: B32) -> Self {
+        let spec = beacon_network_spec();
+        Self {
+            fork_digest,
+            next_fork_version: spec.fulu_fork_version,
+            next_fork_epoch: FAR_FUTURE_EPOCH,
+        }
+    }
 }
 
 impl Encodable for EnrForkId {

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -81,6 +81,7 @@ impl NetworkManagerService {
             attestation_subnets: AttestationSubnets::new(),
             sync_committee_subnets: SyncCommitteeSubnets::new(),
             custody_group_count: CustodyGroupCount::default(),
+            fork_digest_override: None,
         };
 
         let gossipsub_config = init_gossipsub_config_with_topics();

--- a/crates/networking/p2p/src/gossipsub/beacon/topics.rs
+++ b/crates/networking/p2p/src/gossipsub/beacon/topics.rs
@@ -1,7 +1,4 @@
-use alloy_primitives::{
-    aliases::B32,
-    hex::{FromHex, ToHexExt},
-};
+use alloy_primitives::{aliases::B32, hex::FromHex};
 use libp2p::gossipsub::{IdentTopic as Topic, TopicHash};
 
 use crate::gossipsub::error::GossipsubError;
@@ -68,9 +65,15 @@ impl GossipTopic {
             }
         };
 
-        let fork = B32::from_hex(topic_parts[1]).map_err(|err| {
+        // Fork digest on the wire is 4 bytes (8 hex chars). Parse into [u8;4]
+        // then store in the first 4 bytes of B32, rest zeroed.
+        let fork_hex = topic_parts[1];
+        let fork_bytes = <[u8; 4]>::from_hex(fork_hex).map_err(|err| {
             GossipsubError::InvalidTopic(format!("Invalid topic fork: {topic:?} {err:?}"))
         })?;
+        let mut fork = B32::ZERO;
+        fork[..4].copy_from_slice(&fork_bytes);
+
         let kind = match topic_parts[2] {
             BEACON_BLOCK_TOPIC => GossipTopicKind::BeaconBlock,
             BEACON_AGGREGATE_AND_PROOF_TOPIC => GossipTopicKind::AggregateAndProof,
@@ -96,9 +99,8 @@ impl std::fmt::Display for GossipTopic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "/{TOPIC_PREFIX}/{}/{}/{ENCODING_POSTFIX}",
-            self.fork.encode_hex(),
-            self.kind,
+            "/{TOPIC_PREFIX}/{:02x}{:02x}{:02x}{:02x}/{}/{ENCODING_POSTFIX}",
+            self.fork[0], self.fork[1], self.fork[2], self.fork[3], self.kind,
         )
     }
 }

--- a/crates/networking/p2p/src/network/beacon/mod.rs
+++ b/crates/networking/p2p/src/network/beacon/mod.rs
@@ -476,6 +476,14 @@ impl Network {
                     );
                 } else {
                     // send status request to the peer
+                    self.network_state.upsert_peer(
+                        peer_id,
+                        None,
+                        ConnectionState::Connecting,
+                        Direction::Outbound,
+                        None,
+                    );
+
                     let status_message =
                         BeaconRequestMessage::Status(self.network_state.status.read().clone());
                     self.send_request(peer_id, status_message);
@@ -836,6 +844,12 @@ impl Network {
 
         self.swarm.behaviour_mut().gossipsub.unsubscribe(&topic)
     }
+
+    pub fn dial_multiaddr(&mut self, addr: Multiaddr) {
+        if let Err(err) = self.swarm.dial(addr.clone()) {
+            warn!("Failed to dial static peer {addr}: {err}");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -888,6 +902,7 @@ mod tests {
                 attestation_subnets: AttestationSubnets::new(),
                 sync_committee_subnets: SyncCommitteeSubnets::new(),
                 custody_group_count: CustodyGroupCount::default(),
+                fork_digest_override: None,
             },
             gossipsub_config: GossipsubConfig {
                 topics,


### PR DESCRIPTION
### What was wrong?

This PR adds a standalone `ream-da` binary focused entirely on the data layer no fork choice, no execution, no validator duties. 

### How was it fixed?
Built a minimal PeerDAS supernode that connects to an existing beacon client, custodies all 128 data columns, and performs erasure reconstruction

 <!-- List the approach you used, and/or changes made to the codebase  -->
- Subscribes to all 128 `data_column_sidecar_*` gossip topics using fork digest fetched from beacon ENR at startup
- Full per-column validation: well-formed, subnet, inclusion proof, KZG
- Persistent storage via SSZ +snappy with redb slot index and finalized epoch pruning
- Erasure reconstruction at 64-column threshold
- `ConsensusClient` trait for integration with any minimal beacon client
- Static peer dialing with status/ping handshakes

Fixes made: 
- Swapped `column_index`/`row_index` in `recover_matrix` output causing panic
- `B32` fork digest hex parsing failure (`FromHex` expects 64 chars, digest is 8)
- Status handler recomputing fork digest from hardcoded mainnet `FULU_FORK_EPOCH` instead of reading from `network_state`
- Added `upsert_peer` for outbound connections causing peer responses to be dropped

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
