### PR TITLE
feat: update BeaconNetworkSpec to current spec config

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -816,7 +816,7 @@ fn get_current_epoch(genesis_time: u64) -> u64 {
             .duration_since(UNIX_EPOCH + Duration::from_secs(genesis_time))
             .expect("System Time is before the genesis time")
             .as_secs()
-            / beacon_network_spec().seconds_per_slot,
+            / beacon_network_spec().seconds_per_slot(),
     )
 }
 

--- a/crates/common/checkpoint_sync/beacon/src/lib.rs
+++ b/crates/common/checkpoint_sync/beacon/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn initialize_db_from_checkpoint(
     let mut store = get_forkchoice_store(state.clone(), block.message, db)?;
 
     let time = beacon_network_spec().min_genesis_time
-        + beacon_network_spec().seconds_per_slot * (slot + 1);
+        + beacon_network_spec().seconds_per_slot() * (slot + 1);
     on_tick(&mut store, time)?;
     info!("Initial sync complete");
 

--- a/crates/common/consensus/beacon/src/electra/beacon_state.rs
+++ b/crates/common/consensus/beacon/src/electra/beacon_state.rs
@@ -1228,7 +1228,7 @@ impl BeaconState {
 
     pub fn compute_timestamp_at_slot(&self, slot: u64) -> u64 {
         let slots_since_genesis = slot - GENESIS_SLOT;
-        self.genesis_time + slots_since_genesis * beacon_network_spec().seconds_per_slot
+        self.genesis_time + slots_since_genesis * beacon_network_spec().seconds_per_slot()
     }
 
     pub fn validate_voluntary_exit(

--- a/crates/common/consensus/misc/src/blob_parameters.rs
+++ b/crates/common/consensus/misc/src/blob_parameters.rs
@@ -5,6 +5,7 @@ use tree_hash_derive::TreeHash;
 use crate::constants::beacon::{ELECTRA_FORK_EPOCH, MAX_BLOBS_PER_BLOCK_ELECTRA};
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[serde(rename_all = "UPPERCASE")]
 pub struct BlobParameters {
     pub epoch: u64,
     pub max_blobs_per_block: u64,

--- a/crates/common/fork_choice/beacon/src/handlers.rs
+++ b/crates/common/fork_choice/beacon/src/handlers.rs
@@ -100,9 +100,9 @@ pub async fn on_block(
     // Add block timeliness to the store
     let time_into_slot = (store.db.time_provider().get()?
         - store.db.genesis_time_provider().get()?)
-        % beacon_network_spec().seconds_per_slot;
+        % beacon_network_spec().seconds_per_slot();
     let is_before_attesting_interval =
-        time_into_slot < beacon_network_spec().seconds_per_slot / INTERVALS_PER_SLOT;
+        time_into_slot < beacon_network_spec().seconds_per_slot() / INTERVALS_PER_SLOT;
     let is_timely = store.get_current_slot()? == block.slot && is_before_attesting_interval;
     store
         .db
@@ -183,10 +183,10 @@ pub fn on_tick(store: &mut Store, time: u64) -> anyhow::Result<()> {
     // If the ``store.time`` falls behind, while loop catches up slot by slot
     // to ensure that every previous slot is processed with ``on_tick_per_slot``
     let tick_slot =
-        (time - store.db.genesis_time_provider().get()?) / beacon_network_spec().seconds_per_slot;
+        (time - store.db.genesis_time_provider().get()?) / beacon_network_spec().seconds_per_slot();
     while store.get_current_slot()? < tick_slot {
         let previous_time = store.db.genesis_time_provider().get()?
-            + (store.get_current_slot()? + 1) * beacon_network_spec().seconds_per_slot;
+            + (store.get_current_slot()? + 1) * beacon_network_spec().seconds_per_slot();
         store.on_tick_per_slot(previous_time)?;
     }
     store.on_tick_per_slot(time)?;

--- a/crates/common/fork_choice/beacon/src/store.rs
+++ b/crates/common/fork_choice/beacon/src/store.rs
@@ -83,7 +83,7 @@ impl Store {
     pub fn get_slots_since_genesis(&self) -> anyhow::Result<u64> {
         Ok(
             (self.db.time_provider().get()? - self.db.genesis_time_provider().get()?)
-                / beacon_network_spec().seconds_per_slot,
+                / beacon_network_spec().seconds_per_slot(),
         )
     }
 
@@ -354,8 +354,9 @@ impl Store {
         // Use half `SECONDS_PER_SLOT // INTERVALS_PER_SLOT` as the proposer reorg deadline
         let time_into_slot = (self.db.time_provider().get()?
             - self.db.genesis_time_provider().get()?)
-            % beacon_network_spec().seconds_per_slot;
-        let proposer_reorg_cutoff = beacon_network_spec().seconds_per_slot / INTERVALS_PER_SLOT / 2;
+            % beacon_network_spec().seconds_per_slot();
+        let proposer_reorg_cutoff =
+            beacon_network_spec().seconds_per_slot() / INTERVALS_PER_SLOT / 2;
         Ok(time_into_slot <= proposer_reorg_cutoff)
     }
 
@@ -850,7 +851,7 @@ pub fn get_forkchoice_store(
     };
 
     db.time_provider().insert(
-        anchor_state.genesis_time + beacon_network_spec().seconds_per_slot * anchor_state.slot,
+        anchor_state.genesis_time + beacon_network_spec().seconds_per_slot() * anchor_state.slot,
     )?;
     db.genesis_time_provider()
         .insert(anchor_state.genesis_time)?;

--- a/crates/common/network_spec/src/networks/beacon.rs
+++ b/crates/common/network_spec/src/networks/beacon.rs
@@ -6,6 +6,7 @@ use std::{
 
 use alloy_primitives::{Address, B256, U256, address, aliases::B32, b256, fixed_bytes};
 use ream_consensus_misc::{
+    blob_parameters::BlobParameters,
     constants::beacon::GENESIS_VALIDATORS_ROOT,
     fork::Fork,
     fork_data::{ForkData, compute_fork_digest},
@@ -44,6 +45,18 @@ impl<'de> Deserialize<'de> for Network {
             "hoodi" => Ok(Network::Hoodi),
             "dev" => Ok(Network::Dev),
             custom => Ok(Network::Custom(custom.to_string())),
+        }
+    }
+}
+
+impl std::fmt::Display for Network {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Network::Mainnet => write!(f, "mainnet"),
+            Network::Sepolia => write!(f, "sepolia"),
+            Network::Hoodi => write!(f, "hoodi"),
+            Network::Dev => write!(f, "dev"),
+            Network::Custom(name) => write!(f, "{name}"),
         }
     }
 }
@@ -97,31 +110,42 @@ pub struct BeaconNetworkSpec {
     pub genesis_delay: u64,
 
     // Forking
+    // Altair
     #[serde(with = "crate::b32_hex")]
     pub altair_fork_version: B32,
     pub altair_fork_epoch: u64,
+    // Bellatrix
     #[serde(with = "crate::b32_hex")]
     pub bellatrix_fork_version: B32,
     pub bellatrix_fork_epoch: u64,
+    // Capella
     #[serde(with = "crate::b32_hex")]
     pub capella_fork_version: B32,
     pub capella_fork_epoch: u64,
+    // Deneb
     #[serde(with = "crate::b32_hex")]
     pub deneb_fork_version: B32,
     pub deneb_fork_epoch: u64,
+    // Electra
     #[serde(with = "crate::b32_hex")]
     pub electra_fork_version: B32,
     pub electra_fork_epoch: u64,
+    // Fulu
     #[serde(with = "crate::b32_hex")]
     pub fulu_fork_version: B32,
     pub fulu_fork_epoch: u64,
 
     // Time parameters
-    pub seconds_per_slot: u64,
+    pub slot_duration_ms: u64,
     pub seconds_per_eth1_block: u64,
     pub min_validator_withdrawability_delay: u64,
     pub shard_committee_period: u64,
     pub eth1_follow_distance: u64,
+    pub proposer_reorg_cutoff_bps: u64,
+    pub attestation_due_bps: u64,
+    pub aggregate_due_bps: u64,
+    pub sync_message_due_bps: u64,
+    pub contribution_due_bps: u64,
 
     // Validator cycle
     pub inactivity_score_bias: u64,
@@ -147,9 +171,6 @@ pub struct BeaconNetworkSpec {
     pub max_payload_size: u64,
     pub max_request_blocks: u64,
     pub epochs_per_subnet_subscription: u64,
-    pub min_epochs_for_block_requests: u64,
-    pub ttfb_timeout: u64,
-    pub resp_timeout: u64,
     pub attestation_propagation_slot_range: u64,
     pub maximum_gossip_clock_disparity: u64,
     #[serde(with = "crate::b32_hex")]
@@ -159,11 +180,9 @@ pub struct BeaconNetworkSpec {
     pub subnets_per_node: u64,
     pub attestation_subnet_count: u64,
     pub attestation_subnet_extra_bits: u64,
-    pub attestation_subnet_prefix_bits: u64,
 
     // Deneb
     pub max_request_blocks_deneb: u64,
-    pub max_request_blob_sidecars: u64,
     pub min_epochs_for_blob_sidecars_requests: u64,
     pub blob_sidecar_subnet_count: u64,
 
@@ -172,7 +191,18 @@ pub struct BeaconNetworkSpec {
     pub max_per_epoch_activation_exit_churn_limit: u64,
     pub blob_sidecar_subnet_count_electra: u64,
     pub max_blobs_per_block_electra: u64,
-    pub max_request_blob_sidecars_electra: u64,
+
+    // Fulu
+    pub number_of_custody_groups: u64,
+    pub data_column_sidecar_subnet_count: u64,
+    pub samples_per_slot: u64,
+    pub custody_requirement: u64,
+    pub validator_custody_requirement: u64,
+    pub balance_per_additional_custody_group: u64,
+    pub min_epochs_for_data_column_sidecars_requests: u64,
+
+    #[serde(default)]
+    pub blob_schedule: Vec<BlobParameters>,
 }
 
 impl BeaconNetworkSpec {
@@ -232,8 +262,12 @@ impl BeaconNetworkSpec {
         let elapsed = SystemTime::now()
             .duration_since(genesis_instant)
             .expect("System Time is before the genesis time");
-        let current_slot = elapsed.as_secs() / self.seconds_per_slot;
-        current_slot.saturating_sub(n_days_ago * 24 * 60 * 60 / self.seconds_per_slot)
+        let current_slot = elapsed.as_millis() as u64 / self.slot_duration_ms;
+        current_slot.saturating_sub(n_days_ago * 24 * 60 * 60 * 1000 / self.slot_duration_ms)
+    }
+
+    pub fn seconds_per_slot(&self) -> u64 {
+        self.slot_duration_ms / 1000
     }
 }
 
@@ -263,11 +297,16 @@ pub static MAINNET: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         electra_fork_epoch: 364032,
         fulu_fork_version: fixed_bytes!("0x06000000"),
         fulu_fork_epoch: 411392,
-        seconds_per_slot: 12,
+        slot_duration_ms: 12000,
         seconds_per_eth1_block: 14,
         min_validator_withdrawability_delay: 256,
         shard_committee_period: 256,
         eth1_follow_distance: 2048,
+        proposer_reorg_cutoff_bps: 1667,
+        attestation_due_bps: 3333,
+        aggregate_due_bps: 6667,
+        sync_message_due_bps: 3333,
+        contribution_due_bps: 6667,
         inactivity_score_bias: 4,
         inactivity_score_recovery_rate: 16,
         ejection_balance: 16000000000,
@@ -284,9 +323,6 @@ pub static MAINNET: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         max_payload_size: 10485760,
         max_request_blocks: 1024,
         epochs_per_subnet_subscription: 256,
-        min_epochs_for_block_requests: 33024,
-        ttfb_timeout: 5,
-        resp_timeout: 10,
         attestation_propagation_slot_range: 32,
         maximum_gossip_clock_disparity: 500,
         message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
@@ -294,16 +330,30 @@ pub static MAINNET: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         subnets_per_node: 2,
         attestation_subnet_count: 64,
         attestation_subnet_extra_bits: 0,
-        attestation_subnet_prefix_bits: 6,
         max_request_blocks_deneb: 128,
-        max_request_blob_sidecars: 768,
         min_epochs_for_blob_sidecars_requests: 4096,
         blob_sidecar_subnet_count: 6,
         min_per_epoch_churn_limit_electra: 128000000000,
         max_per_epoch_activation_exit_churn_limit: 256000000000,
         blob_sidecar_subnet_count_electra: 9,
         max_blobs_per_block_electra: 9,
-        max_request_blob_sidecars_electra: 1152,
+        number_of_custody_groups: 128,
+        data_column_sidecar_subnet_count: 128,
+        samples_per_slot: 8,
+        custody_requirement: 4,
+        validator_custody_requirement: 8,
+        balance_per_additional_custody_group: 32000000000,
+        min_epochs_for_data_column_sidecars_requests: 4096,
+        blob_schedule: vec![
+            BlobParameters {
+                epoch: 412672,
+                max_blobs_per_block: 15,
+            },
+            BlobParameters {
+                epoch: 419072,
+                max_blobs_per_block: 21,
+            },
+        ],
     }
     .into()
 });
@@ -334,11 +384,16 @@ pub static SEPOLIA: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         electra_fork_epoch: 222464,
         fulu_fork_version: fixed_bytes!("0x90000075"),
         fulu_fork_epoch: 272640,
-        seconds_per_slot: 12,
+        slot_duration_ms: 12000,
         seconds_per_eth1_block: 14,
         min_validator_withdrawability_delay: 256,
         shard_committee_period: 256,
         eth1_follow_distance: 2048,
+        proposer_reorg_cutoff_bps: 1667,
+        attestation_due_bps: 3333,
+        aggregate_due_bps: 6667,
+        sync_message_due_bps: 3333,
+        contribution_due_bps: 6667,
         inactivity_score_bias: 4,
         inactivity_score_recovery_rate: 16,
         ejection_balance: 16000000000,
@@ -355,9 +410,6 @@ pub static SEPOLIA: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         max_payload_size: 10485760,
         max_request_blocks: 1024,
         epochs_per_subnet_subscription: 256,
-        min_epochs_for_block_requests: 33024,
-        ttfb_timeout: 5,
-        resp_timeout: 10,
         attestation_propagation_slot_range: 32,
         maximum_gossip_clock_disparity: 500,
         message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
@@ -365,16 +417,30 @@ pub static SEPOLIA: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         subnets_per_node: 2,
         attestation_subnet_count: 64,
         attestation_subnet_extra_bits: 0,
-        attestation_subnet_prefix_bits: 6,
         max_request_blocks_deneb: 128,
-        max_request_blob_sidecars: 768,
         min_epochs_for_blob_sidecars_requests: 4096,
         blob_sidecar_subnet_count: 6,
         min_per_epoch_churn_limit_electra: 128000000000,
         max_per_epoch_activation_exit_churn_limit: 256000000000,
         blob_sidecar_subnet_count_electra: 9,
         max_blobs_per_block_electra: 9,
-        max_request_blob_sidecars_electra: 1152,
+        number_of_custody_groups: 128,
+        data_column_sidecar_subnet_count: 128,
+        samples_per_slot: 8,
+        custody_requirement: 4,
+        validator_custody_requirement: 8,
+        balance_per_additional_custody_group: 32000000000,
+        min_epochs_for_data_column_sidecars_requests: 4096,
+        blob_schedule: vec![
+            BlobParameters {
+                epoch: 274176,
+                max_blobs_per_block: 15,
+            },
+            BlobParameters {
+                epoch: 275712,
+                max_blobs_per_block: 21,
+            },
+        ],
     }
     .into()
 });
@@ -405,11 +471,16 @@ pub static HOODI: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         electra_fork_epoch: 2048,
         fulu_fork_version: fixed_bytes!("0x70000910"),
         fulu_fork_epoch: 50688,
-        seconds_per_slot: 12,
+        slot_duration_ms: 12000,
         seconds_per_eth1_block: 14,
         min_validator_withdrawability_delay: 256,
         shard_committee_period: 256,
         eth1_follow_distance: 2048,
+        proposer_reorg_cutoff_bps: 1667,
+        attestation_due_bps: 3333,
+        aggregate_due_bps: 6667,
+        sync_message_due_bps: 3333,
+        contribution_due_bps: 6667,
         inactivity_score_bias: 4,
         inactivity_score_recovery_rate: 16,
         ejection_balance: 16000000000,
@@ -426,9 +497,6 @@ pub static HOODI: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         max_payload_size: 10485760,
         max_request_blocks: 1024,
         epochs_per_subnet_subscription: 256,
-        min_epochs_for_block_requests: 33024,
-        ttfb_timeout: 5,
-        resp_timeout: 10,
         attestation_propagation_slot_range: 32,
         maximum_gossip_clock_disparity: 500,
         message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
@@ -436,16 +504,30 @@ pub static HOODI: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         subnets_per_node: 2,
         attestation_subnet_count: 64,
         attestation_subnet_extra_bits: 0,
-        attestation_subnet_prefix_bits: 6,
         max_request_blocks_deneb: 128,
-        max_request_blob_sidecars: 768,
         min_epochs_for_blob_sidecars_requests: 4096,
         blob_sidecar_subnet_count: 6,
         min_per_epoch_churn_limit_electra: 128000000000,
         max_per_epoch_activation_exit_churn_limit: 256000000000,
         blob_sidecar_subnet_count_electra: 9,
         max_blobs_per_block_electra: 9,
-        max_request_blob_sidecars_electra: 1152,
+        number_of_custody_groups: 128,
+        data_column_sidecar_subnet_count: 128,
+        samples_per_slot: 8,
+        custody_requirement: 4,
+        validator_custody_requirement: 8,
+        balance_per_additional_custody_group: 32000000000,
+        min_epochs_for_data_column_sidecars_requests: 4096,
+        blob_schedule: vec![
+            BlobParameters {
+                epoch: 52480,
+                max_blobs_per_block: 15,
+            },
+            BlobParameters {
+                epoch: 54016,
+                max_blobs_per_block: 21,
+            },
+        ],
     }
     .into()
 });
