### PR TITLE
fix: compatibility for devnet4 and devnet5 test vectors

### DIFF
--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -556,23 +556,27 @@ pub fn attestation_data_matches_chain(
     historical_block_hashes: &[B256],
     attestation_data: AttestationData,
 ) -> anyhow::Result<bool> {
-    if attestation_data.source.root == B256::ZERO || attestation_data.target.root == B256::ZERO {
+    if attestation_data.source.root == B256::ZERO
+        || attestation_data.target.root == B256::ZERO
+        || attestation_data.head.root == B256::ZERO
+    {
         return Ok(false);
     }
 
     let source_slot = attestation_data.source.slot as usize;
     let target_slot = attestation_data.target.slot as usize;
+    let head_slot = attestation_data.head.slot as usize;
 
-    if source_slot >= historical_block_hashes.len() {
-        return Ok(false);
-    }
-
-    if target_slot >= historical_block_hashes.len() {
+    if source_slot >= historical_block_hashes.len()
+        || target_slot >= historical_block_hashes.len()
+        || head_slot >= historical_block_hashes.len()
+    {
         return Ok(false);
     }
 
     let matches = attestation_data.source.root == historical_block_hashes[source_slot]
-        && attestation_data.target.root == historical_block_hashes[target_slot];
+        && attestation_data.target.root == historical_block_hashes[target_slot]
+        && attestation_data.head.root == historical_block_hashes[head_slot];
 
     Ok(matches)
 }

--- a/testing/lean-spec-tests/Makefile
+++ b/testing/lean-spec-tests/Makefile
@@ -1,6 +1,7 @@
 NETWORK ?= devnet4
 EXTRACT_DIR = fixtures/$(NETWORK)
 DEVNET4_REPO_URL = https://github.com/ReamLabs/lean-spec-tests.git
+DEVNET4_COMMIT = a3bf5d72e74e3bdf7634e5ee3a8154aabf0a8565
 DEVNET5_RELEASE_URL = https://github.com/leanEthereum/leanSpec/releases/download/latest/fixtures-prod-scheme.tar.gz
 DEVNET5_RELEASE_API_URL = https://api.github.com/repos/leanEthereum/leanSpec/releases/tags/latest
 DEVNET5_ARCHIVE = fixtures-prod-scheme.tar.gz
@@ -32,9 +33,10 @@ prepare-fixtures:
 	@if [ -f $(SOURCE_MARKER) ] && [ -d $(EXTRACT_DIR)/consensus ]; then \
 		echo "$(EXTRACT_DIR) already contains $(NETWORK) fixtures. Skipping download."; \
 	elif [ "$(NETWORK)" = "devnet4" ]; then \
-		echo "Cloning devnet4 fixtures from $(DEVNET4_REPO_URL)..."; \
+		echo "Cloning devnet4 fixtures from $(DEVNET4_REPO_URL) at $(DEVNET4_COMMIT)..."; \
 		rm -rf $(EXTRACT_DIR); \
-		git clone --depth 1 --filter=blob:none --single-branch --quiet $(DEVNET4_REPO_URL) $(EXTRACT_DIR) || { echo "Clone failed. Repository may be private or inaccessible."; exit 1; }; \
+		git clone --filter=blob:none --quiet $(DEVNET4_REPO_URL) $(EXTRACT_DIR) || { echo "Clone failed. Repository may be private or inaccessible."; exit 1; }; \
+		git -C $(EXTRACT_DIR) checkout --quiet $(DEVNET4_COMMIT) || { echo "Checkout of commit $(DEVNET4_COMMIT) failed."; exit 1; }; \
 		touch $(SOURCE_MARKER); \
 		echo "devnet4 fixtures downloaded successfully."; \
 	else \

--- a/testing/lean-spec-tests/src/fork_choice.rs
+++ b/testing/lean-spec-tests/src/fork_choice.rs
@@ -43,7 +43,7 @@ use crate::types::{
 };
 
 #[cfg(feature = "devnet4")]
-const DEVNET4_MAX_BLOCK_ATTESTATIONS: usize = 8;
+const DEVNET4_MAX_BLOCK_ATTESTATIONS: usize = 16;
 
 /// Load a fork choice test fixture from a JSON file
 pub fn load_fork_choice_test(
@@ -69,9 +69,11 @@ pub fn load_fork_choice_test(
 /// Load test private keys from fixtures/{network}/keys/prod_scheme/{i}.json
 fn load_test_keys() -> anyhow::Result<HashMap<u64, PrivateKey>> {
     #[cfg(feature = "devnet5")]
-    let keys_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/devnet5/keys/prod_scheme");
+    let keys_dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/devnet5/keys/prod_scheme");
     #[cfg(not(feature = "devnet5"))]
-    let keys_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/devnet4/keys/prod_scheme");
+    let keys_dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/devnet4/keys/prod_scheme");
     let mut keys = HashMap::new();
 
     for i in 0..12u64 {

--- a/testing/lean-spec-tests/src/slot_clock.rs
+++ b/testing/lean-spec-tests/src/slot_clock.rs
@@ -3,10 +3,7 @@ use std::path::Path;
 use anyhow::{anyhow, bail, ensure};
 use tracing::info;
 
-use crate::types::{
-    TestFixture,
-    slot_clock::{CurrentTimeInput, FromSlotInput, FromUnixTimeInput, SlotClockTest},
-};
+use crate::types::{TestFixture, slot_clock::SlotClockTest};
 
 /// Load a slot_clock test fixture from a JSON file
 pub fn load_slot_clock_test(path: impl AsRef<Path>) -> anyhow::Result<TestFixture<SlotClockTest>> {
@@ -17,14 +14,33 @@ pub fn load_slot_clock_test(path: impl AsRef<Path>) -> anyhow::Result<TestFixtur
         .map_err(|err| anyhow!("Failed to parse test file {}: {err}", path.display()))
 }
 
+/// Parse a JSON value as u64, accepting both integer and float representations.
+fn json_u64(v: &serde_json::Value, field: &str) -> anyhow::Result<u64> {
+    v.as_u64()
+        .or_else(|| v.as_f64().map(|f| f as u64))
+        .ok_or_else(|| anyhow!("Missing or non-numeric field: {field}"))
+}
+
 /// Run a single slot_clock test case
 pub fn run_slot_clock_test(test_name: &str, test: &SlotClockTest) -> anyhow::Result<()> {
-    info!(
-        "Running slot_clock test: {test_name} (operation={})",
-        test.operation
-    );
+    // Config lives at top-level in devnet5, inside output in devnet4.
+    let cfg = test
+        .config
+        .as_ref()
+        .or(test.output.config.as_ref())
+        .ok_or_else(|| anyhow!("Missing config"))?;
 
-    let cfg = &test.output.config;
+    // Operation kind: plain string in devnet4, object with `kind` field in devnet5.
+    let kind: &str = if let Some(s) = test.operation.as_str() {
+        s
+    } else {
+        test.operation["kind"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing operation.kind"))?
+    };
+
+    info!("Running slot_clock test: {test_name} (operation={kind})");
+
     ensure!(
         cfg.seconds_per_slot * 1000 == cfg.intervals_per_slot * cfg.milliseconds_per_interval,
         "Inconsistent config: secondsPerSlot * 1000 != intervalsPerSlot * msPerInterval",
@@ -33,35 +49,46 @@ pub fn run_slot_clock_test(test_name: &str, test: &SlotClockTest) -> anyhow::Res
     let ms_per_slot = cfg.seconds_per_slot * 1000;
     let ms_per_interval = cfg.milliseconds_per_interval;
 
-    match test.operation.as_str() {
+    // In devnet4 params are in `input`; in devnet5 they are in the `operation` object.
+    let params: &serde_json::Value = if let Some(inp) = test.input.as_ref() {
+        inp
+    } else {
+        &test.operation
+    };
+
+    // Look up a u64 param, falling back to an alternate key name if the first is missing.
+    let param_u64 = |key: &str, alt: Option<&str>| -> anyhow::Result<u64> {
+        let v = params
+            .get(key)
+            .or_else(|| alt.and_then(|k| params.get(k)))
+            .ok_or_else(|| anyhow!("Missing param: {key}"))?;
+        json_u64(v, key)
+    };
+
+    match kind {
         "current_slot" => {
-            let input: CurrentTimeInput = serde_json::from_value(test.input.clone())?;
-            let expected = test
-                .output
-                .slot
-                .ok_or_else(|| anyhow!("Missing output.slot"))?;
-            let genesis_ms = input.genesis_time * 1000;
-            let actual = if input.current_time_ms <= genesis_ms {
+            let genesis_time = param_u64("genesisTime", None)?;
+            // devnet4: currentTimeMs (integer), devnet5: currentTimeMilliseconds (float)
+            let current_time_ms = param_u64("currentTimeMs", Some("currentTimeMilliseconds"))?;
+            let expected = test.output.slot.ok_or_else(|| anyhow!("Missing output.slot"))?;
+            let genesis_ms = genesis_time * 1000;
+            let actual = if current_time_ms <= genesis_ms {
                 0
             } else {
-                (input.current_time_ms - genesis_ms) / ms_per_slot
+                (current_time_ms - genesis_ms) / ms_per_slot
             };
-            ensure!(
-                actual == expected,
-                "current_slot mismatch: expected {expected}, got {actual}"
-            );
+            ensure!(actual == expected, "current_slot mismatch: expected {expected}, got {actual}");
         }
         "current_interval" => {
-            let input: CurrentTimeInput = serde_json::from_value(test.input.clone())?;
-            let expected = test
-                .output
-                .interval
-                .ok_or_else(|| anyhow!("Missing output.interval"))?;
-            let genesis_ms = input.genesis_time * 1000;
-            let actual = if input.current_time_ms <= genesis_ms {
+            let genesis_time = param_u64("genesisTime", None)?;
+            let current_time_ms = param_u64("currentTimeMs", Some("currentTimeMilliseconds"))?;
+            let expected =
+                test.output.interval.ok_or_else(|| anyhow!("Missing output.interval"))?;
+            let genesis_ms = genesis_time * 1000;
+            let actual = if current_time_ms <= genesis_ms {
                 0
             } else {
-                let elapsed = input.current_time_ms - genesis_ms;
+                let elapsed = current_time_ms - genesis_ms;
                 (elapsed % ms_per_slot) / ms_per_interval
             };
             ensure!(
@@ -70,16 +97,17 @@ pub fn run_slot_clock_test(test_name: &str, test: &SlotClockTest) -> anyhow::Res
             );
         }
         "total_intervals" => {
-            let input: CurrentTimeInput = serde_json::from_value(test.input.clone())?;
+            let genesis_time = param_u64("genesisTime", None)?;
+            let current_time_ms = param_u64("currentTimeMs", Some("currentTimeMilliseconds"))?;
             let expected = test
                 .output
                 .total_intervals
                 .ok_or_else(|| anyhow!("Missing output.totalIntervals"))?;
-            let genesis_ms = input.genesis_time * 1000;
-            let actual = if input.current_time_ms <= genesis_ms {
+            let genesis_ms = genesis_time * 1000;
+            let actual = if current_time_ms <= genesis_ms {
                 0
             } else {
-                (input.current_time_ms - genesis_ms) / ms_per_interval
+                (current_time_ms - genesis_ms) / ms_per_interval
             };
             ensure!(
                 actual == expected,
@@ -87,27 +115,21 @@ pub fn run_slot_clock_test(test_name: &str, test: &SlotClockTest) -> anyhow::Res
             );
         }
         "from_slot" => {
-            let input: FromSlotInput = serde_json::from_value(test.input.clone())?;
-            let expected = test
-                .output
-                .interval
-                .ok_or_else(|| anyhow!("Missing output.interval"))?;
-            let actual = input.slot * cfg.intervals_per_slot;
-            ensure!(
-                actual == expected,
-                "from_slot mismatch: expected {expected}, got {actual}"
-            );
+            let slot = param_u64("slot", None)?;
+            let expected =
+                test.output.interval.ok_or_else(|| anyhow!("Missing output.interval"))?;
+            let actual = slot * cfg.intervals_per_slot;
+            ensure!(actual == expected, "from_slot mismatch: expected {expected}, got {actual}");
         }
         "from_unix_time" => {
-            let input: FromUnixTimeInput = serde_json::from_value(test.input.clone())?;
-            let expected = test
-                .output
-                .interval
-                .ok_or_else(|| anyhow!("Missing output.interval"))?;
-            let actual = if input.unix_seconds <= input.genesis_time {
+            let genesis_time = param_u64("genesisTime", None)?;
+            let unix_seconds = param_u64("unixSeconds", None)?;
+            let expected =
+                test.output.interval.ok_or_else(|| anyhow!("Missing output.interval"))?;
+            let actual = if unix_seconds <= genesis_time {
                 0
             } else {
-                ((input.unix_seconds - input.genesis_time) * 1000) / ms_per_interval
+                ((unix_seconds - genesis_time) * 1000) / ms_per_interval
             };
             ensure!(
                 actual == expected,

--- a/testing/lean-spec-tests/src/slot_clock.rs
+++ b/testing/lean-spec-tests/src/slot_clock.rs
@@ -70,20 +70,28 @@ pub fn run_slot_clock_test(test_name: &str, test: &SlotClockTest) -> anyhow::Res
             let genesis_time = param_u64("genesisTime", None)?;
             // devnet4: currentTimeMs (integer), devnet5: currentTimeMilliseconds (float)
             let current_time_ms = param_u64("currentTimeMs", Some("currentTimeMilliseconds"))?;
-            let expected = test.output.slot.ok_or_else(|| anyhow!("Missing output.slot"))?;
+            let expected = test
+                .output
+                .slot
+                .ok_or_else(|| anyhow!("Missing output.slot"))?;
             let genesis_ms = genesis_time * 1000;
             let actual = if current_time_ms <= genesis_ms {
                 0
             } else {
                 (current_time_ms - genesis_ms) / ms_per_slot
             };
-            ensure!(actual == expected, "current_slot mismatch: expected {expected}, got {actual}");
+            ensure!(
+                actual == expected,
+                "current_slot mismatch: expected {expected}, got {actual}"
+            );
         }
         "current_interval" => {
             let genesis_time = param_u64("genesisTime", None)?;
             let current_time_ms = param_u64("currentTimeMs", Some("currentTimeMilliseconds"))?;
-            let expected =
-                test.output.interval.ok_or_else(|| anyhow!("Missing output.interval"))?;
+            let expected = test
+                .output
+                .interval
+                .ok_or_else(|| anyhow!("Missing output.interval"))?;
             let genesis_ms = genesis_time * 1000;
             let actual = if current_time_ms <= genesis_ms {
                 0
@@ -116,16 +124,23 @@ pub fn run_slot_clock_test(test_name: &str, test: &SlotClockTest) -> anyhow::Res
         }
         "from_slot" => {
             let slot = param_u64("slot", None)?;
-            let expected =
-                test.output.interval.ok_or_else(|| anyhow!("Missing output.interval"))?;
+            let expected = test
+                .output
+                .interval
+                .ok_or_else(|| anyhow!("Missing output.interval"))?;
             let actual = slot * cfg.intervals_per_slot;
-            ensure!(actual == expected, "from_slot mismatch: expected {expected}, got {actual}");
+            ensure!(
+                actual == expected,
+                "from_slot mismatch: expected {expected}, got {actual}"
+            );
         }
         "from_unix_time" => {
             let genesis_time = param_u64("genesisTime", None)?;
             let unix_seconds = param_u64("unixSeconds", None)?;
-            let expected =
-                test.output.interval.ok_or_else(|| anyhow!("Missing output.interval"))?;
+            let expected = test
+                .output
+                .interval
+                .ok_or_else(|| anyhow!("Missing output.interval"))?;
             let actual = if unix_seconds <= genesis_time {
                 0
             } else {

--- a/testing/lean-spec-tests/src/state_transition.rs
+++ b/testing/lean-spec-tests/src/state_transition.rs
@@ -42,15 +42,13 @@ pub fn run_state_transition_test(
     let mut state = LeanState::try_from(test.pre.clone())
         .map_err(|err| anyhow!("Failed to convert pre-state: {err}"))?;
 
-    // Track whether we expect an exception
-    let expect_exception = test.expect_exception.is_some();
+    // Track whether we expect an exception (devnet4: expectException, devnet5: rejectionReason)
+    let expect_exception = test.expects_failure();
     if expect_exception {
-        info!(
-            "Expected result: Exception: {}",
-            test.expect_exception
-                .as_ref()
-                .expect("Failed to fetch expected exception")
-        );
+        let reason = test.expect_exception.as_deref()
+            .or(test.rejection_reason.as_deref())
+            .unwrap_or("unknown");
+        info!("Expected result: Exception: {reason}");
     } else {
         info!("Expected result: Success");
     }
@@ -95,12 +93,10 @@ pub fn run_state_transition_test(
     // Check if the result matches expectations
     match (result, expect_exception) {
         (Ok(_), true) => {
-            bail!(
-                "Expected exception '{}' but state transition succeeded",
-                test.expect_exception
-                    .as_ref()
-                    .expect("Failed to fetch expected exception")
-            );
+            let reason = test.expect_exception.as_deref()
+                .or(test.rejection_reason.as_deref())
+                .unwrap_or("unknown");
+            bail!("Expected exception '{reason}' but state transition succeeded");
         }
         (Err(err), false) => {
             bail!("State transition should succeed but failed: {err}");

--- a/testing/lean-spec-tests/src/state_transition.rs
+++ b/testing/lean-spec-tests/src/state_transition.rs
@@ -45,7 +45,9 @@ pub fn run_state_transition_test(
     // Track whether we expect an exception (devnet4: expectException, devnet5: rejectionReason)
     let expect_exception = test.expects_failure();
     if expect_exception {
-        let reason = test.expect_exception.as_deref()
+        let reason = test
+            .expect_exception
+            .as_deref()
             .or(test.rejection_reason.as_deref())
             .unwrap_or("unknown");
         info!("Expected result: Exception: {reason}");
@@ -93,7 +95,9 @@ pub fn run_state_transition_test(
     // Check if the result matches expectations
     match (result, expect_exception) {
         (Ok(_), true) => {
-            let reason = test.expect_exception.as_deref()
+            let reason = test
+                .expect_exception
+                .as_deref()
                 .or(test.rejection_reason.as_deref())
                 .unwrap_or("unknown");
             bail!("Expected exception '{reason}' but state transition succeeded");

--- a/testing/lean-spec-tests/src/sync.rs
+++ b/testing/lean-spec-tests/src/sync.rs
@@ -19,13 +19,35 @@ pub fn load_sync_test(path: impl AsRef<Path>) -> anyhow::Result<TestFixture<Sync
 
 /// Run a single sync test case (currently the only operation is `verify_checkpoint`)
 pub fn run_sync_test(test_name: &str, test: &SyncTest) -> anyhow::Result<()> {
-    info!(
-        "Running sync test: {test_name} (operation={})",
-        test.operation
-    );
+    // devnet4: operation is a plain string, params in output
+    // devnet5: operation is an object with kind + params
+    let (operation_kind, num_validators, expected_anchor_slot) =
+        if let Some(kind) = test.operation.as_str() {
+            let num_validators = test
+                .output
+                .validator_count
+                .ok_or_else(|| anyhow!("devnet4 format requires output.validatorCount"))?;
+            let anchor_slot = test
+                .output
+                .anchor_slot
+                .ok_or_else(|| anyhow!("devnet4 format requires output.anchorSlot"))?;
+            (kind.to_string(), num_validators, anchor_slot)
+        } else {
+            let kind = test.operation["kind"]
+                .as_str()
+                .ok_or_else(|| anyhow!("Missing operation.kind"))?
+                .to_string();
+            let num_validators = test.operation["numValidators"]
+                .as_u64()
+                .ok_or_else(|| anyhow!("Missing operation.numValidators"))?;
+            let anchor_slot = test.operation["anchorSlot"].as_u64().unwrap_or(0);
+            (kind, num_validators, anchor_slot)
+        };
 
-    if test.operation != "verify_checkpoint" {
-        bail!("Unknown sync operation: {}", test.operation);
+    info!("Running sync test: {test_name} (operation={operation_kind})");
+
+    if operation_kind != "verify_checkpoint" {
+        bail!("Unknown sync operation: {operation_kind}");
     }
 
     let state_bytes = hex::decode(test.output.state_bytes.trim_start_matches("0x"))
@@ -39,14 +61,12 @@ pub fn run_sync_test(test_name: &str, test: &SyncTest) -> anyhow::Result<()> {
     let actually_valid = actual_validator_count > 0;
 
     ensure!(
-        actual_validator_count == test.output.validator_count,
-        "validatorCount mismatch: expected {}, got {actual_validator_count}",
-        test.output.validator_count,
+        actual_validator_count == num_validators,
+        "validatorCount mismatch: expected {num_validators}, got {actual_validator_count}",
     );
     ensure!(
-        actual_slot == test.output.anchor_slot,
-        "anchorSlot mismatch: expected {}, got {actual_slot}",
-        test.output.anchor_slot,
+        actual_slot == expected_anchor_slot,
+        "anchorSlot mismatch: expected {expected_anchor_slot}, got {actual_slot}",
     );
     ensure!(
         actually_valid == test.output.valid,

--- a/testing/lean-spec-tests/src/types/slot_clock.rs
+++ b/testing/lean-spec-tests/src/types/slot_clock.rs
@@ -4,15 +4,23 @@ use serde::Deserialize;
 #[serde(rename_all = "camelCase")]
 pub struct SlotClockTest {
     pub network: String,
-    pub operation: String,
-    pub input: serde_json::Value,
+    /// devnet4: plain string; devnet5: object with `kind` and input params
+    pub operation: serde_json::Value,
+    /// devnet4 only — params moved into `operation` in devnet5
+    #[serde(default)]
+    pub input: Option<serde_json::Value>,
     pub output: SlotClockOutput,
+    /// devnet5: top-level; devnet4: inside `output`
+    #[serde(default)]
+    pub config: Option<SlotClockConfig>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SlotClockOutput {
-    pub config: SlotClockConfig,
+    /// devnet4 only — moved to top-level in devnet5
+    #[serde(default)]
+    pub config: Option<SlotClockConfig>,
     #[serde(default)]
     pub slot: Option<u64>,
     #[serde(default)]
@@ -21,30 +29,10 @@ pub struct SlotClockOutput {
     pub total_intervals: Option<u64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SlotClockConfig {
     pub seconds_per_slot: u64,
     pub intervals_per_slot: u64,
     pub milliseconds_per_interval: u64,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CurrentTimeInput {
-    pub genesis_time: u64,
-    pub current_time_ms: u64,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FromSlotInput {
-    pub slot: u64,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FromUnixTimeInput {
-    pub unix_seconds: u64,
-    pub genesis_time: u64,
 }

--- a/testing/lean-spec-tests/src/types/state_transition.rs
+++ b/testing/lean-spec-tests/src/types/state_transition.rs
@@ -11,7 +11,16 @@ pub struct StateTransitionTest {
     pub pre: State,
     pub blocks: Vec<Block>,
     pub post: Option<StateExpectation>,
+    /// devnet4 field name for expected failure
     pub expect_exception: Option<String>,
+    /// devnet5 field name for expected failure
+    pub rejection_reason: Option<String>,
+}
+
+impl StateTransitionTest {
+    pub fn expects_failure(&self) -> bool {
+        self.expect_exception.is_some() || self.rejection_reason.is_some()
+    }
 }
 
 /// State expectations for state transition tests

--- a/testing/lean-spec-tests/src/types/sync.rs
+++ b/testing/lean-spec-tests/src/types/sync.rs
@@ -4,8 +4,11 @@ use serde::Deserialize;
 #[serde(rename_all = "camelCase")]
 pub struct SyncTest {
     pub network: String,
-    pub operation: String,
-    pub input: SyncInput,
+    /// devnet4: plain string; devnet5: object with `kind`, `numValidators`, `anchorSlot`
+    pub operation: serde_json::Value,
+    /// devnet4 only — params moved into `operation` in devnet5
+    #[serde(default)]
+    pub input: Option<SyncInput>,
     pub output: SyncOutput,
 }
 
@@ -22,6 +25,10 @@ pub struct SyncInput {
 pub struct SyncOutput {
     pub valid: bool,
     pub state_bytes: String,
-    pub validator_count: u64,
-    pub anchor_slot: u64,
+    /// devnet4 only — in devnet5 this lives in `operation`
+    #[serde(default)]
+    pub validator_count: Option<u64>,
+    /// devnet4 only — in devnet5 this lives in `operation`
+    #[serde(default)]
+    pub anchor_slot: Option<u64>,
 }

--- a/testing/lean-spec-tests/tests/tests.rs
+++ b/testing/lean-spec-tests/tests/tests.rs
@@ -51,7 +51,9 @@ fn find_fixture_files(suite: &str) -> Vec<PathBuf> {
     let network = "devnet5";
     #[cfg(not(feature = "devnet5"))]
     let network = "devnet4";
-    find_json_files(&format!("fixtures/{network}/consensus/{suite}/{FIXTURE_PROFILE}"))
+    find_json_files(&format!(
+        "fixtures/{network}/consensus/{suite}/{FIXTURE_PROFILE}"
+    ))
 }
 
 fn should_run_fixture_suite(suite: &str, fixtures: &[PathBuf]) -> bool {


### PR DESCRIPTION
### What was wrong?

On running `make test-devnet4` and `make test-devnet5` in the `testing/lean-spec-tests` folder, 3 and 42 tests were failing respectively. This PR addresses and makes the appropriate changes for all tests to work. 


### How was it fixed?

- For devnet4, the tests were failing due to the const for max attestation being set to 8, which in the test vectors was assumed to be 16, so just changing that was enough for all tests to pass. 

- For devnet5, most of the changes were due to changes in the fixture format(in JSON)  as compared to devnet4, so changed the appropriate tests for sync, slot clock and state transition fixtures . The final change was addition of validation checks for the head checkpoint. 

I have added an example below to show the difference in the test fixtures format :-  
```json
  // devnet4
  {
    "operation": "current_slot",
    "input": { "genesisTime": 1700000000, "currentTimeMs": 1700002000 },
    "output": {
      "config": { "secondsPerSlot": 4, "intervalsPerSlot": 5, "millisecondsPerInterval": 800 },
      "slot": 0 
    }
  }

  // devnet5
  {
    "operation": { "kind": "current_slot", "genesisTime": 1700000000, "currentTimeMilliseconds": 1700002000.0 },
    "config": { "secondsPerSlot": 4, "intervalsPerSlot": 5, "millisecondsPerInterval": 800 },
    "output": { "slot": 0 }
  }
```

### Result 

All the test vectors for both devnet4 and devnet5 are running properly. 

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
