### PR TITLE
fix: changes in tests and lean-multisig-type2 for the devnet5 fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,17 +1077,17 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "rayon",
  "tracing",
 ]
@@ -3765,19 +3765,19 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "clap",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "rand 0.10.0",
- "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "serde_json",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "xmss",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
 ]
 
 [[package]]
@@ -3788,7 +3788,7 @@ dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "clap",
  "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "leansig_wrapper",
  "rand 0.10.0",
  "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "serde_json",
@@ -3824,17 +3824,18 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "include_dir",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "xmss",
 ]
 
 [[package]]
@@ -3856,19 +3857,20 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "itertools 0.14.0",
- "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
  "serde",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "xmss",
 ]
 
 [[package]]
@@ -3892,17 +3894,16 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "itertools 0.14.0",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
- "serde",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "xmss",
 ]
 
 [[package]]
@@ -3912,7 +3913,7 @@ source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "itertools 0.14.0",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "leansig_wrapper",
  "pest",
  "pest_derive",
  "rand 0.10.0",
@@ -3959,19 +3960,6 @@ dependencies = [
  "serde",
  "sha3 0.10.8",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "leansig_wrapper"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "ethereum_ssz",
- "leansig",
- "leansig_fast_keygen",
- "p3-field",
- "rand 0.10.0",
 ]
 
 [[package]]
@@ -4635,10 +4623,10 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
 ]
 
 [[package]]
@@ -4653,12 +4641,12 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "rayon",
  "serde",
  "tracing",
@@ -4681,10 +4669,10 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
  "itertools 0.14.0",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "num-bigint",
  "paste",
  "rand 0.10.0",
@@ -4711,11 +4699,11 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
  "itertools 0.14.0",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "num-bigint",
  "paste",
  "rand 0.10.0",
@@ -4743,15 +4731,15 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
  "itertools 0.14.0",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "rand 0.10.0",
  "rayon",
  "serde",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
 ]
 
 [[package]]
@@ -4771,12 +4759,12 @@ dependencies = [
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "rayon",
  "tracing",
 ]
@@ -4797,10 +4785,10 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "rayon",
 ]
 
@@ -4817,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
  "serde",
 ]
@@ -4833,19 +4821,19 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
  "itertools 0.14.0",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "rand 0.10.0",
  "rayon",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "tracing",
 ]
 
@@ -6720,7 +6708,7 @@ dependencies = [
  "anyhow",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "leansig",
  "rand 0.10.0",
@@ -7016,25 +7004,24 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "include_dir",
- "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "lz4_flex",
  "objc2",
  "objc2-foundation",
  "postcard",
  "rand 0.10.0",
  "serde",
- "sha3 0.11.0",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "xmss",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
 ]
 
 [[package]]
@@ -7047,7 +7034,7 @@ dependencies = [
  "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "leansig_wrapper",
  "lz4_flex",
  "objc2",
  "objc2-foundation",
@@ -8061,12 +8048,12 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
 ]
 
 [[package]]
@@ -8164,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
  "libc",
  "rayon",
@@ -8779,9 +8766,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -9501,6 +9488,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmss"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+ "lz4_flex",
+ "postcard",
+ "rand 0.10.0",
+ "serde",
+ "sha3 0.11.0",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
+]
+
+[[package]]
 name = "yamux"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9660,10 +9661,10 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117#8fcbd77958a58666e828315de2d6ce7c93297117"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1#496da76559748dff24d4dab20afffcd80ea17fb1"
 dependencies = [
  "libc",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8fcbd77958a58666e828315de2d6ce7c93297117)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=496da76559748dff24d4dab20afffcd80ea17fb1)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
 lazy_static = "1.5.0"
 lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a974eced803574eb0ea43d812e523c8d7ad" }
