### PR TITLE
feat: type SignedBlock.proof and rename multi-signature types

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -16,7 +16,7 @@ use ream_consensus_lean::attestation::SignatureKey;
 #[cfg(feature = "devnet5")]
 use ream_consensus_lean::attestation::SignedAggregatedAttestation;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature;
+use ream_consensus_lean::attestation::SingleMessageAggregate;
 use ream_consensus_lean::{
     attestation::{AttestationData, SignedAttestation},
     block::{BlockWithSignatures, SignedBlock},
@@ -1080,7 +1080,7 @@ impl LeanChainService {
             return Vec::new();
         }
 
-        let mut local_proofs_by_root: HashMap<B256, Vec<TypeOneMultiSignature>> = HashMap::new();
+        let mut local_proofs_by_root: HashMap<B256, Vec<SingleMessageAggregate>> = HashMap::new();
         let initial_payloads = database
             .latest_new_aggregated_payloads_provider()
             .get_all()
@@ -1142,7 +1142,7 @@ impl LeanChainService {
         let type_two = match type_2_from_wire(block.proof.as_ref(), &public_keys_per_component) {
             Ok(proof) => proof,
             Err(err) => {
-                debug!("Post-block Type-2 decode failed: {err}");
+                debug!("Post-block multi-message aggregate decode failed: {err}");
                 return Vec::new();
             }
         };
@@ -1174,62 +1174,72 @@ impl LeanChainService {
             let block_t1 = match type_2_split(type_two.clone(), component_index) {
                 Ok(t1) => t1,
                 Err(err) => {
-                    debug!("Post-block Type-2 split failed for component {component_index}: {err}");
+                    debug!(
+                        "Post-block multi-message aggregate split failed for component {component_index}: {err}"
+                    );
                     continue;
                 }
             };
 
-            let combined = match local_proofs {
-                Some(locals) if !locals.is_empty() => {
-                    let att_root: [u8; 32] = data_root.into();
-                    let slot = attestation.message.slot as u32;
+            let combined = if let Some(locals) = local_proofs {
+                let mut children = Vec::with_capacity(locals.len() + 1);
+                let mut union_bits = attestation.aggregation_bits.clone();
 
-                    let mut children = Vec::with_capacity(locals.len() + 1);
-                    let mut union_bits = attestation.aggregation_bits.clone();
+                children.push((
+                    block_t1.clone(),
+                    public_keys_per_component[component_index].clone(),
+                ));
 
-                    children.push(block_t1.clone());
-                    for proof in locals {
-                        for validator_id in proof.to_validator_indices() {
-                            let _ = union_bits.set(validator_id as usize, true);
-                        }
-                        match type_1_from_wire(
-                            &proof.proof,
-                            &local_proof_public_keys(proof, validators),
-                        ) {
-                            Ok(child) => children.push(child),
-                            Err(err) => {
-                                debug!("Local Type-1 reconstruct failed: {err}; skipping merge");
-                            }
-                        }
+                for proof in locals {
+                    for validator_id in proof.to_validator_indices() {
+                        let _ = union_bits.set(validator_id as usize, true);
                     }
+                    let pubkeys: Vec<_> = proof
+                        .to_validator_indices()
+                        .iter()
+                        .filter_map(|&vid| {
+                            validators
+                                .get(vid as usize)
+                                .map(|v| v.attestation_public_key)
+                        })
+                        .collect();
+                    children.push((proof.clone(), pubkeys));
+                }
 
-                    match type_1_aggregate(&children, &[], &att_root, slot) {
-                        Ok(merged) => TypeOneMultiSignature::new(
-                            union_bits,
-                            VariableList::new(type_1_to_wire(&merged))
-                                .expect("Aggregate size limit exceeded"),
-                        ),
-                        Err(err) => {
-                            debug!("Post-block re-aggregation failed for {data_root}: {err}");
-                            TypeOneMultiSignature::new(
-                                attestation.aggregation_bits.clone(),
-                                VariableList::new(type_1_to_wire(&block_t1))
-                                    .expect("Proof size limit exceeded"),
-                            )
-                        }
+                match type_1_aggregate(
+                    &children,
+                    &[],
+                    &data_root.into(),
+                    attestation.message.slot as u32,
+                ) {
+                    Ok(merged) => SingleMessageAggregate::new(
+                        union_bits,
+                        VariableList::new(type_1_to_wire(&merged))
+                            .expect("Aggregate size limit exceeded"),
+                    ),
+                    Err(err) => {
+                        debug!("Post-block re-aggregation failed for {data_root}: {err}");
+                        SingleMessageAggregate::new(
+                            attestation.aggregation_bits.clone(),
+                            VariableList::new(type_1_to_wire(&block_t1))
+                                .expect("Proof size limit exceeded"),
+                        )
                     }
                 }
-                _ => TypeOneMultiSignature::new(
+            } else {
+                SingleMessageAggregate::new(
                     attestation.aggregation_bits.clone(),
                     VariableList::new(type_1_to_wire(&block_t1))
                         .expect("Proof size limit exceeded"),
-                ),
+                )
             };
 
-            if local_proofs.is_some_and(|locals| !locals.is_empty()) {
-                let superseded = local_proofs.cloned().unwrap_or_default();
-                for proofs in new_payloads.values_mut() {
-                    proofs.retain(|proof| !superseded.contains(proof));
+            if let Some(locals) = local_proofs {
+                let superseded: std::collections::HashSet<_> = locals.iter().collect();
+                for (key, proofs) in new_payloads.iter_mut() {
+                    if key.data_root == data_root {
+                        proofs.retain(|proof| !superseded.contains(proof));
+                    }
                 }
                 new_payloads.retain(|_, value| !value.is_empty());
             }
@@ -2963,7 +2973,7 @@ fn pending_block_parent_root(block: &SignedBlock) -> B256 {
 
 #[cfg(feature = "devnet5")]
 fn local_proof_public_keys(
-    proof: &TypeOneMultiSignature,
+    proof: &SingleMessageAggregate,
     validators: &ssz_types::VariableList<
         ream_consensus_lean::validator::Validator,
         ssz_types::typenum::U4096,

--- a/crates/common/consensus/lean/src/attestation.rs
+++ b/crates/common/consensus/lean/src/attestation.rs
@@ -68,13 +68,13 @@ impl AggregatedSignatureProof {
 
 #[cfg(feature = "devnet5")]
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Encode, Decode, TreeHash)]
-pub struct TypeOneMultiSignature {
+pub struct SingleMessageAggregate {
     pub participants: BitList<U4096>,
     pub proof: VariableList<u8, U524288>,
 }
 
 #[cfg(feature = "devnet5")]
-impl TypeOneMultiSignature {
+impl SingleMessageAggregate {
     pub fn new(participants: BitList<U4096>, proof: VariableList<u8, U524288>) -> Self {
         Self {
             participants,
@@ -94,12 +94,12 @@ impl TypeOneMultiSignature {
 
 #[cfg(feature = "devnet5")]
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, Encode, Decode, TreeHash)]
-pub struct TypeTwoMultiSignature {
+pub struct MultiMessageAggregate {
     pub proof: VariableList<u8, U524288>,
 }
 
 #[cfg(feature = "devnet5")]
-impl TypeTwoMultiSignature {
+impl MultiMessageAggregate {
     pub fn new(proof: VariableList<u8, U524288>) -> Self {
         Self { proof }
     }
@@ -168,5 +168,5 @@ pub struct SignedAggregatedAttestation {
     pub proof: AggregatedSignatureProof,
 
     #[cfg(feature = "devnet5")]
-    pub proof: TypeOneMultiSignature,
+    pub proof: SingleMessageAggregate,
 }

--- a/crates/common/consensus/lean/src/block.rs
+++ b/crates/common/consensus/lean/src/block.rs
@@ -25,7 +25,7 @@ use tree_hash_derive::TreeHash;
 #[cfg(feature = "devnet4")]
 use crate::attestation::{AggregatedAttestation, AggregatedAttestations, AggregatedSignatureProof};
 #[cfg(feature = "devnet5")]
-use crate::attestation::{AggregatedAttestation, AggregatedAttestations, TypeOneMultiSignature};
+use crate::attestation::{AggregatedAttestation, AggregatedAttestations, SingleMessageAggregate};
 use crate::state::LeanState;
 
 #[cfg(feature = "devnet4")]
@@ -287,7 +287,7 @@ pub struct BlockWithSignatures {
     pub signatures: VariableList<AggregatedSignatureProof, U4096>,
 
     #[cfg(feature = "devnet5")]
-    pub signatures: VariableList<TypeOneMultiSignature, U4096>,
+    pub signatures: VariableList<SingleMessageAggregate, U4096>,
 
     #[cfg(feature = "devnet5")]
     pub attestation_public_keys: Vec<Vec<ream_post_quantum_crypto::leansig::public_key::PublicKey>>,

--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -22,7 +22,7 @@ use tree_hash_derive::TreeHash;
 #[cfg(feature = "devnet4")]
 use crate::attestation::{AggregatedAttestation, AggregatedSignatureProof, AttestationData};
 #[cfg(feature = "devnet5")]
-use crate::attestation::{AggregatedAttestation, AttestationData, TypeOneMultiSignature};
+use crate::attestation::{AggregatedAttestation, AttestationData, SingleMessageAggregate};
 use crate::{
     block::{Block, BlockBody, BlockHeader},
     checkpoint::Checkpoint,
@@ -146,8 +146,8 @@ impl LeanState {
         &self,
         #[cfg(feature = "devnet4")] proofs: Option<&HashSet<AggregatedSignatureProof>>,
         #[cfg(feature = "devnet4")] selected_proofs: &mut Vec<AggregatedSignatureProof>,
-        #[cfg(feature = "devnet5")] proofs: Option<&HashSet<TypeOneMultiSignature>>,
-        #[cfg(feature = "devnet5")] selected_proofs: &mut Vec<TypeOneMultiSignature>,
+        #[cfg(feature = "devnet5")] proofs: Option<&HashSet<SingleMessageAggregate>>,
+        #[cfg(feature = "devnet5")] selected_proofs: &mut Vec<SingleMessageAggregate>,
         covered_validators: &mut HashSet<u64>,
     ) {
         let Some(proofs) = proofs else { return };

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, ensure};
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::attestation::AggregatedSignatureProof as PayloadProof;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature as PayloadProof;
+use ream_consensus_lean::attestation::SingleMessageAggregate as PayloadProof;
 use ream_consensus_lean::{
     attestation::{
         AggregatedAttestation, AggregatedAttestations, AttestationData, SignatureKey,

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -299,8 +299,9 @@ impl ValidatorService {
 
         let mut components = Vec::with_capacity(signatures.len() + 1);
         for (proof, public_keys) in signatures.iter().zip(attestation_public_keys.iter()) {
-            let component = type_1_from_wire(&proof.proof, public_keys)
-                .map_err(|err| anyhow!("Failed to reconstruct attestation Type-1 proof: {err}"))?;
+            let component = type_1_from_wire(&proof.proof, public_keys).map_err(|err| {
+                anyhow!("Failed to reconstruct attestation single-message aggregate proof: {err}")
+            })?;
             components.push(component);
         }
 
@@ -310,11 +311,11 @@ impl ValidatorService {
             &block_root_bytes,
             slot as u32,
         )
-        .map_err(|err| anyhow!("Failed to build proposer Type-1 proof: {err}"))?;
+        .map_err(|err| anyhow!("Failed to build proposer single-message aggregate proof: {err}"))?;
         components.push(proposer_type_1);
 
         let merged = type_2_merge(components)
-            .map_err(|err| anyhow!("Failed to merge block Type-2 proof: {err}"))?;
+            .map_err(|err| anyhow!("Failed to merge block multi-message aggregate proof: {err}"))?;
 
         Ok(SignedBlock {
             block,

--- a/crates/crypto/post_quantum/src/lean_multisig/type_2.rs
+++ b/crates/crypto/post_quantum/src/lean_multisig/type_2.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use lean_multisig_type2::{
-    TypeOneMultiSignature, TypeTwoMultiSignature, XmssPublicKey, XmssSignature, aggregate_type_1,
+    MultiMessageAggregate, SingleMessageAggregate, XmssPublicKey, XmssSignature, aggregate_type_1,
     merge_many_type_1, setup_prover, split_type_2, verify_type_1, verify_type_2,
 };
 
@@ -20,25 +20,26 @@ fn to_lib_signature(signature: &Signature) -> Result<XmssSignature> {
     signature.as_lean_sig()
 }
 
-pub fn type_1_from_wire(wire: &[u8], public_keys: &[PublicKey]) -> Result<TypeOneMultiSignature> {
+pub fn type_1_from_wire(wire: &[u8], public_keys: &[PublicKey]) -> Result<SingleMessageAggregate> {
     let lib_public_keys = public_keys
         .iter()
         .map(to_lib_public_key)
         .collect::<Result<Vec<_>>>()?;
-    TypeOneMultiSignature::decompress_without_pubkeys(wire, lib_public_keys)
-        .ok_or_else(|| anyhow!("Failed to decode Type-1 multi-signature from wire bytes"))
+    SingleMessageAggregate::decompress_without_pubkeys(wire, lib_public_keys).ok_or_else(|| {
+        anyhow!("Failed to decode single-message aggregate multi-signature from wire bytes")
+    })
 }
 
-pub fn type_1_to_wire(proof: &TypeOneMultiSignature) -> Vec<u8> {
+pub fn type_1_to_wire(proof: &SingleMessageAggregate) -> Vec<u8> {
     proof.compress_without_pubkeys()
 }
 
 pub fn type_1_aggregate(
-    children: &[TypeOneMultiSignature],
+    children: &[SingleMessageAggregate],
     raw_xmss: &[(PublicKey, Signature)],
     message: &[u8; 32],
     slot: u32,
-) -> Result<TypeOneMultiSignature> {
+) -> Result<SingleMessageAggregate> {
     type_2_setup();
 
     let raw: Vec<_> = raw_xmss
@@ -49,29 +50,30 @@ pub fn type_1_aggregate(
         .collect::<Result<Vec<_>>>()?;
 
     aggregate_type_1(children, raw, *message, slot, LOG_INV_RATE)
-        .map_err(|err| anyhow!("Type-1 aggregation failed: {err:?}"))
+        .map_err(|err| anyhow!("single-message aggregate aggregation failed: {err:?}"))
 }
 
-pub fn type_1_verify(proof: &TypeOneMultiSignature) -> Result<()> {
+pub fn type_1_verify(proof: &SingleMessageAggregate) -> Result<()> {
     type_2_setup();
     verify_type_1(proof)
         .map(|_| ())
-        .map_err(|err| anyhow!("Type-1 verification failed: {err:?}"))
+        .map_err(|err| anyhow!("single-message aggregate verification failed: {err:?}"))
 }
 
-pub fn type_2_merge(parts: Vec<TypeOneMultiSignature>) -> Result<TypeTwoMultiSignature> {
+pub fn type_2_merge(parts: Vec<SingleMessageAggregate>) -> Result<MultiMessageAggregate> {
     type_2_setup();
-    merge_many_type_1(parts, LOG_INV_RATE).map_err(|err| anyhow!("Type-2 merge failed: {err:?}"))
+    merge_many_type_1(parts, LOG_INV_RATE)
+        .map_err(|err| anyhow!("multi-message aggregate merge failed: {err:?}"))
 }
 
-pub fn type_2_to_wire(proof: &TypeTwoMultiSignature) -> Vec<u8> {
+pub fn type_2_to_wire(proof: &MultiMessageAggregate) -> Vec<u8> {
     proof.compress_without_pubkeys()
 }
 
 pub fn type_2_from_wire(
     wire: &[u8],
     public_keys_per_component: &[Vec<PublicKey>],
-) -> Result<TypeTwoMultiSignature> {
+) -> Result<MultiMessageAggregate> {
     let lib_public_keys = public_keys_per_component
         .iter()
         .map(|public_keys| {
@@ -81,20 +83,22 @@ pub fn type_2_from_wire(
                 .collect::<Result<Vec<_>>>()
         })
         .collect::<Result<Vec<_>>>()?;
-    TypeTwoMultiSignature::decompress_without_pubkeys(wire, lib_public_keys)
-        .ok_or_else(|| anyhow!("Failed to decode Type-2 multi-signature from wire bytes"))
+    MultiMessageAggregate::decompress_without_pubkeys(wire, lib_public_keys).ok_or_else(|| {
+        anyhow!("Failed to decode multi-message aggregate multi-signature from wire bytes")
+    })
 }
 
-pub fn type_2_verify(proof: &TypeTwoMultiSignature) -> Result<()> {
+pub fn type_2_verify(proof: &MultiMessageAggregate) -> Result<()> {
     type_2_setup();
     verify_type_2(proof)
         .map(|_| ())
-        .map_err(|err| anyhow!("Type-2 verification failed: {err:?}"))
+        .map_err(|err| anyhow!("multi-message aggregate verification failed: {err:?}"))
 }
 
-pub fn type_2_split(proof: TypeTwoMultiSignature, index: usize) -> Result<TypeOneMultiSignature> {
+pub fn type_2_split(proof: MultiMessageAggregate, index: usize) -> Result<SingleMessageAggregate> {
     type_2_setup();
-    split_type_2(proof, index, LOG_INV_RATE).map_err(|err| anyhow!("Type-2 split failed: {err:?}"))
+    split_type_2(proof, index, LOG_INV_RATE)
+        .map_err(|err| anyhow!("multi-message aggregate split failed: {err:?}"))
 }
 
 pub fn type_2_verify_block(
@@ -129,5 +133,5 @@ pub fn type_2_verify_block(
 
     verify_type_2(&proof)
         .map(|_| ())
-        .map_err(|err| anyhow!("Type-2 verification failed: {err:?}"))
+        .map_err(|err| anyhow!("multi-message aggregate verification failed: {err:?}"))
 }

--- a/crates/rpc/lean/src/handlers/test_driver.rs
+++ b/crates/rpc/lean/src/handlers/test_driver.rs
@@ -15,7 +15,7 @@ use ream_api_types_common::error::ApiError;
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::attestation::AggregatedSignatureProof;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature;
+use ream_consensus_lean::attestation::SingleMessageAggregate;
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::block::BlockSignatures;
 use ream_consensus_lean::{
@@ -381,7 +381,7 @@ fn convert_gossip_aggregate(
         #[cfg(feature = "devnet4")]
         proof: AggregatedSignatureProof::new(participants, proof_data),
         #[cfg(feature = "devnet5")]
-        proof: TypeOneMultiSignature::new(participants, proof),
+        proof: SingleMessageAggregate::new(participants, proof),
     })
 }
 

--- a/crates/storage/src/tables/lean/aggregated_payloads.rs
+++ b/crates/storage/src/tables/lean/aggregated_payloads.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use ream_consensus_lean::attestation::AggregatedSignatureProof;
 use ream_consensus_lean::attestation::SignatureKey;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature;
+use ream_consensus_lean::attestation::SingleMessageAggregate;
 use redb::{Database, Durability, TableDefinition};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{VariableList, typenum::U4096};
@@ -16,47 +16,44 @@ use crate::{
 
 /// Wrapper for a list of aggregated signature proofs.
 /// Uses VariableList for SSZ compatibility.
+#[cfg(feature = "devnet4")]
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 pub struct AggregatedPayloadList {
-    #[cfg(feature = "devnet4")]
     pub proofs: VariableList<AggregatedSignatureProof, U4096>,
-
-    #[cfg(feature = "devnet5")]
-    pub proofs: VariableList<TypeOneMultiSignature, U4096>,
 }
 
+#[cfg(feature = "devnet4")]
 impl AggregatedPayloadList {
     pub fn new() -> Self {
         Self {
             proofs: VariableList::empty(),
         }
     }
-
-    #[cfg(feature = "devnet4")]
     pub fn push(&mut self, proof: AggregatedSignatureProof) -> Result<(), ssz_types::Error> {
         self.proofs.push(proof)
     }
-
-    #[cfg(feature = "devnet5")]
-    pub fn push(&mut self, proof: TypeOneMultiSignature) -> Result<(), ssz_types::Error> {
-        self.proofs.push(proof)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.proofs.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.proofs.len()
-    }
-
-    #[cfg(feature = "devnet4")]
     pub fn iter(&self) -> impl Iterator<Item = &AggregatedSignatureProof> {
         self.proofs.iter()
     }
+}
 
-    #[cfg(feature = "devnet5")]
-    pub fn iter(&self) -> impl Iterator<Item = &TypeOneMultiSignature> {
+#[cfg(feature = "devnet5")]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub struct AggregatedPayloadList {
+    pub proofs: VariableList<SingleMessageAggregate, U4096>,
+}
+
+#[cfg(feature = "devnet5")]
+impl AggregatedPayloadList {
+    pub fn new() -> Self {
+        Self {
+            proofs: VariableList::empty(),
+        }
+    }
+    pub fn push(&mut self, proof: SingleMessageAggregate) -> Result<(), ssz_types::Error> {
+        self.proofs.push(proof)
+    }
+    pub fn iter(&self) -> impl Iterator<Item = &SingleMessageAggregate> {
         self.proofs.iter()
     }
 }
@@ -67,9 +64,17 @@ impl Default for AggregatedPayloadList {
     }
 }
 
+impl AggregatedPayloadList {
+    pub fn is_empty(&self) -> bool {
+        self.proofs.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.proofs.len()
+    }
+}
+
 /// Table for storing aggregated signature proofs learned from blocks.
-/// Key: SignatureKey (validator_id, attestation_data_root)
-/// Value: AggregatedPayloadList (list of AggregateSignature proofs)
 pub struct AggregatedPayloadsTable {
     pub db: Arc<Database>,
 }
@@ -110,7 +115,7 @@ impl AggregatedPayloadsTable {
     pub fn append_proof(
         &self,
         key: SignatureKey,
-        proof: TypeOneMultiSignature,
+        proof: SingleMessageAggregate,
     ) -> Result<(), StoreError> {
         let mut list = self.get(key.clone())?.unwrap_or_default();
         list.push(proof)

--- a/crates/storage/src/tables/lean/latest_known_aggregated_payloads.rs
+++ b/crates/storage/src/tables/lean/latest_known_aggregated_payloads.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use ream_consensus_lean::attestation::AggregatedSignatureProof as PayloadProof;
 use ream_consensus_lean::attestation::SignatureKey;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature as PayloadProof;
+use ream_consensus_lean::attestation::SingleMessageAggregate as PayloadProof;
 use redb::{Database, Durability, ReadableDatabase, ReadableTable, TableDefinition};
 
 use crate::{
@@ -19,7 +19,7 @@ pub struct LeanLatestKnownAggregatedPayloadsTable {
 /// Table definition for the Lean Latest Known Aggregated Payloads table
 ///
 /// Key: SignatureKey
-/// Value: [PayloadProof] (Maps to AggregatedSignatureProof on devnet4, TypeOneMultiSignature on
+/// Value: [PayloadProof] (Maps to AggregatedSignatureProof on devnet4, SingleMessageAggregate on
 /// devnet5)
 impl REDBTable for LeanLatestKnownAggregatedPayloadsTable {
     const TABLE_DEFINITION: TableDefinition<

--- a/crates/storage/src/tables/lean/latest_new_aggregated_payloads.rs
+++ b/crates/storage/src/tables/lean/latest_new_aggregated_payloads.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, sync::Arc};
 use ream_consensus_lean::attestation::AggregatedSignatureProof as PayloadProof;
 use ream_consensus_lean::attestation::SignatureKey;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature as PayloadProof;
+use ream_consensus_lean::attestation::SingleMessageAggregate as PayloadProof;
 use redb::{Database, Durability, ReadableDatabase, ReadableTable, TableDefinition};
 
 use crate::{
@@ -19,7 +19,7 @@ pub struct LeanLatestNewAggregatedPayloadsTable {
 /// Table definition for the Lean Latest New Aggregated Payloads table
 ///
 /// Key: SignatureKey
-/// Value: [PayloadProof] (Maps to AggregatedSignatureProof on devnet4, TypeOneMultiSignature on
+/// Value: [PayloadProof] (Maps to AggregatedSignatureProof on devnet4, SingleMessageAggregate on
 /// devnet5)
 impl REDBTable for LeanLatestNewAggregatedPayloadsTable {
     const TABLE_DEFINITION: TableDefinition<

--- a/testing/lean-spec-tests/src/fork_choice.rs
+++ b/testing/lean-spec-tests/src/fork_choice.rs
@@ -10,7 +10,7 @@ use ream_consensus_lean::attestation::AggregatedSignatureProof;
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::attestation::AttestationData;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature;
+use ream_consensus_lean::attestation::SingleMessageAggregate;
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::block::BlockSignatures;
 #[cfg(feature = "devnet4")]
@@ -212,7 +212,7 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
                 let proof = AggregatedSignatureProof::new(participants, proof_data);
 
                 #[cfg(feature = "devnet5")]
-                let proof = TypeOneMultiSignature::new(participants, proof);
+                let proof = SingleMessageAggregate::new(participants, proof);
 
                 let signed = SignedAggregatedAttestation {
                     data: attestation.data.clone(),

--- a/testing/lean-spec-tests/src/ssz.rs
+++ b/testing/lean-spec-tests/src/ssz.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, bail};
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::attestation::AggregatedSignatureProof;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature;
+use ream_consensus_lean::attestation::SingleMessageAggregate;
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::block::BlockSignatures;
 use ream_consensus_lean::{
@@ -92,10 +92,12 @@ pub fn run_ssz_test(test_name: &str, test: &SSZTest) -> anyhow::Result<bool> {
         >(&test.value, &expected_ssz),
 
         #[cfg(feature = "devnet5")]
-        "TypeOneMultiSignature" => run_test::<AggregatedSignatureProofJSON, TypeOneMultiSignature>(
-            &test.value,
-            &expected_ssz,
-        ),
+        "SingleMessageAggregate" => {
+            run_test::<AggregatedSignatureProofJSON, SingleMessageAggregate>(
+                &test.value,
+                &expected_ssz,
+            )
+        }
 
         _ => {
             warn!("Unknown type: {}, skipping", test.type_name);

--- a/testing/lean-spec-tests/src/types/ssz.rs
+++ b/testing/lean-spec-tests/src/types/ssz.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, ensure};
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::attestation::AggregatedSignatureProof;
 #[cfg(feature = "devnet5")]
-use ream_consensus_lean::attestation::TypeOneMultiSignature;
+use ream_consensus_lean::attestation::SingleMessageAggregate;
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::block::BlockSignatures;
 use ream_consensus_lean::{
@@ -426,7 +426,7 @@ impl TryFrom<&AggregatedSignatureProofJSON> for AggregatedSignatureProof {
 }
 
 #[cfg(feature = "devnet5")]
-impl TryFrom<&AggregatedSignatureProofJSON> for TypeOneMultiSignature {
+impl TryFrom<&AggregatedSignatureProofJSON> for SingleMessageAggregate {
     type Error = anyhow::Error;
 
     fn try_from(value: &AggregatedSignatureProofJSON) -> anyhow::Result<Self> {


### PR DESCRIPTION
### What was wrong?

Fixes: https://github.com/ReamLabs/ream/issues/1411

### How was it fixed?

renames TypeOneMultiSignature to SingleMessageAggregate and TypeTwoMultiSignature  to MultiMessageAggregate. I also update the 

It seems as though the leanvm devnet5 branch still needs to pass in the commit that changes these structs to there new names 