@@ -476,11 +558,16 @@ pub static DEV: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         electra_fork_epoch: 364032,
         fulu_fork_version: fixed_bytes!("0x06000000"),
         fulu_fork_epoch: 411392,
-        seconds_per_slot: 12,
+        slot_duration_ms: 12000,
         seconds_per_eth1_block: 14,
         min_validator_withdrawability_delay: 256,
         shard_committee_period: 256,
         eth1_follow_distance: 2048,
+        proposer_reorg_cutoff_bps: 1667,
+        attestation_due_bps: 3333,
+        aggregate_due_bps: 6667,
+        sync_message_due_bps: 3333,
+        contribution_due_bps: 6667,
         inactivity_score_bias: 4,
         inactivity_score_recovery_rate: 16,
         ejection_balance: 16000000000,
@@ -497,9 +584,6 @@ pub static DEV: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         max_payload_size: 10485760,
         max_request_blocks: 1024,
         epochs_per_subnet_subscription: 256,
-        min_epochs_for_block_requests: 33024,
-        ttfb_timeout: 5,
-        resp_timeout: 10,
         attestation_propagation_slot_range: 32,
         maximum_gossip_clock_disparity: 500,
         message_domain_invalid_snappy: fixed_bytes!("0x00000000"),
@@ -507,16 +591,21 @@ pub static DEV: LazyLock<Arc<BeaconNetworkSpec>> = LazyLock::new(|| {
         subnets_per_node: 2,
         attestation_subnet_count: 64,
         attestation_subnet_extra_bits: 0,
-        attestation_subnet_prefix_bits: 6,
         max_request_blocks_deneb: 128,
-        max_request_blob_sidecars: 768,
         min_epochs_for_blob_sidecars_requests: 4096,
         blob_sidecar_subnet_count: 6,
         min_per_epoch_churn_limit_electra: 128000000000,
         max_per_epoch_activation_exit_churn_limit: 256000000000,
         blob_sidecar_subnet_count_electra: 9,
         max_blobs_per_block_electra: 9,
-        max_request_blob_sidecars_electra: 1152,
+        number_of_custody_groups: 128,
+        data_column_sidecar_subnet_count: 128,
+        samples_per_slot: 8,
+        custody_requirement: 4,
+        validator_custody_requirement: 8,
+        balance_per_additional_custody_group: 32000000000,
+        min_epochs_for_data_column_sidecars_requests: 4096,
+        blob_schedule: vec![],
     }
     .into()
 });

