### PR TITLE
fix: report fork_choice validator_count as null when head state missing

### DIFF
--- a/crates/rpc/lean/src/handlers/fork_choice.rs
+++ b/crates/rpc/lean/src/handlers/fork_choice.rs
@@ -44,9 +44,7 @@ pub async fn get_fork_choice_tree(
         .get(head_root)
         .map_err(|err| ApiError::InternalError(format!("Unable to get head state: {err:?}")))?;
 
-    let validator_count = head_state
-        .map(|state| state.validators.len() as u64)
-        .unwrap_or(0);
+    let validator_count = head_state.map(|state| state.validators.len() as u64);
 
     let blocks = db
         .block_provider()


### PR DESCRIPTION
Fixes #1429.

When the node does not have the head state, the `/fork_choice` API used to return `validator_count: 0`. But `0` is also a real count, so a reader could not tell "no validators" apart from "state is missing".

Now it returns `validator_count: null` when the head state is missing. `null` means "unknown".

This matches leanSpec PR leanEthereum/leanSpec#1104. The null case is already covered by leanSpec's server test, and the happy path by the apitest conformance run.