### PR TITLE
chore: update lean multisig hash for devnet4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -689,7 +689,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -700,7 +700,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1077,6 +1077,25 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "backend"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "backend"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -1088,24 +1107,6 @@ dependencies = [
  "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "rayon",
- "tracing",
-]
-
-[[package]]
-name = "backend"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "rayon",
  "tracing",
 ]
@@ -2011,7 +2012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2184,7 +2185,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2447,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3765,6 +3766,25 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "clap",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "rand 0.10.0",
+ "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "serde_json",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "lean-multisig"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -3778,24 +3798,6 @@ dependencies = [
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
-]
-
-[[package]]
-name = "lean-multisig"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "clap",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rand 0.10.0",
- "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "serde_json",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
 ]
 
 [[package]]
@@ -3824,6 +3826,22 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "include_dir",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "pest",
+ "pest_derive",
+ "rand 0.10.0",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "tracing",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "lean_compiler"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -3838,19 +3856,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "lean_compiler"
+name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "include_dir",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "itertools 0.14.0",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "serde",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -3872,21 +3892,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "lean_prover"
+name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "itertools 0.14.0",
- "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
  "serde",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -3903,22 +3921,6 @@ dependencies = [
  "serde",
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
-]
-
-[[package]]
-name = "lean_vm"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "itertools 0.14.0",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "pest",
- "pest_derive",
- "rand 0.10.0",
- "serde",
- "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
 ]
 
 [[package]]
@@ -3964,9 +3966,9 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "ethereum_ssz",
  "leansig",
  "leansig_fast_keygen",
@@ -3977,9 +3979,9 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "ethereum_ssz",
  "leansig",
  "leansig_fast_keygen",
@@ -4635,6 +4637,15 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "mt-air"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "mt-air"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -4642,12 +4653,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-air"
+name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -4665,15 +4681,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-fiat-shamir"
+name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rayon",
+ "itertools 0.14.0",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "num-bigint",
+ "parallel",
+ "paste",
+ "rand 0.10.0",
  "serde",
  "tracing",
 ]
@@ -4694,16 +4711,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-field"
+name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
  "itertools 0.14.0",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "num-bigint",
  "paste",
  "rand 0.10.0",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -4725,19 +4742,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-koala-bear"
+name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
  "itertools 0.14.0",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "num-bigint",
- "paste",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
  "rand 0.10.0",
- "rayon",
  "serde",
- "tracing",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -4755,17 +4771,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-poly"
+name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "itertools 0.14.0",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rand 0.10.0",
- "rayon",
- "serde",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -4782,16 +4798,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-sumcheck"
+name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rayon",
- "tracing",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -4805,13 +4819,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-symetric"
+name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -4823,11 +4835,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "mt-utils"
+name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "serde",
+ "itertools 0.14.0",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "rand 0.10.0",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -4846,25 +4870,6 @@ dependencies = [
  "rand 0.10.0",
  "rayon",
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "tracing",
-]
-
-[[package]]
-name = "mt-whir"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "itertools 0.14.0",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "rand 0.10.0",
- "rayon",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "tracing",
 ]
 
@@ -5006,7 +5011,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5332,6 +5337,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "parallel"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
@@ -6720,8 +6733,8 @@ dependencies = [
  "anyhow",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
  "leansig",
  "rand 0.10.0",
  "serde",
@@ -7016,6 +7029,30 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "include_dir",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lz4_flex",
+ "objc2",
+ "objc2-foundation",
+ "postcard",
+ "rand 0.10.0",
+ "serde",
+ "sha3 0.11.0",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "tracing",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "rec_aggregation"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
@@ -7035,30 +7072,6 @@ dependencies = [
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
-]
-
-[[package]]
-name = "rec_aggregation"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "include_dir",
- "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lz4_flex",
- "objc2",
- "objc2-foundation",
- "postcard",
- "rand 0.10.0",
- "serde",
- "sha3 0.11.0",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
 ]
 
 [[package]]
@@ -7396,7 +7409,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7988,7 +8001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8061,23 +8074,24 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+ "parallel",
+ "tracing",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
+]
+
+[[package]]
+name = "sub_protocols"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
-]
-
-[[package]]
-name = "sub_protocols"
-version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
-dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
- "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
 ]
 
 [[package]]
@@ -8164,16 +8178,15 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
  "libc",
- "rayon",
 ]
 
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "libc",
  "rayon",
@@ -8208,10 +8221,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8779,9 +8792,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -8790,9 +8803,9 @@ dependencies = [
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -9660,19 +9673,20 @@ dependencies = [
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa#8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa"
 dependencies = [
  "libc",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "parallel",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa)",
 ]
 
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
 dependencies = [
  "libc",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ itertools = "0.14"
 jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
 lazy_static = "1.5.0"
-lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a974eced803574eb0ea43d812e523c8d7ad" }
+lean-multisig = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa" }
 lean-multisig-type2 = { package = "lean-multisig", git = "https://github.com/leanEthereum/leanMultisig.git", rev = "b00d6ba3dc574f915dc40a1796d95972178ac420" }
 leansig = { git = "https://github.com/leanEthereum//leanSig.git", branch = "devnet4" }
 libp2p = { version = "0.56", default-features = false, features = ["identify", "yamux", "noise", "dns", "serde", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping"] }

--- a/testing/lean-spec-tests/src/fork_choice.rs
+++ b/testing/lean-spec-tests/src/fork_choice.rs
@@ -278,9 +278,8 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
                 if ream_block.body.attestations.len() > DEVNET4_MAX_BLOCK_ATTESTATIONS {
                     if *valid {
                         bail!(
-                            "Block at slot {} exceeds devnet4 attestation limit of {}",
+                            "Block at slot {} exceeds devnet4 attestation limit of {DEVNET4_MAX_BLOCK_ATTESTATIONS}",
                             block.slot,
-                            DEVNET4_MAX_BLOCK_ATTESTATIONS
                         );
                     }
                     if let Some(checks) = checks {


### PR DESCRIPTION
Updates the devnet4 `lean-multisig` dependency to commit `8eec56c199ea1a77d5ca7d3bc27da7b308a5a5fa`.