### PR TITLE
fix: changes for hive sync test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
  "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "tracing",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
 ]
@@ -1096,19 +1096,20 @@ dependencies = [
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "rayon",
+ "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-whir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -3772,7 +3773,7 @@ dependencies = [
  "clap",
  "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "rand 0.10.0",
  "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "serde_json",
@@ -3785,19 +3786,20 @@ dependencies = [
 [[package]]
 name = "lean-multisig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "clap",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "libc",
  "rand 0.10.0",
- "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "serde_json",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -3842,17 +3844,17 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "include_dir",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -3876,19 +3878,19 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "itertools 0.14.0",
- "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
  "serde",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -3910,17 +3912,17 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "itertools 0.14.0",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "pest",
  "pest_derive",
  "rand 0.10.0",
  "serde",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -3979,9 +3981,9 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "ethereum_ssz",
  "leansig",
  "leansig_fast_keygen",
@@ -4646,10 +4648,10 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -4661,7 +4663,7 @@ dependencies = [
  "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "serde",
  "tracing",
 ]
@@ -4669,13 +4671,13 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "rayon",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "serde",
  "tracing",
 ]
@@ -4688,7 +4690,7 @@ dependencies = [
  "itertools 0.14.0",
  "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "num-bigint",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "paste",
  "rand 0.10.0",
  "serde",
@@ -4698,14 +4700,14 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "num-bigint",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "paste",
  "rand 0.10.0",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -4728,15 +4730,14 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "num-bigint",
  "paste",
  "rand 0.10.0",
- "rayon",
  "serde",
  "tracing",
 ]
@@ -4749,7 +4750,7 @@ dependencies = [
  "itertools 0.14.0",
  "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "rand 0.10.0",
  "serde",
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
@@ -4759,15 +4760,16 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "rand 0.10.0",
- "rayon",
  "serde",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -4779,7 +4781,7 @@ dependencies = [
  "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "tracing",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
 ]
@@ -4787,14 +4789,15 @@ dependencies = [
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "rayon",
+ "mt-air 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -4804,18 +4807,19 @@ source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a9
 dependencies = [
  "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
 ]
 
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "rayon",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -4829,7 +4833,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "serde",
 ]
@@ -4847,7 +4851,7 @@ dependencies = [
  "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "rand 0.10.0",
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "tracing",
@@ -4857,20 +4861,21 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "itertools 0.14.0",
- "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "mt-fiat-shamir 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-field 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-koala-bear 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-poly 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-sumcheck 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-symetric 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "mt-utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "rand 0.10.0",
- "rayon",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -5345,6 +5350,14 @@ version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
+]
+
+[[package]]
+name = "parallel"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
+dependencies = [
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -6734,7 +6747,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "leansig",
  "rand 0.10.0",
  "serde",
@@ -7053,14 +7066,14 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "include_dir",
- "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "leansig_wrapper 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "lz4_flex",
  "objc2",
  "objc2-foundation",
@@ -7068,10 +7081,10 @@ dependencies = [
  "rand 0.10.0",
  "serde",
  "sha3 0.11.0",
- "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -8078,7 +8091,7 @@ source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a9
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
 ]
@@ -8086,12 +8099,12 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
- "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "tracing",
- "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]
@@ -8186,10 +8199,9 @@ dependencies = [
 [[package]]
 name = "system-info"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "libc",
- "rayon",
 ]
 
 [[package]]
@@ -8803,9 +8815,9 @@ dependencies = [
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
- "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -9676,17 +9688,18 @@ version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
 dependencies = [
  "libc",
- "parallel",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
 ]
 
 [[package]]
 name = "zk-alloc"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420#b00d6ba3dc574f915dc40a1796d95972178ac420"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "libc",
- "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=b00d6ba3dc574f915dc40a1796d95972178ac420)",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,14 @@ exclude = ["book/cli"]
 [workspace.package]
 authors = ["https://github.com/ReamLabs/ream/graphs/contributors"]
 edition = "2024"
-keywords = ["ethereum", "beam-chain", "blockchain", "consensus", "protocol", "ream"]
+keywords = [
+    "ethereum",
+    "beam-chain",
+    "blockchain",
+    "consensus",
+    "protocol",
+    "ream",
+]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ReamLabs/ream"
@@ -78,7 +85,9 @@ actix-web-lab = "0.24.3"
 aes = "0.8.4"
 alloy-consensus = { version = "1.0.41", default-features = false }
 alloy-primitives = { version = "1.4.1", features = ['serde'] }
-alloy-rlp = { version = "0.3.12", default-features = false, features = ["derive"] }
+alloy-rlp = { version = "0.3.12", default-features = false, features = [
+    "derive",
+] }
 alloy-rpc-types-beacon = "1.0.41"
 alloy-rpc-types-eth = "1.0.41"
 anyhow = "1.0.100"
@@ -103,9 +112,26 @@ jsonwebtoken = "9.3.1"
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
 lazy_static = "1.5.0"
 lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "2498896ca4d32a545a98a1b1cf1ca78f7f13f553" }
-lean-multisig-type2 = { package = "lean-multisig", git = "https://github.com/leanEthereum/leanMultisig.git", rev = "b00d6ba3dc574f915dc40a1796d95972178ac420" }
+lean-multisig-type2 = { package = "lean-multisig", git = "https://github.com/leanEthereum/leanMultisig.git", rev = "e2592df4e30fdddbbf8ae26a333116c68cec7026" }
 leansig = { git = "https://github.com/leanEthereum//leanSig.git", branch = "devnet4" }
-libp2p = { version = "0.56", default-features = false, features = ["identify", "yamux", "noise", "dns", "serde", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "gossipsub", "ping"] }
+libp2p = { version = "0.56", default-features = false, features = [
+    "identify",
+    "yamux",
+    "noise",
+    "dns",
+    "serde",
+    "tcp",
+    "tokio",
+    "plaintext",
+    "secp256k1",
+    "macros",
+    "ecdsa",
+    "metrics",
+    "quic",
+    "upnp",
+    "gossipsub",
+    "ping",
+] }
 libp2p-identity = "0.2.12"
 libp2p-mplex = "0.43.1"
 libp2p-swarm = "0.47"
@@ -115,10 +141,13 @@ prometheus_exporter = { git = "https://github.com/AlexanderThaller/prometheus_ex
 rand = "0.9"
 rand_chacha = "0.9"
 redb = "3.1.0"
-reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12.24", default-features = false, features = [
+    "rustls-tls",
+    "json",
+] }
 rstest = "0.26.1"
 rust-kzg-blst = { git = 'https://github.com/grandinetech/rust-kzg.git' }
-rust_eth_kzg = { git = "https://github.com/crate-crypto/rust-eth-kzg.git", tag = "v0.5.4" } 
+rust_eth_kzg = { git = "https://github.com/crate-crypto/rust-eth-kzg.git", tag = "v0.5.4" }
 serde = { version = '1.0', features = ['derive', "rc"] }
 serde_json = "1.0.145"
 serde_yaml = "0.9"
@@ -128,7 +157,14 @@ ssz_types = { git = "https://github.com/sigp/ssz_types.git", rev = "5dc2d521ed31
 tempdir = "0.3.7"
 tempfile = "3.23.0"
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "sync", "signal", "time", "macros"] }
+tokio = { version = "1.48.0", features = [
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "signal",
+    "time",
+    "macros",
+] }
 tokio-util = { version = "0.7.16", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = "0.3.20"
@@ -144,7 +180,9 @@ ream-account-manager = { path = "crates/common/account_manager" }
 ream-api-types-beacon = { path = "crates/common/api_types/beacon" }
 ream-api-types-common = { path = "crates/common/api_types/common" }
 ream-api-types-lean = { path = "crates/common/api_types/lean" }
-ream-bls = { path = "crates/crypto/bls", features = ["zkcrypto"] } # Default feature is zkcrypto
+ream-bls = { path = "crates/crypto/bls", features = [
+    "zkcrypto",
+] } # Default feature is zkcrypto
 ream-chain-beacon = { path = "crates/common/chain/beacon" }
 ream-chain-lean = { path = "crates/common/chain/lean", default-features = false }
 ream-checkpoint-sync-beacon = { path = "crates/common/checkpoint_sync/beacon" }


### PR DESCRIPTION
### What was wrong?

All the tests in the Sync Test suite in [Hive](https://hive.leanroadmap.org/) were currently failing for ream-devnet5. 

### How was it fixed?

Earlier the failure was caused due to the lean simulator in hive still using the devnet-4 pattern which was fixed in this PR  [ethereum/hive#1592](https://github.com/ethereum/hive/pull/1542). This was causing a SSZ decode error in the logs of all the Sync tests which was fixed. 
```
Failed to decode TopicHash { hash: "/leanconsensus/12345678/block/ssz_snappy" } gossip topic: InvalidData("Failed to decode ssz: OffsetSkipsVariableBytes(2540)")
```

The sync test suite were still failing for ream, ream would start and connect to the leanSpec helper mesh but would not go past genesis and the tests timed out and the logs kept on showing Failed to parse req/resp error. 
On running on local device and checking the ream client container logs, it showed Multi-Message Aggregate decode error.
```
Failed to handle process block message: Block proof verification failed: Failed to decode multi-message aggregate multi-signature from wire bytes
```
This error was due to mismatch in the `lean-multisig-type2 rev` being used in the Cargo.toml for ream( verifier)  and the [lean-mutlisig-py](https://github.com/anshalshukla/leanMultisig-py/commit/39b9c397fd4d2c358f8efe2815d4fb78f0e47e67) version being used by the hive simulator to generate the proof. 
The current rev in ream for lean-multisig-type2 (leanVM) is the same one that was used in [lean-multisig-py](https://github.com/anshalshukla/leanMultisig-py/commit/39b9c397fd4d2c358f8efe2815d4fb78f0e47e67) i.e `e2592df` matching the rev resulted in the sync test suite passing on local.  

<img width="1141" height="662" alt="image" src="https://github.com/user-attachments/assets/9a00dde4-1f11-4661-adb3-7f054ea51b66" />

To replicate on local , update your rev for lean-multisig-type2 to commit `e2592df4e30fdddbbf8ae26a333116c68cec7026`,

```bash
cd ream
CROSS_CONTAINER_ENGINE=docker cross build --release --package ream --bin ream --target x86_64-unknown-linux-gnu --no-default-features --features devnet5
mkdir -p bin/amd64
cp target/x86_64-unknown-linux-gnu/release/ream bin/amd64/ream
docker buildx build -f Dockerfile.cross . \
    --platform linux/amd64 \
    --tag ghcr.io/reamlabs/ream:latest-devnet5 \
    --load
```
Build the Hive binary and run the following command to run the sync test suite
```
cd hive
go build -o hive .
./hive --sim lean --sim.limit 'sync' --client ream_devnet5  --docker.nocache lean
```
All the above steps took about ~2hrs on my mac air M2 16 gb ram. 


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 ~~Updating lean-multisig to the latest commit instead of `e2592df4e30fdddbbf8ae26a333116c68cec7026`.~~
- [x] Updating docker image using `make docker-build-push-devnet5` 
