### PR TITLE
fix: Enforcing distinct attestation data cap in state transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6310,6 +6310,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "itertools 0.14.0",
+ "ream-consensus-misc",
  "ream-metrics",
  "ream-post-quantum-crypto",
  "serde",

--- a/crates/common/consensus/lean/Cargo.toml
+++ b/crates/common/consensus/lean/Cargo.toml
@@ -28,6 +28,7 @@ tree_hash.workspace = true
 tree_hash_derive.workspace = true
 
 # Local dependencies
+ream-consensus-misc.workspace = true
 ream-metrics.workspace = true
 ream-post-quantum-crypto.workspace = true
 

--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use alloy_primitives::B256;
 use anyhow::{Context, anyhow, ensure};
 use itertools::Itertools;
+use ream_consensus_misc::constants::lean::MAX_ATTESTATIONS_DATA;
 use ream_metrics::{
     FINALIZED_SLOT, JUSTIFIED_SLOT, STATE_TRANSITION_ATTESTATIONS_PROCESSED_TOTAL,
     STATE_TRANSITION_ATTESTATIONS_PROCESSING_TIME, STATE_TRANSITION_BLOCK_PROCESSING_TIME,
@@ -277,6 +278,17 @@ impl LeanState {
         attestations: &[AggregatedAttestation],
     ) -> anyhow::Result<()> {
         let timer = start_timer(&STATE_TRANSITION_ATTESTATIONS_PROCESSING_TIME, &[]);
+
+        let mut distinct_data_roots = HashSet::new();
+        for attestation in attestations {
+            distinct_data_roots.insert(attestation.message.tree_hash_root());
+        }
+        let distinct_attestation_data = distinct_data_roots.len();
+        ensure!(
+            distinct_attestation_data as u64 <= MAX_ATTESTATIONS_DATA,
+            "Block contains {distinct_attestation_data} distinct AttestationData entries; \
+             maximum is {MAX_ATTESTATIONS_DATA}",
+        );
 
         ensure!(
             !self.justifications_roots.contains(&B256::ZERO),

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1232,12 +1232,6 @@ impl Store {
                  each AttestationData must appear at most once",
             );
         }
-        let distinct_attestation_data = seen_attestation_data.len();
-        ensure!(
-            distinct_attestation_data as u64 <= MAX_ATTESTATIONS_DATA,
-            "Block contains {distinct_attestation_data} distinct AttestationData entries; \
-             maximum is {MAX_ATTESTATIONS_DATA}",
-        );
 
         #[cfg(feature = "devnet4")]
         {


### PR DESCRIPTION
### What was wrong?

#1443 


### How was it fixed?

Earlier the distinct-data cap was being enforced in the fork choice in the `crates/common/fork_choice/lean/src/store.rs`, the bound check is now moved to the attestation processing step directly to state transition in `crates/common/consensus/lean/src/state.rs`. 

currently also implemented a unit test `process_attestations_rejects_over_distinct_data_cap` to verify the procedure, the test can be removed as the fixtures are updated. 

<img width="726" height="310" alt="image" src="https://github.com/user-attachments/assets/2718af88-897e-42cd-9914-145828c19dc6" />

### Update

As the unit test was a duplicate, it has been removed 
### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