--- a/crates/common/validator/beacon/src/validator.rs
+++ b/crates/common/validator/beacon/src/validator.rs
@@ -116,7 +116,7 @@ impl ValidatorService {
     }
 
     pub async fn start(mut self) {
-        let seconds_per_slot = beacon_network_spec().seconds_per_slot;
+        let seconds_per_slot = beacon_network_spec().seconds_per_slot();
         let seconds_per_interval = seconds_per_slot / INTERVALS_PER_SLOT;
 
         let genesis_instant =
@@ -510,7 +510,7 @@ impl ValidatorService {
         committee_index: u64,
     ) -> anyhow::Result<()> {
         sleep(Duration::from_secs(
-            beacon_network_spec().seconds_per_slot / 3,
+            beacon_network_spec().seconds_per_slot() / 3,
         ))
         .await;
 

--- a/crates/common/validator/beacon/src/voluntary_exit.rs
+++ b/crates/common/validator/beacon/src/voluntary_exit.rs
@@ -73,7 +73,10 @@ pub async fn process_voluntary_exit(
 
     if wait_till_exit {
         loop {
-            sleep(Duration::from_secs(beacon_network_spec().seconds_per_slot)).await;
+            sleep(Duration::from_secs(
+                beacon_network_spec().seconds_per_slot(),
+            ))
+            .await;
             match beacon_api_client
                 .get_state_validator(ID::Head, ValidatorID::Index(validator_index))
                 .await?

--- a/crates/networking/manager/src/service.rs
+++ b/crates/networking/manager/src/service.rs
@@ -139,7 +139,9 @@ impl NetworkManagerService {
             ..
         } = self;
 
-        let mut interval = interval(Duration::from_secs(beacon_network_spec().seconds_per_slot));
+        let mut interval = interval(Duration::from_secs(
+            beacon_network_spec().seconds_per_slot(),
+        ));
         let mut syncer_handle = block_range_syncer.start();
         loop {
             tokio::select! {

--- a/crates/networking/p2p/src/gossipsub/beacon/configurations.rs
+++ b/crates/networking/p2p/src/gossipsub/beacon/configurations.rs
@@ -30,7 +30,7 @@ impl Default for GossipsubConfig {
             .history_gossip(3)
             .max_messages_per_rpc(Some(500))
             .duplicate_cache_time(Duration::from_secs(
-                SLOTS_PER_EPOCH * beacon_network_spec().seconds_per_slot * 2,
+                SLOTS_PER_EPOCH * beacon_network_spec().seconds_per_slot() * 2,
             ))
             .validate_messages()
             .validation_mode(ValidationMode::Anonymous)


### PR DESCRIPTION
### What was wrong?

`BeaconNetworkSpec` was out of sync with the consensus-specs config format: it was missing Ful fields (custody groups, blob schedule, etc.) and contained fields no longer present in current mainnet.yaml/minimal.yaml configs, causing custom network configs to fail to parse.

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
 
 https://github.com/ethereum/consensus-specs/tree/master/configs

### How was it fixed?

- added the missing fulu fields

- removed stale fields (min_epochs_for_block_requests, ttfb_timeout, resp_timeout, attestation_subnet_prefix_bits, max_request_blob_sidecars)

- replaced seconds_per_slot with slot_duration_ms (current spec field), exposing seconds_per_slot() as a derived method

- updated MAINNET, SEPOLIA, HOODI static configs

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
