### PR TITLE
perf: reduce allocations in lean block import and head computation

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -380,12 +380,13 @@ impl Store {
         let latest_justified_root = latest_justified_provider.get()?.root;
 
         let attestations = {
-            let new_payloads = latest_new_aggregated_payloads_provider
+            let new_payload_keys = latest_new_aggregated_payloads_provider
                 .iter()?
                 .into_iter()
-                .collect();
+                .map(|(signature_key, _proofs)| signature_key)
+                .collect::<Vec<_>>();
 
-            self.extract_attestations_from_aggregated_payloads(&new_payloads)
+            self.extract_attestations_from_aggregated_payloads(&new_payload_keys)
                 .await?
         };
 
@@ -463,7 +464,7 @@ impl Store {
 
         set_int_gauge_vec(
             &LATEST_KNOWN_AGGREGATED_PAYLOADS,
-            latest_known_aggregated_payloads_provider.iter()?.len() as i64,
+            latest_known_aggregated_payloads_provider.entry_count()? as i64,
             &[],
         );
 
@@ -560,18 +561,16 @@ impl Store {
         let latest_finalized_checkpoint = latest_finalized_provider.get()?;
         let finalized_slot = latest_finalized_checkpoint.slot;
         let attestations = {
-            let entries = latest_known_aggregated_payloads_provider.iter()?;
-            let mut all_payloads: HashMap<SignatureKey, Vec<PayloadProof>> = HashMap::new();
-
-            for (key, proofs) in entries {
+            let mut relevant_keys = Vec::new();
+            for key in latest_known_aggregated_payloads_provider.iter_keys()? {
                 if let Some(data) = attestation_data_by_root_provider.get(key.data_root)?
                     && data.head.slot > finalized_slot
                 {
-                    all_payloads.insert(key, proofs);
+                    relevant_keys.push(key);
                 }
             }
 
-            self.extract_attestations_from_aggregated_payloads(&all_payloads)
+            self.extract_attestations_from_aggregated_payloads(&relevant_keys)
                 .await?
         };
 
@@ -1561,12 +1560,9 @@ impl Store {
             start_timer(&PROPOSE_BLOCK_TIME, &["add_valid_attestations_to_block"]);
 
         let attestation_data_map = {
-            let entries = latest_known_aggregated_payloads_provider.iter()?;
+            let signature_keys = latest_known_aggregated_payloads_provider.iter_keys()?;
 
-            let all_payloads: HashMap<SignatureKey, Vec<PayloadProof>> =
-                entries.into_iter().collect();
-
-            self.extract_attestations_from_aggregated_payloads(&all_payloads)
+            self.extract_attestations_from_aggregated_payloads(&signature_keys)
                 .await?
         };
 
@@ -2021,17 +2017,13 @@ impl Store {
 
     pub async fn extract_attestations_from_aggregated_payloads(
         &self,
-        aggregated_payloads: &HashMap<SignatureKey, Vec<PayloadProof>>,
+        signature_keys: &[SignatureKey],
     ) -> anyhow::Result<HashMap<u64, AttestationData>> {
         let attestation_data_by_root_provider =
             self.store.lock().await.attestation_data_by_root_provider();
-        let mut resolved_attestations = Vec::with_capacity(aggregated_payloads.len());
+        let mut resolved_attestations = Vec::with_capacity(signature_keys.len());
 
-        for (signature_key, proofs) in aggregated_payloads {
-            if proofs.is_empty() {
-                continue;
-            }
-
+        for signature_key in signature_keys {
             let data_root = signature_key.data_root;
             let Some(attestation_data) = attestation_data_by_root_provider.get(data_root)? else {
                 continue;
@@ -2366,13 +2358,10 @@ impl Store {
             )
         };
 
-        let aggregated_payloads = latest_known_aggregated_payloads_provider
-            .iter()?
-            .into_iter()
-            .collect();
+        let signature_keys = latest_known_aggregated_payloads_provider.iter_keys()?;
 
         let attestations = self
-            .extract_attestations_from_aggregated_payloads(&aggregated_payloads)
+            .extract_attestations_from_aggregated_payloads(&signature_keys)
             .await?;
 
         let start_slot = latest_finalized_provider.get()?.slot;

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1681,7 +1681,7 @@ impl Store {
 
         set_int_gauge_vec(&JUSTIFIED_SLOT, latest_justified.slot as i64, &[]);
         set_int_gauge_vec(&LATEST_JUSTIFIED_SLOT, latest_justified.slot as i64, &[]);
-        block_provider.insert(block_root, signed_block.clone())?;
+        block_provider.insert_ref(block_root, signed_block)?;
         state_provider.insert(block_root, parent_state)?;
         latest_justified_provider.insert(latest_justified)?;
         let aggregated_attestations = &block.body.attestations;

--- a/crates/storage/src/tables/lean/block.rs
+++ b/crates/storage/src/tables/lean/block.rs
@@ -68,6 +68,47 @@ impl REDBTable for LeanBlockTable {
     }
 
     fn insert(&self, key: Self::Key, value: Self::Value) -> Result<(), StoreError> {
+        self.insert_ref(key, &value)
+    }
+
+    fn remove(&self, key: Self::Key) -> Result<Option<Self::Value>, StoreError> {
+        if let Some(cache) = &self.cache
+            && let Ok(mut cache_lock) = cache.blocks.lock()
+        {
+            cache_lock.pop(&key);
+        }
+
+        let write_txn = self.db.begin_write()?;
+        let mut table = write_txn.open_table(Self::TABLE_DEFINITION)?;
+        let value = table.remove(key)?.map(|v| v.value());
+        if let Some(block) = &value {
+            let slot_index_table = LeanSlotIndexTable {
+                db: self.db.clone(),
+            };
+            slot_index_table.remove(block.block.slot)?;
+            let state_root_index_table = LeanStateRootIndexTable {
+                db: self.db.clone(),
+            };
+
+            state_root_index_table.remove(block.block.state_root)?;
+
+            let children_index_table = LeanChildrenIndexTable {
+                db: self.db.clone(),
+            };
+            children_index_table.remove(key)?;
+        }
+        drop(table);
+        write_txn.commit()?;
+        Ok(value)
+    }
+}
+
+impl LeanBlockTable {
+    pub fn contains_key(&self, key: B256) -> bool {
+        matches!(self.get(key), Ok(Some(_)))
+    }
+
+    pub fn insert_ref(&self, key: B256, value: &SignedBlock) -> Result<(), StoreError> {
         // insert entry to slot_index table
         let block_root = value.block.tree_hash_root();
         let slot_index_table = LeanSlotIndexTable {
@@ -109,43 +150,6 @@ impl REDBTable for LeanBlockTable {
         drop(table);
         write_txn.commit()?;
         Ok(())
-    }
-
-    fn remove(&self, key: Self::Key) -> Result<Option<Self::Value>, StoreError> {
-        if let Some(cache) = &self.cache
-            && let Ok(mut cache_lock) = cache.blocks.lock()
-        {
-            cache_lock.pop(&key);
-        }
-
-        let write_txn = self.db.begin_write()?;
-        let mut table = write_txn.open_table(Self::TABLE_DEFINITION)?;
-        let value = table.remove(key)?.map(|v| v.value());
-        if let Some(block) = &value {
-            let slot_index_table = LeanSlotIndexTable {
-                db: self.db.clone(),
-            };
-            slot_index_table.remove(block.block.slot)?;
-            let state_root_index_table = LeanStateRootIndexTable {
-                db: self.db.clone(),
-            };
-
-            state_root_index_table.remove(block.block.state_root)?;
-
-            let children_index_table = LeanChildrenIndexTable {
-                db: self.db.clone(),
-            };
-            children_index_table.remove(key)?;
-        }
-        drop(table);
-        write_txn.commit()?;
-        Ok(value)
-    }
-}
-
-impl LeanBlockTable {
-    pub fn contains_key(&self, key: B256) -> bool {
-        matches!(self.get(key), Ok(Some(_)))
     }
 
     /// Build the `parent_root -> children` adjacency map used by LMD GHOST.

--- a/crates/storage/src/tables/lean/latest_known_aggregated_payloads.rs
+++ b/crates/storage/src/tables/lean/latest_known_aggregated_payloads.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use ream_consensus_lean::attestation::SignatureKey;
 #[cfg(feature = "devnet5")]
 use ream_consensus_lean::attestation::SingleMessageAggregate as PayloadProof;
-use redb::{Database, Durability, ReadableDatabase, ReadableTable, TableDefinition};
+use redb::{
+    Database, Durability, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition,
+};
 
 use crate::{
     errors::StoreError,
@@ -71,6 +73,24 @@ impl LeanLatestKnownAggregatedPayloadsTable {
             entries.push((key, value));
         }
         Ok(entries)
+    }
+
+    pub fn iter_keys(&self) -> Result<Vec<SignatureKey>, StoreError> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(Self::TABLE_DEFINITION)?;
+
+        let mut keys = Vec::new();
+        for result in table.iter()? {
+            let (key_guard, _value_guard) = result?;
+            keys.push(key_guard.value());
+        }
+        Ok(keys)
+    }
+
+    pub fn entry_count(&self) -> Result<u64, StoreError> {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(Self::TABLE_DEFINITION)?;
+        Ok(table.len()?)
     }
 
     pub fn retain<F>(&self, mut f: F) -> Result<(), StoreError>


### PR DESCRIPTION
### What was wrong?

Two hot paths in the lean node allocated far more than necessary on every block and tick:

- `update_head` and `produce_block_with_signatures` iterated the entire
  `latest_known_aggregated_payloads` table and SSZ-decoded every `Vec<PayloadProof>`
  (the large post-quantum signatures) on each call. The only consumer reads just the
  validator id and attestation data root from each key, so the proof values were
  decoded and thrown away.
- `on_block` cloned the whole `SignedBlock`, carrying those same large signatures,
  just to hand it to the block store, which then cloned it again for its cache.

### How was it fixed?

- Added `iter_keys()` and `entry_count()` to the payloads table so callers read the
  keys and the entry count without decoding the proof values, and changed
  `extract_attestations_from_aggregated_payloads` to take `&[SignatureKey]`. The
  previous `is_empty()` skip is preserved by construction: both insert sites only ever
  store non-empty proof lists.
- Added `LeanBlockTable::insert_ref` so `on_block` passes the block by reference and
  redb serializes it in place; the owned `insert` now delegates to it.

No behavior change. Measured on a single-node devnet-4 (60s): `produce_block_with_signatures`
~22 MB -> ~40 KB per call, `update_head` ~15 MB -> ~4 MB per call, total process
allocation churn ~8.4 GB -> ~7.3 GB.

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
