### PR TITLE
fix: correct field swap in recover_matrix (#1449)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6281,6 +6281,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "itertools 0.14.0",
+ "rand 0.9.2",
  "ream-bls",
  "ream-consensus-misc",
  "ream-execution-engine",

--- a/crates/common/consensus/beacon/Cargo.toml
+++ b/crates/common/consensus/beacon/Cargo.toml
@@ -45,5 +45,8 @@ ream-execution-rpc-types.workspace = true
 ream-merkle.workspace = true
 ream-network-spec.workspace = true
 
+[dev-dependencies]
+rand.workspace = true
+
 [lints]
 workspace = true

--- a/crates/common/consensus/beacon/src/matrix_entry.rs
+++ b/crates/common/consensus/beacon/src/matrix_entry.rs
@@ -8,7 +8,7 @@ use ssz_types::FixedVector;
 
 use crate::data_column_sidecar::Cell;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MatrixEntry {
     cell: Cell,
     #[allow(dead_code)]
@@ -60,8 +60,8 @@ pub fn recover_matrix(
             matrix.push(MatrixEntry {
                 cell,
                 kzg_proof,
-                column_index: blob_index,
-                row_index: cell_index as u64,
+                column_index: cell_index as u64,
+                row_index: blob_index,
             });
         }
     }
@@ -155,4 +155,95 @@ pub fn compute_cells(
         .map_err(|err| anyhow!("Failed to convert to fixed array {err:?}"))?;
 
     Ok(final_cells)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{Rng, SeedableRng, rngs::StdRng, seq::SliceRandom};
+    use rust_eth_kzg::{DASContext, TrustedSetup, UsePrecomp};
+    use ssz::Decode;
+
+    use super::*;
+
+    const BYTES_PER_BLOB: usize = 131072;
+
+    fn get_sample_blob(rng: &mut StdRng) -> Blob {
+        let mut bytes = vec![0u8; BYTES_PER_BLOB];
+        for chunk in bytes.chunks_mut(32) {
+            rng.fill(&mut chunk[1..]);
+        }
+        Blob::from_ssz_bytes(&bytes).expect("constructed blob bytes should decode")
+    }
+
+    fn chunks<T: Clone>(items: &[T], size: usize) -> Vec<Vec<T>> {
+        items.chunks(size).map(|chunk| chunk.to_vec()).collect()
+    }
+
+    #[test]
+    fn test_compute_matrix() -> Result<()> {
+        let mut rng = StdRng::seed_from_u64(5566);
+        let context = DASContext::new(&TrustedSetup::default(), UsePrecomp::No);
+
+        let blob_count = 2;
+        let input_blobs: Vec<Blob> = (0..blob_count).map(|_| get_sample_blob(&mut rng)).collect();
+
+        let matrix = compute_matrix(input_blobs.clone(), &context)?;
+        assert_eq!(matrix.len(), CELLS_PER_EXT_BLOB as usize * blob_count);
+
+        let rows = chunks(&matrix, CELLS_PER_EXT_BLOB as usize);
+        assert_eq!(rows.len(), blob_count);
+        for row in &rows {
+            assert_eq!(row.len(), CELLS_PER_EXT_BLOB as usize);
+        }
+
+        for (blob_index, row) in rows.iter().enumerate() {
+            let mut column_indices: Vec<u64> = row
+                .iter()
+                .map(|entry| {
+                    assert_eq!(entry.row_index, blob_index as u64);
+                    entry.column_index
+                })
+                .collect();
+            column_indices.sort();
+            assert_eq!(column_indices, (0..CELLS_PER_EXT_BLOB).collect::<Vec<_>>());
+
+            let mut extended_blob = Vec::<u8>::new();
+            for entry in row {
+                extended_blob.extend::<Vec<u8>>(entry.cell.clone().into());
+            }
+            let blob_part = &extended_blob[..extended_blob.len() / 2];
+            let original: Vec<u8> = input_blobs[blob_index].inner.clone().into();
+            assert_eq!(blob_part, original.as_slice());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_recover_matrix() -> Result<()> {
+        let mut rng = StdRng::seed_from_u64(5566);
+        let context = DASContext::new(&TrustedSetup::default(), UsePrecomp::No);
+
+        let n_samples = (CELLS_PER_EXT_BLOB / 2) as usize;
+        let blob_count = 2;
+
+        let blobs: Vec<Blob> = (0..blob_count).map(|_| get_sample_blob(&mut rng)).collect();
+        let matrix = compute_matrix(blobs, &context)?;
+
+        let mut partial_matrix = Vec::new();
+        for blob_entries in chunks(&matrix, CELLS_PER_EXT_BLOB as usize) {
+            let mut indices: Vec<usize> = (0..blob_entries.len()).collect();
+
+            indices.shuffle(&mut rng);
+            let mut sampled = indices[..n_samples].to_vec();
+            sampled.sort();
+            partial_matrix.extend(sampled.into_iter().map(|i| blob_entries[i].clone()));
+        }
+
+        let recovered_matrix = recover_matrix(partial_matrix, blob_count as u64, &context)?;
+
+        assert_eq!(recovered_matrix, matrix);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
### What was wrong?

Fixes #1449 

`recover_matrix` was reconstructing `MatrixEntry` with `column_index` and `row_index` swapped

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

### How was it fixed?

Fix the swap and add the `test_compute_matrix` and `test_recover_matrix` unit tests from the spec's [das-core unittests](https://github.com/ethereum/consensus-specs/blob/master/tests/core/pyspec/eth_consensus_specs/test/fulu/unittests/das/test_das.py) that were missing 