### PR TITLE
fix: changes for build failure in devnet5 parallel ci test

### DIFF
--- a/crates/common/chain/lean/src/sync/forward_background_syncer.rs
+++ b/crates/common/chain/lean/src/sync/forward_background_syncer.rs
@@ -162,6 +162,8 @@ mod tests {
     use std::sync::Arc;
 
     use libp2p_identity::PeerId;
+    #[cfg(feature = "devnet5")]
+    use ream_consensus_lean::attestation::MultiMessageAggregate;
     #[cfg(feature = "devnet4")]
     use ream_consensus_lean::block::BlockSignatures;
     use ream_consensus_lean::block::SignedBlock;
@@ -189,7 +191,9 @@ mod tests {
                     proposer_signature: Signature::blank(),
                 },
                 #[cfg(feature = "devnet5")]
-                proof: ssz_types::VariableList::default(),
+                proof: MultiMessageAggregate {
+                    proof: ssz_types::VariableList::default(),
+                },
             };
             store.on_block(&signed_block, false).await.unwrap();
         }
@@ -206,7 +210,9 @@ mod tests {
                 proposer_signature: Signature::mock(),
             },
             #[cfg(feature = "devnet5")]
-            proof: ssz_types::VariableList::default(),
+            proof: MultiMessageAggregate {
+                proof: ssz_types::VariableList::default(),
+            },
         };
         let bad_root = B256::repeat_byte(0xef);
         store

--- a/crates/common/checkpoint_sync/lean/src/lib.rs
+++ b/crates/common/checkpoint_sync/lean/src/lib.rs
@@ -115,6 +115,8 @@ mod tests {
         web::{self, Data},
     };
     use alloy_primitives::B256;
+    #[cfg(feature = "devnet5")]
+    use ream_consensus_lean::attestation::MultiMessageAggregate;
     #[cfg(feature = "devnet4")]
     use ream_consensus_lean::block::BlockSignatures;
     use ream_consensus_lean::{
@@ -512,7 +514,9 @@ mod tests {
                 proposer_signature: Signature::blank(),
             },
             #[cfg(feature = "devnet5")]
-            proof: VariableList::<u8, U524288>::default(),
+            proof: MultiMessageAggregate {
+                proof: VariableList::<u8, U524288>::default(),
+            },
         }
     }
 


### PR DESCRIPTION
### What was wrong?

Currently in the CI tests, only one test was having a build failure, rest all were related to test failures. This is an example of the [test/devnet-5 parallel](https://github.com/ReamLabs/ream/actions/runs/27647161974/job/81762031817) failing the build. 

### How was it fixed?

The actual proof representation for devnet5 is as follows, but it was just used as `VariableList::default()` 
```proof : MultiMessageAggregate {proof : VariableList<_,_>}```

adding MultiMessageAggregate in imports and encapsulating the VariableList fixes the failing build. 

The test/devnet-5 parallel CI runs the following command, which can be used to check the test' behaviour on local.
 `cargo test --workspace --no-default-features --features devnet5 -- --nocapture`

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
