### PR TITLE
chore: update lean multisig hash for devnet4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -700,7 +700,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1077,6 +1077,25 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "backend"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "backend"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -1088,24 +1107,6 @@ dependencies = [
  "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "rayon",
- "tracing",
-]
-
-[[package]]
-name = "backend"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "rayon",
  "tracing",
 ]
@@ -2184,7 +2185,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2447,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3765,6 +3766,25 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "clap",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "rand 0.10.0",
+ "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "serde_json",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "lean-multisig"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -3778,24 +3798,6 @@ dependencies = [
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
-]
-
-[[package]]
-name = "lean-multisig"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "clap",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rand 0.10.0",
- "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "serde_json",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
 ]
 
 [[package]]
@@ -3824,6 +3826,22 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "include_dir",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "pest",
+ "pest_derive",
+ "rand 0.10.0",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "tracing",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "lean_compiler"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -3838,19 +3856,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "lean_compiler"
+name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "include_dir",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "itertools 0.14.0",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "serde",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -3872,21 +3892,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "lean_prover"
+name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "itertools 0.14.0",
- "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
  "serde",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -3903,22 +3921,6 @@ dependencies = [
  "serde",
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
-]
-
-[[package]]
-name = "lean_vm"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "itertools 0.14.0",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "pest",
- "pest_derive",
- "rand 0.10.0",
- "serde",
- "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
 ]
 
 [[package]]
@@ -3964,9 +3966,9 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "ethereum_ssz",
  "leansig",
  "leansig_fast_keygen",
@@ -3977,9 +3979,9 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "ethereum_ssz",
  "leansig",
  "leansig_fast_keygen",
@@ -4635,6 +4637,15 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "mt-air"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "mt-air"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -4642,12 +4653,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-air"
+name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -4665,15 +4681,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-fiat-shamir"
+name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rayon",
+ "itertools 0.14.0",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "num-bigint",
+ "parallel",
+ "paste",
+ "rand 0.10.0",
  "serde",
  "tracing",
 ]
@@ -4694,16 +4711,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-field"
+name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
  "itertools 0.14.0",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "num-bigint",
  "paste",
  "rand 0.10.0",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -4725,19 +4742,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-koala-bear"
+name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
  "itertools 0.14.0",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "num-bigint",
- "paste",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
  "rand 0.10.0",
- "rayon",
  "serde",
- "tracing",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -4755,17 +4771,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-poly"
+name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "itertools 0.14.0",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rand 0.10.0",
- "rayon",
- "serde",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -4782,16 +4798,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-sumcheck"
+name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rayon",
- "tracing",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -4805,13 +4819,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-symetric"
+name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -4823,11 +4835,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-utils"
+name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "serde",
+ "itertools 0.14.0",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "rand 0.10.0",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -4846,25 +4870,6 @@ dependencies = [
  "rand 0.10.0",
  "rayon",
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "tracing",
-]
-
-[[package]]
-name = "mt-whir"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "itertools 0.14.0",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rand 0.10.0",
- "rayon",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "tracing",
 ]
 
@@ -5006,7 +5011,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5160,7 +5165,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -5175,7 +5180,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -5188,21 +5193,21 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
- "spin 0.10.0",
+ "spin 0.11.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-field"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -5217,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -5232,7 +5237,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5246,12 +5251,12 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 
 [[package]]
 name = "p3-mds"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -5263,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -5279,16 +5284,17 @@ dependencies = [
  "paste",
  "rand 0.10.0",
  "serde",
- "spin 0.10.0",
+ "spin 0.11.0",
  "tracing",
 ]
 
 [[package]]
 name = "p3-poseidon1"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "p3-field",
+ "p3-mds",
  "p3-symmetric",
  "rand 0.10.0",
 ]
@@ -5296,7 +5302,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -5308,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5319,7 +5325,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#7a6895887780ef4e5ee0eecd73078a2b06f8f3ad"
+source = "git+https://github.com/Plonky3/Plonky3.git#750f990ec04cf57202a9d1a657c5e4f57a2c2c75"
 dependencies = [
  "serde",
  "transpose",
@@ -5332,6 +5338,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "parallel"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -6720,8 +6734,8 @@ dependencies = [
  "anyhow",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "leansig",
  "rand 0.10.0",
  "serde",
@@ -7016,6 +7030,30 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "include_dir",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lz4_flex",
+ "objc2",
+ "objc2-foundation",
+ "postcard",
+ "rand 0.10.0",
+ "serde",
+ "sha3 0.11.0",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "tracing",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "rec_aggregation"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -7035,30 +7073,6 @@ dependencies = [
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
-]
-
-[[package]]
-name = "rec_aggregation"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "include_dir",
- "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lz4_flex",
- "objc2",
- "objc2-foundation",
- "postcard",
- "rand 0.10.0",
- "serde",
- "sha3 0.11.0",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
 ]
 
 [[package]]
@@ -7396,7 +7410,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7988,7 +8002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8002,9 +8016,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
 dependencies = [
  "lock_api",
 ]
@@ -8061,23 +8075,24 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "tracing",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "sub_protocols"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
-]
-
-[[package]]
-name = "sub_protocols"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
 ]
 
 [[package]]
@@ -8164,16 +8179,15 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
  "libc",
- "rayon",
 ]
 
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "libc",
  "rayon",
@@ -8211,7 +8225,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8779,9 +8793,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -8790,9 +8804,9 @@ dependencies = [
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -9660,19 +9674,20 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
  "libc",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "parallel",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "libc",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ itertools = "0.14"
 jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
 lazy_static = "1.5.0"
-lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a974eced803574eb0ea43d812e523c8d7ad" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa" }
 lean-multisig-type2 = { package = "lean-multisig", git = "https://github.com/leanEthereum/leanMultisig.git", rev = "b00d6ba3dc574f915dc40a1796d95972178ac420" }
 leansig = { git = "https://github.com/leanEthereum//leanSig.git", branch = "devnet4" }
 libp2p = { version = "0.56", default-features = false, features = ["identify", "yamux", "noise", "dns", "serde", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping"] }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
```Latest devnet4 commit of leanVM: better performance + no more "global_allocator", all the fancy memory allocation work is now handled internally (easier to integrate with). Not a snark breaking-change (i.e. not a mandatory upgrade). 8eec56c```

I want to use this for devnet4 devnets.


### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
