### PR TITLE
feat(fork-choice): add tiered attestation scoring

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Reverse,
     collections::{HashMap, HashSet},
     sync::Arc,
     time::Instant,
@@ -66,6 +67,46 @@ use crate::constants::JUSTIFICATION_LOOKBACK_SLOTS;
 
 pub type LeanStoreWriter = Writer<Store>;
 pub type LeanStoreReader = Reader<Store>;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum AttestationScoreTier {
+    Finalize = 1,
+    Justify = 2,
+    Build = 3,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AttestationEntryScore {
+    tier: AttestationScoreTier,
+    new_voter_count: usize,
+    target_slot: u64,
+    attestation_slot: u64,
+}
+
+#[allow(dead_code)]
+impl AttestationEntryScore {
+    fn ordering_key(&self, data_root: B256) -> AttestationEntryOrderingKey {
+        AttestationEntryOrderingKey {
+            tier: self.tier,
+            new_voter_count: Reverse(self.new_voter_count),
+            target_slot: self.target_slot,
+            attestation_slot: self.attestation_slot,
+            data_root,
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct AttestationEntryOrderingKey {
+    tier: AttestationScoreTier,
+    new_voter_count: Reverse<usize>,
+    target_slot: u64,
+    attestation_slot: u64,
+    data_root: B256,
+}
 
 /// [Store] represents the state that the Lean node should maintain.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
### What was wrong?

### How was it fixed?

- `AttestationScoreTier` for `Finalize`, `Justify`, and `Build` priority tiers.
- `AttestationEntryScore` for candidate scoring metadata.
- `AttestationEntryOrderingKey` to preserve deterministic candidate ordering.
- In progress...

### To-Do

- [ ] Port the tiered attestation selection algorithm.
- [ ] Add focused tests for tier ordering and candidate selection.
- [ ] Benchmark block production impact.
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).