### PR TITLE
fix: build failure in devnet-5 parallel ci 

### DIFF
--- a/testing/test_utils/src/store.rs
+++ b/testing/test_utils/src/store.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "devnet5")]
+use ream_consensus_lean::attestation::MultiMessageAggregate;
 #[cfg(feature = "devnet4")]
 use ream_consensus_lean::block::BlockSignatures;
 use ream_consensus_lean::{block::SignedBlock, utils::generate_default_validators};
@@ -23,7 +25,9 @@ pub async fn sample_store(no_of_validators: usize) -> Store {
             proposer_signature: Signature::blank(),
         },
         #[cfg(feature = "devnet5")]
-        proof: VariableList::default(),
+        proof: MultiMessageAggregate {
+            proof: VariableList::default(),
+        },
     };
 
     let temp_path = std::env::temp_dir().join(format!(


### PR DESCRIPTION
### What was wrong?

Currently in the CI tests, only one test was having a build failure, rest all were related to test failures. This is an example of  the [test/devnet-5 parallel](https://github.com/ReamLabs/ream/actions/runs/27647161974/job/81762031817) failing the build 

### How was it fixed?

It expected a `MultiMessageAggregate`, but was sent a `VariableList<_,_>`, just adding MultiMessageAggregate as the dependency and wrapping `VariableList<_,_>` by it was sufficient. 
 

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