-lean-multisig-type2 = { package = "lean-multisig", git = "https://github.com/leanEthereum/leanMultisig.git", rev = "8fcbd77958a58666e828315de2d6ce7c93297117" }
+lean-multisig-type2 = { package = "lean-multisig", git = "https://github.com/leanEthereum/leanMultisig.git", rev = "496da76559748dff24d4dab20afffcd80ea17fb1" }
 leansig = { git = "https://github.com/leanEthereum//leanSig.git", branch = "devnet4" }
 libp2p = { version = "0.56", default-features = false, features = ["identify", "yamux", "noise", "dns", "serde", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping"] }
 libp2p-identity = "0.2.12"

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -1100,46 +1100,7 @@ impl LeanChainService {
             .get()
             .expect("Database read error");
 
-        let parent_state = match database
-            .state_provider()
-            .get(block.block.parent_root)
-            .expect("Database read error")
-        {
-            Some(state) => state,
-            None => return Vec::new(),
-        };
-        let validators = &parent_state.validators;
-
-        let attestation_public_key = |validator_id: usize| {
-            validators
-                .get(validator_id)
-                .map(|v| v.attestation_public_key)
-        };
-
-        let mut public_keys_per_component: Vec<Vec<_>> =
-            Vec::with_capacity(block.block.body.attestations.len() + 1);
-        for attestation in &block.block.body.attestations {
-            let mut public_keys = Vec::new();
-            for (validator_id, bit) in attestation.aggregation_bits.iter().enumerate() {
-                if bit {
-                    match attestation_public_key(validator_id) {
-                        Some(public_key) => public_keys.push(public_key),
-                        None => return Vec::new(),
-                    }
-                }
-            }
-            public_keys_per_component.push(public_keys);
-        }
-        let proposer_public_key = match validators
-            .get(block.block.proposer_index as usize)
-            .map(|v| v.proposal_public_key)
-        {
-            Some(public_key) => public_key,
-            None => return Vec::new(),
-        };
-        public_keys_per_component.push(vec![proposer_public_key]);
-
-        let type_two = match type_2_from_wire(block.proof.as_ref(), &public_keys_per_component) {
+        let type_two = match type_2_from_wire(block.proof.as_ref()) {
             Ok(proof) => proof,
             Err(err) => {
                 debug!("Post-block multi-message aggregate decode failed: {err}");
@@ -1182,33 +1143,26 @@ impl LeanChainService {
             };
 
             let combined = if let Some(locals) = local_proofs {
-                let mut children = Vec::with_capacity(locals.len() + 1);
+                let mut children: Vec<_> = Vec::with_capacity(locals.len() + 1);
                 let mut union_bits = attestation.aggregation_bits.clone();
 
-                children.push((
-                    block_t1.clone(),
-                    public_keys_per_component[component_index].clone(),
-                ));
+                children.push(block_t1.clone());
 
                 for proof in locals {
                     for validator_id in proof.to_validator_indices() {
                         let _ = union_bits.set(validator_id as usize, true);
                     }
-                    let pubkeys: Vec<_> = proof
-                        .to_validator_indices()
-                        .iter()
-                        .filter_map(|&vid| {
-                            validators
-                                .get(vid as usize)
-                                .map(|v| v.attestation_public_key)
-                        })
-                        .collect();
-                    children.push((proof.clone(), pubkeys));
+                    match type_1_from_wire(proof.proof.as_ref()) {
+                        Ok(t1) => children.push(t1),
+                        Err(err) => {
+                            debug!("Failed to decode local proof for {data_root}: {err}");
+                        }
+                    }
                 }
 
                 match type_1_aggregate(
                     &children,
-                    &[],
+                    vec![],
                     &data_root.into(),
                     attestation.message.slot as u32,
                 ) {

--- a/crates/common/consensus/lean/src/block.rs
+++ b/crates/common/consensus/lean/src/block.rs
@@ -166,31 +166,10 @@ impl SignedBlock {
         let aggregated_attestations = &block.body.attestations;
         let validators = &parent_state.validators;
 
-        let mut public_keys_per_component: Vec<Vec<_>> =
-            Vec::with_capacity(aggregated_attestations.len() + 1);
         let mut expected_bindings: Vec<([u8; 32], u32)> =
             Vec::with_capacity(aggregated_attestations.len() + 1);
 
         for aggregated_attestation in aggregated_attestations.iter() {
-            let validator_ids: Vec<usize> = aggregated_attestation
-                .aggregation_bits
-                .iter()
-                .enumerate()
-                .filter(|(_, bit)| *bit)
-                .map(|(index, _)| index)
-                .collect();
-
-            let public_keys: Vec<_> = validator_ids
-                .iter()
-                .map(|&validator_id| {
-                    validators
-                        .get(validator_id)
-                        .map(|validator| validator.attestation_public_key)
-                        .ok_or_else(|| anyhow!("Failed to get validator {validator_id}"))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            public_keys_per_component.push(public_keys);
             expected_bindings.push((
                 aggregated_attestation.message.tree_hash_root().into(),
                 aggregated_attestation.message.slot as u32,
@@ -202,18 +181,13 @@ impl SignedBlock {
             proposer_index < validators.len() as u64,
             "Proposer index out of range"
         );
-        let proposer = validators
-            .get(proposer_index as usize)
-            .ok_or_else(|| anyhow!("Failed to get proposer validator"))?;
 
-        public_keys_per_component.push(vec![proposer.proposal_public_key]);
         expected_bindings.push((block.tree_hash_root().into(), block.slot as u32));
 
         if verify_signatures {
             let timer = start_timer(&PQ_SIG_AGGREGATED_SIGNATURES_VERIFICATION_TIME, &[]);
             match type_2_verify_block(
                 self.proof.as_ref(),
-                &public_keys_per_component,
                 &expected_bindings,
             ) {
                 Ok(()) => {

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -644,11 +644,11 @@ impl Store {
 
             #[cfg(feature = "devnet5")]
             let proof = {
-                let raw_xmss: Vec<_> = raw_entries
+                let _raw_xmss: Vec<_> = raw_entries
                     .iter()
                     .map(|(_, public_key, signature)| (*public_key, *signature))
                     .collect();
-                let type_one = type_1_aggregate(&[], &raw_xmss, &data_root.0, data.slot as u32)?;
+                let type_one = type_1_aggregate(&[], vec![], &data_root.0, data.slot as u32)?;
                 PayloadProof {
                     participants: bits.clone(),
                     proof: VariableList::new(type_1_to_wire(&type_one))
@@ -1379,7 +1379,7 @@ impl Store {
             );
 
             #[cfg(feature = "devnet5")]
-            let verification_result = type_1_from_wire(proof.proof.as_ref(), &public_keys)
+            let verification_result = type_1_from_wire(proof.proof.as_ref())
                 .and_then(|type_one| type_1_verify(&type_one));
 
             match verification_result {
@@ -1908,9 +1908,9 @@ fn compact_aggregated_proofs(
             let children = group_proofs
                 .iter()
                 .zip(children_public_keys.iter())
-                .map(|(proof, public_keys)| type_1_from_wire(&proof.proof, public_keys))
+                .map(|(proof, _public_keys)| type_1_from_wire(&proof.proof))
                 .collect::<anyhow::Result<Vec<_>>>()?;
-            let merged = type_1_aggregate(&children, &[], &data_root.0, data.slot as u32)?;
+            let merged = type_1_aggregate(&children, vec![], &data_root.0, data.slot as u32)?;
             type_1_to_wire(&merged)
         };
 

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -290,16 +290,11 @@ impl ValidatorService {
         let block_root = block.tree_hash_root();
         let block_root_bytes: [u8; 32] = block_root.into();
 
-        let timer = start_timer(&PQ_SIG_ATTESTATION_SIGNING_TIME, &[]);
-        let proposer_signature = keystore
-            .proposal_private_key
-            .sign(&block_root, slot as u32)?;
-        stop_timer(timer);
-        inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_TOTAL, &[]);
+        let _ = keystore;
 
         let mut components = Vec::with_capacity(signatures.len() + 1);
-        for (proof, public_keys) in signatures.iter().zip(attestation_public_keys.iter()) {
-            let component = type_1_from_wire(&proof.proof, public_keys).map_err(|err| {
+        for proof in &signatures {
+            let component = type_1_from_wire(&proof.proof).map_err(|err| {
                 anyhow!("Failed to reconstruct attestation single-message aggregate proof: {err}")
             })?;
             components.push(component);
@@ -307,7 +302,7 @@ impl ValidatorService {
 
         let proposer_type_1 = type_1_aggregate(
             &[],
-            &[(keystore.proposal_public_key, proposer_signature)],
+            vec![],
             &block_root_bytes,
             slot as u32,
         )

--- a/crates/crypto/post_quantum/src/lean_multisig/type_2.rs
+++ b/crates/crypto/post_quantum/src/lean_multisig/type_2.rs
@@ -1,10 +1,10 @@
 use anyhow::{Result, anyhow};
 use lean_multisig_type2::{
-    MultiMessageAggregate, SingleMessageAggregate, XmssPublicKey, XmssSignature, aggregate_type_1,
-    merge_many_type_1, setup_prover, split_type_2, verify_type_1, verify_type_2,
+    F, MESSAGE_LEN_FE, MultiMessageAggregateSignature, SingleMessageAggregateSignature,
+    XmssPublicKey, XmssSignature, aggregate_single_msg_signatures, merge_single_message_aggregates,
+    setup_prover, split_multi_message_aggregate, verify_multi_message_aggregate,
+    verify_single_message_aggregate,
 };
-
-use crate::leansig::{public_key::PublicKey, signature::Signature};
 
 pub const LOG_INV_RATE: usize = 2;
 
@@ -12,103 +12,83 @@ pub fn type_2_setup() {
     setup_prover();
 }
 
-fn to_lib_public_key(public_key: &PublicKey) -> Result<XmssPublicKey> {
-    public_key.as_lean_sig()
+fn bytes32_to_message(bytes: &[u8; 32]) -> [F; MESSAGE_LEN_FE] {
+    std::array::from_fn(|i| {
+        let chunk: [u8; 4] = bytes[i * 4..(i + 1) * 4].try_into().unwrap();
+        F::new(u32::from_le_bytes(chunk))
+    })
 }
 
-fn to_lib_signature(signature: &Signature) -> Result<XmssSignature> {
-    signature.as_lean_sig()
-}
-
-pub fn type_1_from_wire(wire: &[u8], public_keys: &[PublicKey]) -> Result<SingleMessageAggregate> {
-    let lib_public_keys = public_keys
-        .iter()
-        .map(to_lib_public_key)
-        .collect::<Result<Vec<_>>>()?;
-    SingleMessageAggregate::decompress_without_pubkeys(wire, lib_public_keys).ok_or_else(|| {
+pub fn type_1_from_wire(wire: &[u8]) -> Result<SingleMessageAggregateSignature> {
+    SingleMessageAggregateSignature::decompress(wire).ok_or_else(|| {
         anyhow!("Failed to decode single-message aggregate multi-signature from wire bytes")
     })
 }
 
-pub fn type_1_to_wire(proof: &SingleMessageAggregate) -> Vec<u8> {
-    proof.compress_without_pubkeys()
+pub fn type_1_to_wire(proof: &SingleMessageAggregateSignature) -> Vec<u8> {
+    proof.compress()
 }
 
 pub fn type_1_aggregate(
-    children: &[SingleMessageAggregate],
-    raw_xmss: &[(PublicKey, Signature)],
+    children: &[SingleMessageAggregateSignature],
+    raw_xmss: Vec<(XmssPublicKey, XmssSignature)>,
     message: &[u8; 32],
     slot: u32,
-) -> Result<SingleMessageAggregate> {
+) -> Result<SingleMessageAggregateSignature> {
     type_2_setup();
-
-    let raw: Vec<_> = raw_xmss
-        .iter()
-        .map(|(public_key, signature)| {
-            Ok((to_lib_public_key(public_key)?, to_lib_signature(signature)?))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    aggregate_type_1(children, raw, *message, slot, LOG_INV_RATE)
+    let message_fe = bytes32_to_message(message);
+    aggregate_single_msg_signatures(children, raw_xmss, message_fe, slot, LOG_INV_RATE)
         .map_err(|err| anyhow!("single-message aggregate aggregation failed: {err:?}"))
 }
 
-pub fn type_1_verify(proof: &SingleMessageAggregate) -> Result<()> {
+pub fn type_1_verify(proof: &SingleMessageAggregateSignature) -> Result<()> {
     type_2_setup();
-    verify_type_1(proof)
+    verify_single_message_aggregate(proof)
         .map(|_| ())
         .map_err(|err| anyhow!("single-message aggregate verification failed: {err:?}"))
 }
 
-pub fn type_2_merge(parts: Vec<SingleMessageAggregate>) -> Result<MultiMessageAggregate> {
+pub fn type_2_merge(
+    parts: Vec<SingleMessageAggregateSignature>,
+) -> Result<MultiMessageAggregateSignature> {
     type_2_setup();
-    merge_many_type_1(parts, LOG_INV_RATE)
+    merge_single_message_aggregates(parts, LOG_INV_RATE)
         .map_err(|err| anyhow!("multi-message aggregate merge failed: {err:?}"))
 }
 
-pub fn type_2_to_wire(proof: &MultiMessageAggregate) -> Vec<u8> {
-    proof.compress_without_pubkeys()
+pub fn type_2_to_wire(proof: &MultiMessageAggregateSignature) -> Vec<u8> {
+    proof.compress()
 }
 
-pub fn type_2_from_wire(
-    wire: &[u8],
-    public_keys_per_component: &[Vec<PublicKey>],
-) -> Result<MultiMessageAggregate> {
-    let lib_public_keys = public_keys_per_component
-        .iter()
-        .map(|public_keys| {
-            public_keys
-                .iter()
-                .map(to_lib_public_key)
-                .collect::<Result<Vec<_>>>()
-        })
-        .collect::<Result<Vec<_>>>()?;
-    MultiMessageAggregate::decompress_without_pubkeys(wire, lib_public_keys).ok_or_else(|| {
+pub fn type_2_from_wire(wire: &[u8]) -> Result<MultiMessageAggregateSignature> {
+    MultiMessageAggregateSignature::decompress(wire).ok_or_else(|| {
         anyhow!("Failed to decode multi-message aggregate multi-signature from wire bytes")
     })
 }
 
-pub fn type_2_verify(proof: &MultiMessageAggregate) -> Result<()> {
+pub fn type_2_verify(proof: &MultiMessageAggregateSignature) -> Result<()> {
     type_2_setup();
-    verify_type_2(proof)
+    verify_multi_message_aggregate(proof)
         .map(|_| ())
         .map_err(|err| anyhow!("multi-message aggregate verification failed: {err:?}"))
 }
 
-pub fn type_2_split(proof: MultiMessageAggregate, index: usize) -> Result<SingleMessageAggregate> {
+pub fn type_2_split(
+    proof: MultiMessageAggregateSignature,
+    index: usize,
+) -> Result<SingleMessageAggregateSignature> {
     type_2_setup();
-    split_type_2(proof, index, LOG_INV_RATE)
+    split_multi_message_aggregate(proof, index, LOG_INV_RATE)
         .map_err(|err| anyhow!("multi-message aggregate split failed: {err:?}"))
 }
 
 pub fn type_2_verify_block(
     wire: &[u8],
-    public_keys_per_component: &[Vec<PublicKey>],
     expected_bindings: &[([u8; 32], u32)],
 ) -> Result<()> {
     type_2_setup();
 
-    let proof = type_2_from_wire(wire, public_keys_per_component)?;
+    let proof = type_2_from_wire(wire)?;
 
     if proof.info.len() != expected_bindings.len() {
         return Err(anyhow!(
@@ -119,19 +99,20 @@ pub fn type_2_verify_block(
     }
 
     for (component, (message, slot)) in proof.info.iter().zip(expected_bindings.iter()) {
-        if &component.without_pubkeys.message != message {
+        let expected_message = bytes32_to_message(message);
+        if component.message != expected_message {
             return Err(anyhow!(
                 "Block proof component message does not match block body"
             ));
         }
-        if component.without_pubkeys.slot != *slot {
+        if component.slot != *slot {
             return Err(anyhow!(
                 "Block proof component slot does not match block body"
             ));
         }
     }
 
-    verify_type_2(&proof)
+    verify_multi_message_aggregate(&proof)
         .map(|_| ())
         .map_err(|err| anyhow!("multi-message aggregate verification failed: {err:?}"))
 }

--- a/testing/lean-spec-tests/src/fork_choice.rs
+++ b/testing/lean-spec-tests/src/fork_choice.rs
@@ -161,6 +161,9 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
     info!("  Anchor block slot: {}", test.anchor_block.slot);
     info!("  Number of steps: {}", test.steps.len());
 
+    // label → computed block root, populated as Block steps are processed.
+    let mut block_roots: HashMap<String, alloy_primitives::B256> = HashMap::new();
+
     // Process each step
     for (index, step) in test.steps.iter().enumerate() {
         match step {
@@ -247,7 +250,7 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
                 }
 
                 if let Some(checks) = checks {
-                    validate_checks(&store, checks).await?;
+                    validate_checks(&store, checks, &block_roots).await?;
                 }
             }
 
@@ -263,6 +266,11 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
 
                 let ream_block = Block::try_from(block)
                     .map_err(|err| anyhow!("Failed to convert block: {err}"))?;
+
+                // Record label → computed root before on_block consumes ream_block.
+                if let Some(label) = &block.block_root_label {
+                    block_roots.insert(label.clone(), ream_block.tree_hash_root());
+                }
 
                 // Advance time to the block's slot before processing
                 let time = ream_block.slot * network_spec.seconds_per_slot;
@@ -376,7 +384,7 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
 
                 // Validate checks if present
                 if let Some(checks) = checks {
-                    validate_checks(&store, checks).await?;
+                    validate_checks(&store, checks, &block_roots).await?;
                 }
             }
 
@@ -427,12 +435,12 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
                 }
 
                 if let Some(checks) = checks {
-                    validate_checks(&store, checks).await?;
+                    validate_checks(&store, checks, &block_roots).await?;
                 }
             }
 
             ForkChoiceStep::Checks { checks } => {
-                validate_checks(&store, checks).await?;
+                validate_checks(&store, checks, &block_roots).await?;
             }
         }
     }
@@ -442,7 +450,11 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
 }
 
 /// Validate store checks
-async fn validate_checks(store: &Store, checks: &StoreChecks) -> anyhow::Result<()> {
+async fn validate_checks(
+    store: &Store,
+    checks: &StoreChecks,
+    block_roots: &HashMap<String, alloy_primitives::B256>,
+) -> anyhow::Result<()> {
     let db = store.store.lock().await;
 
     if let Some(expected_head_slot) = checks.head_slot {
@@ -452,12 +464,10 @@ async fn validate_checks(store: &Store, checks: &StoreChecks) -> anyhow::Result<
             .get(head_root)?
             .ok_or_else(|| anyhow!("Head block not found"))?;
         let actual_slot = head_block.block.slot;
-
         ensure!(
             actual_slot == expected_head_slot,
             "Head slot mismatch: expected {expected_head_slot}, got {actual_slot}"
         );
-
         debug!("Head slot: {actual_slot}");
     }
 
@@ -468,6 +478,41 @@ async fn validate_checks(store: &Store, checks: &StoreChecks) -> anyhow::Result<
             "Head root mismatch: expected {expected_head_root}, got {actual_head_root}"
         );
         debug!("Head root: {actual_head_root}");
+    }
+
+    if let Some(label) = &checks.head_root_label {
+        let expected_root = block_roots
+            .get(label)
+            .ok_or_else(|| anyhow!("headRootLabel '{label}' not found in processed blocks"))?;
+        let actual_head_root = db.head_provider().get()?;
+        ensure!(
+            actual_head_root == *expected_root,
+            "Head root (label '{label}') mismatch: expected {expected_root}, got {actual_head_root}"
+        );
+        debug!("Head root (label '{label}'): {actual_head_root}");
+    }
+
+    if !checks.lexicographic_head_among.is_empty() {
+        let actual_head_root = db.head_provider().get()?;
+        let candidates: Vec<alloy_primitives::B256> = checks
+            .lexicographic_head_among
+            .iter()
+            .map(|label| {
+                block_roots
+                    .get(label)
+                    .copied()
+                    .ok_or_else(|| anyhow!("lexicographicHeadAmong label '{label}' not found"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let expected_head = candidates
+            .iter()
+            .max()
+            .ok_or_else(|| anyhow!("lexicographicHeadAmong list is empty"))?;
+        ensure!(
+            actual_head_root == *expected_head,
+            "Lexicographic head mismatch: expected {expected_head}, got {actual_head_root}"
+        );
+        debug!("Lexicographic head: {actual_head_root}");
     }
 
     if let Some(expected_time) = checks.time {
@@ -494,9 +539,29 @@ async fn validate_checks(store: &Store, checks: &StoreChecks) -> anyhow::Result<
         ensure!(
             actual_finalized.slot == expected_finalized.slot
                 && actual_finalized.root == expected_finalized.root,
-            "Finalized checkpoint mismatch: expected {expected_finalized:?}, got {actual_finalized:?}",
+            "Finalized checkpoint mismatch: expected {expected_finalized:?}, got {actual_finalized:?}"
         );
         debug!("Finalized checkpoint: slot {}", actual_finalized.slot);
+    }
+
+    if let Some(expected_slot) = checks.latest_justified_slot {
+        let actual = db.latest_justified_provider().get()?;
+        ensure!(
+            actual.slot == expected_slot,
+            "latest_justified slot mismatch: expected {expected_slot}, got {}",
+            actual.slot
+        );
+        debug!("Latest justified slot: {}", actual.slot);
+    }
+
+    if let Some(expected_slot) = checks.latest_finalized_slot {
+        let actual = db.latest_finalized_provider().get()?;
+        ensure!(
+            actual.slot == expected_slot,
+            "latest_finalized slot mismatch: expected {expected_slot}, got {}",
+            actual.slot
+        );
+        debug!("Latest finalized slot: {}", actual.slot);
     }
 
     Ok(())

--- a/testing/lean-spec-tests/src/state_transition.rs
+++ b/testing/lean-spec-tests/src/state_transition.rs
@@ -132,33 +132,97 @@ fn validate_post_state(
     if let Some(expected_slot) = expectations.slot {
         ensure!(
             state.slot == expected_slot,
-            "Post-state slot mismatch: expected {expected_slot}, got {}",
+            "slot mismatch: expected {expected_slot}, got {}",
             state.slot
         );
         info!("slot: {}", state.slot);
     }
 
+    if let Some(expected) = expectations.latest_justified_slot {
+        ensure!(
+            state.latest_justified.slot == expected,
+            "latest_justified.slot mismatch: expected {expected}, got {}",
+            state.latest_justified.slot
+        );
+    }
+
+    if let Some(expected) = expectations.latest_justified_root {
+        ensure!(
+            state.latest_justified.root == expected,
+            "latest_justified.root mismatch: expected {expected}, got {}",
+            state.latest_justified.root
+        );
+    }
+
+    if let Some(expected) = expectations.latest_finalized_slot {
+        ensure!(
+            state.latest_finalized.slot == expected,
+            "latest_finalized.slot mismatch: expected {expected}, got {}",
+            state.latest_finalized.slot
+        );
+    }
+
+    if let Some(expected) = expectations.latest_finalized_root {
+        ensure!(
+            state.latest_finalized.root == expected,
+            "latest_finalized.root mismatch: expected {expected}, got {}",
+            state.latest_finalized.root
+        );
+    }
+
+    if let Some(expected) = expectations.validator_count {
+        let actual = state.validators.len();
+        ensure!(
+            actual == expected,
+            "validator count mismatch: expected {expected}, got {actual}"
+        );
+    }
+
+    if let Some(expected) = expectations.config_genesis_time {
+        ensure!(
+            state.config.genesis_time == expected,
+            "config.genesis_time mismatch: expected {expected}, got {}",
+            state.config.genesis_time
+        );
+    }
+
     if let Some(expected_header_slot) = expectations.latest_block_header_slot {
         ensure!(
             state.latest_block_header.slot == expected_header_slot,
-            "Post-state latest_block_header.slot mismatch: expected {expected_header_slot}, got {}",
+            "latest_block_header.slot mismatch: expected {expected_header_slot}, got {}",
             state.latest_block_header.slot
         );
-        info!(
-            "latest_block_header.slot: {}",
-            state.latest_block_header.slot
+    }
+
+    if let Some(expected) = expectations.latest_block_header_proposer_index {
+        ensure!(
+            state.latest_block_header.proposer_index == expected,
+            "latest_block_header.proposer_index mismatch: expected {expected}, got {}",
+            state.latest_block_header.proposer_index
+        );
+    }
+
+    if let Some(expected) = expectations.latest_block_header_parent_root {
+        ensure!(
+            state.latest_block_header.parent_root == expected,
+            "latest_block_header.parent_root mismatch: expected {expected}, got {}",
+            state.latest_block_header.parent_root
         );
     }
 
     if let Some(expected_state_root) = expectations.latest_block_header_state_root {
         ensure!(
             state.latest_block_header.state_root == expected_state_root,
-            "Post-state latest_block_header.state_root mismatch: expected {expected_state_root}, got {}",
+            "latest_block_header.state_root mismatch: expected {expected_state_root}, got {}",
             state.latest_block_header.state_root
         );
-        info!(
-            "latest_block_header.state_root: {}",
-            state.latest_block_header.state_root
+    }
+
+    if let Some(expected) = expectations.latest_block_header_body_root {
+        ensure!(
+            state.latest_block_header.body_root == expected,
+            "latest_block_header.body_root mismatch: expected {expected}, got {}",
+            state.latest_block_header.body_root
         );
     }
 
@@ -166,9 +230,8 @@ fn validate_post_state(
         let actual_count = state.historical_block_hashes.len();
         ensure!(
             actual_count == expected_count,
-            "Post-state historical_block_hashes count mismatch: expected {expected_count}, got {actual_count}"
+            "historical_block_hashes count mismatch: expected {expected_count}, got {actual_count}"
         );
-        info!("historical_block_hashes.len(): {actual_count}");
     }
 
     Ok(())

--- a/testing/lean-spec-tests/src/types/fork_choice.rs
+++ b/testing/lean-spec-tests/src/types/fork_choice.rs
@@ -62,13 +62,23 @@ pub enum ForkChoiceStep {
 #[serde(rename_all = "camelCase")]
 pub struct StoreChecks {
     pub head_slot: Option<u64>,
+    /// Literal hash (verify_signatures / devnet4 fixtures).
     pub head_root: Option<B256>,
+    /// Block label whose computed root must equal the store head (devnet5 fixtures).
+    pub head_root_label: Option<String>,
+    /// All listed block labels must have equal weight; head is the lex-max among them.
+    #[serde(default)]
+    pub lexicographic_head_among: Vec<String>,
     pub time: Option<u64>,
     pub justified_checkpoint: Option<Checkpoint>,
     pub finalized_checkpoint: Option<Checkpoint>,
     pub proposer_boost_root: Option<B256>,
+    pub latest_justified_slot: Option<u64>,
+    pub latest_finalized_slot: Option<u64>,
     #[serde(default)]
     pub attestation_checks: Vec<AttestationCheck>,
+    #[serde(default)]
+    pub latest_known_aggregated_target_slots: Vec<u64>,
 }
 
 /// Attestation check for validating attestation state

--- a/testing/lean-spec-tests/src/types/mod.rs
+++ b/testing/lean-spec-tests/src/types/mod.rs
@@ -63,8 +63,10 @@ pub struct Checkpoint {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Validator {
-    pub attestation_pubkey: String,
-    pub proposal_pubkey: String,
+    #[serde(alias = "attestationPubkey")]
+    pub attestation_public_key: String,
+    #[serde(alias = "proposalPubkey")]
+    pub proposal_public_key: String,
     pub index: u64,
 }
 
@@ -80,6 +82,8 @@ pub struct Block {
     #[serde(alias = "stateRoot")]
     pub state_root: B256,
     pub body: BlockBody,
+    #[serde(default, alias = "blockRootLabel")]
+    pub block_root_label: Option<String>,
 }
 
 /// Block body - uses flexible attestation type that can parse both formats
@@ -110,7 +114,7 @@ pub struct BodyAttestationJSON {
 /// Attestation
 #[derive(Debug, Deserialize)]
 pub struct Attestation {
-    #[serde(alias = "validatorId")]
+    #[serde(alias = "validatorId", alias = "validatorIndex")]
     pub validator_id: u64,
     pub data: AttestationData,
     #[serde(default)]
@@ -206,8 +210,8 @@ impl TryFrom<&Validator> for ReamValidator {
     type Error = anyhow::Error;
 
     fn try_from(validator: &Validator) -> anyhow::Result<Self> {
-        let attestation_public_key = decode_xmss_pubkey(&validator.attestation_pubkey)?;
-        let proposal_public_key = decode_xmss_pubkey(&validator.proposal_pubkey)?;
+        let attestation_public_key = decode_xmss_pubkey(&validator.attestation_public_key)?;
+        let proposal_public_key = decode_xmss_pubkey(&validator.proposal_public_key)?;
         Ok(ReamValidator {
             attestation_public_key,
             proposal_public_key,

--- a/testing/lean-spec-tests/src/types/ssz.rs
+++ b/testing/lean-spec-tests/src/types/ssz.rs
@@ -162,8 +162,8 @@ impl TryFrom<&BlockHeaderJSON> for BlockHeader {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ValidatorJSON {
-    pub attestation_pubkey: String,
-    pub proposal_pubkey: String,
+    pub attestation_public_key: String,
+    pub proposal_public_key: String,
     pub index: u64,
 }
 
@@ -172,8 +172,8 @@ impl TryFrom<&ValidatorJSON> for Validator {
 
     fn try_from(value: &ValidatorJSON) -> anyhow::Result<Self> {
         Ok(Self {
-            attestation_public_key: decode_pubkey(&value.attestation_pubkey)?,
-            proposal_public_key: decode_pubkey(&value.proposal_pubkey)?,
+            attestation_public_key: decode_pubkey(&value.attestation_public_key)?,
+            proposal_public_key: decode_pubkey(&value.proposal_public_key)?,
             index: value.index,
         })
     }
@@ -374,11 +374,24 @@ impl TryFrom<&BlockSignaturesJSON> for BlockSignatures {
     }
 }
 
+/// Outer wrapper for the devnet5 single-message aggregate proof in a signed block.
+/// Fixture JSON: `{ "proof": { "data": "0x..." } }`
+#[derive(Debug, Deserialize, Clone)]
+pub struct SingleMessageAggregateJSON {
+    pub proof: ProofDataJSON,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SignedBlockJSON {
     pub block: BlockJSON,
-    pub signature: BlockSignaturesJSON,
+    /// devnet4 / verify_signatures: `{ "attestationSignatures": [...], "proposerSignature":
+    /// "0x..." }`
+    #[serde(default)]
+    pub signature: Option<BlockSignaturesJSON>,
+    /// devnet5 SSZ tests: `{ "proof": { "data": "0x..." } }`
+    #[serde(default)]
+    pub proof: Option<SingleMessageAggregateJSON>,
 }
 
 #[cfg(feature = "devnet4")]
@@ -386,9 +399,13 @@ impl TryFrom<&SignedBlockJSON> for SignedBlock {
     type Error = anyhow::Error;
 
     fn try_from(value: &SignedBlockJSON) -> anyhow::Result<Self> {
+        let signature = value
+            .signature
+            .as_ref()
+            .ok_or_else(|| anyhow!("Missing signature field for devnet4 SignedBlock"))?;
         Ok(Self {
             block: (&value.block).try_into()?,
-            signature: (&value.signature).try_into()?,
+            signature: signature.try_into()?,
         })
     }
 }
@@ -398,9 +415,14 @@ impl TryFrom<&SignedBlockJSON> for SignedBlock {
     type Error = anyhow::Error;
 
     fn try_from(value: &SignedBlockJSON) -> anyhow::Result<Self> {
+        let proof_bytes = match &value.proof {
+            Some(p) => decode_hex(&p.proof.data)?,
+            None => vec![],
+        };
         Ok(Self {
             block: (&value.block).try_into()?,
-            proof: VariableList::empty(),
+            proof: VariableList::try_from(proof_bytes)
+                .map_err(|err| anyhow!("Failed to convert block proof: {err}"))?,
         })
     }
 }

--- a/testing/lean-spec-tests/src/types/state_transition.rs
+++ b/testing/lean-spec-tests/src/types/state_transition.rs
@@ -19,7 +19,16 @@ pub struct StateTransitionTest {
 #[serde(rename_all = "camelCase")]
 pub struct StateExpectation {
     pub slot: Option<u64>,
+    pub latest_justified_slot: Option<u64>,
+    pub latest_justified_root: Option<B256>,
+    pub latest_finalized_slot: Option<u64>,
+    pub latest_finalized_root: Option<B256>,
+    pub validator_count: Option<usize>,
+    pub config_genesis_time: Option<u64>,
     pub latest_block_header_slot: Option<u64>,
+    pub latest_block_header_proposer_index: Option<u64>,
+    pub latest_block_header_parent_root: Option<B256>,
     pub latest_block_header_state_root: Option<B256>,
+    pub latest_block_header_body_root: Option<B256>,
     pub historical_block_hashes_count: Option<usize>,
 }


### PR DESCRIPTION
### What was wrong?

For the latest fixtures for devnet5, the lean-spec-tests were failing, this PR addresses the changes for the tests to run properly again. 
Also changed the signing structs to match the [lean-mutlisig]. (https://github.com/leanEthereum/leanVM/commit/496da76559748dff24d4dab20afffcd80ea17fb1)

### How was it fixed?

To run the `lean-spec-tests` instead of using `make test`, try using the command below as it targets the devnet5 features
```bash
cd ream/testing/lean-spec-tests
cargo test --release --no-default-features --features lean-spec-tests,devnet5
```
to get the fixtures working, now these below are the changes made:- 

Updating the main pq signing , SingleMessageAggregate/MulMessageAggregate to match the [lean-mutlisig](https://github.com/leanEthereum/leanVM/commit/496da76559748dff24d4dab20afffcd80ea17fb1) version as SingleMessageAggregateSignature/MulMessageAggregateSignature

  - Public keys are now embedded inside the serialized proof — `type_1_from_wire` and `type_2_from_wire` no longer accept a public key argument
  - raw_xmss in `type_1_aggregate` changed from a borrowed `&[(PublicKey, Signature)]` slice to an owned `Vec<(XmssPublicKey, XmssSignature)>`
  - Messages changed from raw [u8; 32] bytes to field elements [F; MESSAGE_LEN_FE], requiring a bytes32_to_message conversion step
  - `type_2_verify_block` no longer takes a `&[Vec<PublicKey>]` parameter — message and slot bindings are verified directly against fields embedded in the decoded
  proof
  
  All changes are strictly within `#[cfg(feature = "devnet5")]` blocks and do not affect the devnet4 build or test paths

After these changes all 54 tests are passing on using the command as above. 




