### PR TITLE
fix: hive client interop

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -72,13 +72,13 @@ use ream_p2p::{
     network::lean::{LeanNetworkConfig, LeanNetworkService},
 };
 #[cfg(feature = "devnet4")]
-use ream_post_quantum_crypto::leansig::signature::Signature;
-#[cfg(feature = "devnet4")]
 use ream_post_quantum_crypto::lean_multisig::aggregate::{
     aggregation_setup_prover, aggregation_setup_verifier,
 };
 #[cfg(feature = "devnet5")]
 use ream_post_quantum_crypto::lean_multisig::type_2::{type_2_setup, type_2_setup_verifier};
+#[cfg(feature = "devnet4")]
+use ream_post_quantum_crypto::leansig::signature::Signature;
 use ream_post_quantum_crypto::leansig::{
     private_key::PrivateKey as LeanSigPrivateKey, public_key::PublicKey,
 };

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -73,9 +73,14 @@ use ream_p2p::{
 };
 #[cfg(feature = "devnet4")]
 use ream_post_quantum_crypto::leansig::signature::Signature;
-use ream_post_quantum_crypto::{
-    lean_multisig::aggregate::{aggregation_setup_prover, aggregation_setup_verifier},
-    leansig::{private_key::PrivateKey as LeanSigPrivateKey, public_key::PublicKey},
+#[cfg(feature = "devnet4")]
+use ream_post_quantum_crypto::lean_multisig::aggregate::{
+    aggregation_setup_prover, aggregation_setup_verifier,
+};
+#[cfg(feature = "devnet5")]
+use ream_post_quantum_crypto::lean_multisig::type_2::{type_2_setup, type_2_setup_verifier};
+use ream_post_quantum_crypto::leansig::{
+    private_key::PrivateKey as LeanSigPrivateKey, public_key::PublicKey,
 };
 use ream_rpc_common::config::RpcServerConfig;
 use ream_rpc_lean::{
@@ -249,13 +254,19 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
     // Initialize aggregation verifier bytecode — all nodes need this to verify
     // aggregate signatures when processing blocks during sync.
     info!("Initializing aggregation verifier bytecode...");
+    #[cfg(feature = "devnet4")]
     aggregation_setup_verifier();
+    #[cfg(feature = "devnet5")]
+    type_2_setup_verifier();
     info!("Aggregation verifier bytecode initialized");
 
     // Initialize aggregation prover bytecode only if this node is an aggregator.
     if config.is_aggregator {
         info!("Initializing aggregation prover bytecode for aggregator mode...");
+        #[cfg(feature = "devnet4")]
         aggregation_setup_prover();
+        #[cfg(feature = "devnet5")]
+        type_2_setup();
         info!("Aggregation prover bytecode initialized");
     }
 

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -342,7 +342,7 @@ impl LeanChainService {
                         self.sync_status = self.update_sync_status().await?;
                     }
                     if self.sync_status == SyncStatus::Synced {
-                        self.store.write().await.tick_interval(tick_count.is_multiple_of(INTERVALS_PER_SLOT), self.is_aggregator).await.expect("Failed to tick interval");
+                        self.store.write().await.tick_interval(tick_count.is_multiple_of(INTERVALS_PER_SLOT), self.is_aggregator).await?;
                         self.step_head_sync(tick_count).await?;
                     }
 
@@ -653,12 +653,7 @@ impl LeanChainService {
                     tick = tick_count,
                     "Computing safe target"
                 );
-                self.store
-                    .write()
-                    .await
-                    .update_safe_target()
-                    .await
-                    .expect("Failed to update safe target");
+                self.store.write().await.update_safe_target().await?;
             }
             4 => {
                 // Fifth tick: Accept new attestations.
@@ -667,12 +662,7 @@ impl LeanChainService {
                     tick = tick_count,
                     "Accepting new attestations"
                 );
-                self.store
-                    .write()
-                    .await
-                    .accept_new_attestations()
-                    .await
-                    .expect("Failed to accept new attestations");
+                self.store.write().await.accept_new_attestations().await?;
             }
             _ => {
                 // Other ticks: Do nothing.

--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -293,9 +293,14 @@ impl LeanState {
             for (i, root) in self.justifications_roots.iter().enumerate() {
                 let start_index = i * validator_count;
                 let end_index = start_index + validator_count;
-                let vote_slice = &flat_votes
-                    .get(start_index..end_index)
-                    .expect("Could not get indexs");
+                let vote_slice = &flat_votes.get(start_index..end_index).ok_or_else(|| {
+                    anyhow!(
+                        "justifications_validators too short: expected at least {end_index} bits \
+                         ({} roots x {validator_count} validators), got {}",
+                        self.justifications_roots.len(),
+                        flat_votes.len(),
+                    )
+                })?;
 
                 let mut new_bitlist = BitList::<U1073741824>::with_capacity(validator_count)
                     .map_err(|err| {

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -699,11 +699,33 @@ impl Store {
 
             #[cfg(feature = "devnet5")]
             let proof = {
+                let children: Vec<_> = child_proofs
+                    .iter()
+                    .map(|child| {
+                        let public_keys = child
+                            .to_validator_indices()
+                            .into_iter()
+                            .map(|validator_id| {
+                                head_state
+                                    .validators
+                                    .get(validator_id as usize)
+                                    .map(|validator| validator.attestation_public_key)
+                                    .ok_or_else(|| {
+                                        anyhow!(
+                                            "Validator index {validator_id} out of range during aggregation"
+                                        )
+                                    })
+                            })
+                            .collect::<anyhow::Result<Vec<_>>>()?;
+                        type_1_from_wire(&child.proof, &public_keys)
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?;
                 let raw_xmss: Vec<_> = raw_entries
                     .iter()
                     .map(|(_, public_key, signature)| (*public_key, *signature))
                     .collect();
-                let type_one = type_1_aggregate(&[], &raw_xmss, &data_root.0, data.slot as u32)?;
+                let type_one =
+                    type_1_aggregate(&children, &raw_xmss, &data_root.0, data.slot as u32)?;
                 PayloadProof {
                     participants: bits.clone(),
                     proof: VariableList::new(type_1_to_wire(&type_one))

--- a/crates/crypto/post_quantum/src/lean_multisig/type_2.rs
+++ b/crates/crypto/post_quantum/src/lean_multisig/type_2.rs
@@ -3,7 +3,8 @@ use lean_multisig_type2::{
     MultiMessageAggregateSignature as MultiMessageAggregate,
     SingleMessageAggregateSignature as SingleMessageAggregate, XmssPublicKey, XmssSignature,
     aggregate_single_message_signatures, merge_single_message_aggregates, setup_prover,
-    split_multi_message_aggregate, verify_multi_message_aggregate, verify_single_message_aggregate,
+    setup_verifier, split_multi_message_aggregate, verify_multi_message_aggregate,
+    verify_single_message_aggregate,
 };
 
 use crate::leansig::{public_key::PublicKey, signature::Signature};
@@ -12,6 +13,12 @@ pub const LOG_INV_RATE: usize = 2;
 
 pub fn type_2_setup() {
     setup_prover();
+}
+
+/// Initialize only the aggregation bytecode needed to *verify* aggregates.
+/// Skips the prover-only DFT twiddle precomputation.
+pub fn type_2_setup_verifier() {
+    setup_verifier();
 }
 
 fn to_lib_public_key(public_key: &PublicKey) -> Result<XmssPublicKey> {


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->
In the devnet5 lean client-interop tests, every mixed ream/ethlambda topology where ethlambda was the aggregator failed: the ream nodes panicked and died (RPC went dead and then connection refused on /lean/v0/fork_choice). The container logs revealed that non-aggregator ream nodes never initialized the type-2 aggregation bytecode, so they panicked (call init_aggregation_bytecode() first) the first time they had to verify an aggregate produced by the ethlambda aggregator. Startup only initialized the devnet4 bytecode, a different crate from the devnet5 one that verification actually reads — so for any non-aggregator the type-2 BYTECODE was never set. Aggregators masked the bug because they warm it lazily when producing aggregates while non-aggregators never aggregate.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->
- `bin/ream/src/main.rs`: always initialize the aggregation verifier bytecode at startup for every node (not just aggregators), so any node can verify incoming aggregates. Feature-gated so devnet4 keeps its leanVM setup and devnet5 uses the type-2 setup; aggregators still additionally initialize the prover side.
- `crates/crypto/post_quantum/src/lean_multisig/type_2.rs`: added type_2_setup_verifier() (wraps the library's setup_verifier() / init_aggregation_bytecode()), the lightweight verify-only init called from main.rs for non-aggregators; skips the prover-only DFT twiddle precompute.
- `crates/common/fork_choice/lean/src/store.rs`: in the aggregator's recursive aggregation (state_aggregate), fold the selected child proofs into type_1_aggregate instead of passing an empty set.
- Propagates the error in some places instead of panicking. (Feel free to grill on this one, I'm not very sure if the newer one is better)

Ream, Ethlambda interop results:
<img width="614" height="428" alt="Screenshot 2026-06-21 at 8 38 33 PM" src="https://github.com/user-attachments/assets/383d914a-46c2-44a8-b585-b639a7288602" />

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

