### PR TITLE
chore: separating the test vectors for devnet4 and devnet5

### DIFF
--- a/testing/lean-spec-tests/Makefile
+++ b/testing/lean-spec-tests/Makefile
@@ -1,18 +1,18 @@
-EXTRACT_DIR = fixtures
 NETWORK ?= devnet4
+EXTRACT_DIR = fixtures/$(NETWORK)
 DEVNET4_REPO_URL = https://github.com/ReamLabs/lean-spec-tests.git
 DEVNET5_RELEASE_URL = https://github.com/leanEthereum/leanSpec/releases/download/latest/fixtures-prod-scheme.tar.gz
 DEVNET5_RELEASE_API_URL = https://api.github.com/repos/leanEthereum/leanSpec/releases/tags/latest
 DEVNET5_ARCHIVE = fixtures-prod-scheme.tar.gz
 DEVNET5_TMP_DIR = .leanSpec-fixtures
 CURL = curl --fail --location --retry 3 --retry-all-errors --retry-delay 5 --connect-timeout 30 --speed-time 60 --speed-limit 1024
-KEYS_DIR = fixtures/keys/prod_scheme
+KEYS_DIR = $(EXTRACT_DIR)/keys/prod_scheme
 KEYS_URL = https://github.com/leanEthereum/leansig-test-keys/releases/download/leanSpec-bbbbf62/prod_scheme.tar.gz
 
 FIXTURES := state_transition ssz fork_choice justifiability slot_clock sync verify_signatures
 SELECTED := $(filter $(FIXTURES),$(MAKECMDGOALS))
 CARGO_FEATURES = lean-spec-tests $(NETWORK)
-SOURCE_MARKER = $(EXTRACT_DIR)/.ream-source-$(NETWORK)
+SOURCE_MARKER = $(EXTRACT_DIR)/.ream-source
 
 .PHONY: all clean test test-devnet4 test-devnet5 prepare-fixtures $(FIXTURES)
 
@@ -70,8 +70,8 @@ $(KEYS_DIR):
 		echo "$(KEYS_DIR) already exists. Skipping download."; \
 	else \
 		echo "Downloading test keys..."; \
-		mkdir -p fixtures/keys; \
-		$(CURL) --silent --output - $(KEYS_URL) | tar xz -C fixtures/keys || { echo "Key download failed."; exit 1; }; \
+		mkdir -p $(EXTRACT_DIR)/keys; \
+		$(CURL) --silent --output - $(KEYS_URL) | tar xz -C $(EXTRACT_DIR)/keys || { echo "Key download failed."; exit 1; }; \
 		echo "Test keys downloaded successfully."; \
 	fi
 
@@ -90,6 +90,6 @@ $(FIXTURES):
 
 clean:
 	@echo "Cleaning up downloaded fixtures and keys..."
-	@rm -rf $(EXTRACT_DIR)
+	@rm -rf fixtures/devnet4 fixtures/devnet5
 	@rm -rf $(DEVNET5_TMP_DIR)
 	@echo "Clean up complete."

--- a/testing/lean-spec-tests/src/fork_choice.rs
+++ b/testing/lean-spec-tests/src/fork_choice.rs
@@ -66,9 +66,12 @@ pub fn load_fork_choice_test(
     Ok(fixture)
 }
 
-/// Load test private keys from fixtures/keys/prod_scheme/{i}.json
+/// Load test private keys from fixtures/{network}/keys/prod_scheme/{i}.json
 fn load_test_keys() -> anyhow::Result<HashMap<u64, PrivateKey>> {
-    let keys_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/keys/prod_scheme");
+    #[cfg(feature = "devnet5")]
+    let keys_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/devnet5/keys/prod_scheme");
+    #[cfg(not(feature = "devnet5"))]
+    let keys_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/devnet4/keys/prod_scheme");
     let mut keys = HashMap::new();
 
     for i in 0..12u64 {

--- a/testing/lean-spec-tests/tests/tests.rs
+++ b/testing/lean-spec-tests/tests/tests.rs
@@ -47,7 +47,11 @@ fn find_json_files(dir: &str) -> Vec<PathBuf> {
 }
 
 fn find_fixture_files(suite: &str) -> Vec<PathBuf> {
-    find_json_files(&format!("fixtures/consensus/{suite}/{FIXTURE_PROFILE}"))
+    #[cfg(feature = "devnet5")]
+    let network = "devnet5";
+    #[cfg(not(feature = "devnet5"))]
+    let network = "devnet4";
+    find_json_files(&format!("fixtures/{network}/consensus/{suite}/{FIXTURE_PROFILE}"))
 }
 
 fn should_run_fixture_suite(suite: &str, fixtures: &[PathBuf]) -> bool {


### PR DESCRIPTION
### What was wrong?

When running the Makefile commands for the test vectors in testing/lean-spec-tests, the same fixtures folder is used for devnet4 and devnet5, which would lead to re-downloading if we want to switch from devnet4 to devnet5 and back to devnet4 


### How was it fixed?

It was fixed by creating a split in the fixtures folder and adding the test vectors for both devnet4 and devnet5 in fixtures/{network} folders and changing the Makefile and some part accordingly. 


### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
