### PR TITLE
feat: implement validator custody requirement

### DIFF
--- a/crates/common/consensus/beacon/src/custody_group.rs
+++ b/crates/common/consensus/beacon/src/custody_group.rs
@@ -1,9 +1,45 @@
-use anyhow::{Ok, Result, ensure};
+use anyhow::{Ok, Result, anyhow, ensure};
 use discv5::enr::NodeId;
 use ream_consensus_misc::constants::beacon::NUM_CUSTODY_GROUPS;
+use ream_network_spec::networks::beacon::beacon_network_spec;
 use sha2::{Digest, Sha256};
 
-use crate::data_column_sidecar::NUMBER_OF_COLUMNS;
+use crate::{data_column_sidecar::NUMBER_OF_COLUMNS, electra::beacon_state::BeaconState};
+
+pub fn get_validators_custody_requirement(
+    state: &BeaconState,
+    validator_indices: &[u64],
+) -> Result<u64> {
+    let mut total_node_balance = 0u128;
+    for validator_index in validator_indices {
+        let validator = state
+            .validators
+            .get(*validator_index as usize)
+            .ok_or_else(|| anyhow!("Validator index out of bounds: {validator_index}"))?;
+        total_node_balance += validator.effective_balance as u128;
+    }
+
+    let spec = beacon_network_spec();
+    Ok(compute_validators_custody_requirement(
+        total_node_balance,
+        spec.balance_per_additional_custody_group,
+        spec.validator_custody_requirement,
+        spec.number_of_custody_groups,
+    ))
+}
+
+fn compute_validators_custody_requirement(
+    total_node_balance: u128,
+    balance_per_additional_custody_group: u64,
+    validator_custody_requirement: u64,
+    number_of_custody_groups: u64,
+) -> u64 {
+    let count = total_node_balance / balance_per_additional_custody_group as u128;
+    let count = count.min(number_of_custody_groups as u128) as u64;
+    count
+        .max(validator_custody_requirement)
+        .min(number_of_custody_groups)
+}
 
 pub fn get_custody_group_indices(node_id: NodeId, custody_group_count: u64) -> Result<Vec<u64>> {
     ensure!(
@@ -56,4 +92,46 @@ pub fn compute_columns_for_custody_group(custody_group_index: u64) -> Result<Vec
     }
 
     Ok(column_indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_validators_custody_requirement;
+
+    const BALANCE_PER_ADDITIONAL_CUSTODY_GROUP: u64 = 32_000_000_000;
+    const VALIDATOR_CUSTODY_REQUIREMENT: u64 = 8;
+    const NUMBER_OF_CUSTODY_GROUPS: u64 = 128;
+
+    fn compute(total_node_balance: u128) -> u64 {
+        compute_validators_custody_requirement(
+            total_node_balance,
+            BALANCE_PER_ADDITIONAL_CUSTODY_GROUP,
+            VALIDATOR_CUSTODY_REQUIREMENT,
+            NUMBER_OF_CUSTODY_GROUPS,
+        )
+    }
+
+    #[test]
+    fn custody_requirement_respects_minimum_for_empty_balance() {
+        assert_eq!(compute(0), VALIDATOR_CUSTODY_REQUIREMENT);
+    }
+
+    #[test]
+    fn custody_requirement_respects_minimum_for_low_balance() {
+        let total_node_balance = (VALIDATOR_CUSTODY_REQUIREMENT - 1) as u128
+            * BALANCE_PER_ADDITIONAL_CUSTODY_GROUP as u128;
+        assert_eq!(compute(total_node_balance), VALIDATOR_CUSTODY_REQUIREMENT);
+    }
+
+    #[test]
+    fn custody_requirement_scales_with_effective_balance() {
+        let total_node_balance = 10u128 * BALANCE_PER_ADDITIONAL_CUSTODY_GROUP as u128;
+        assert_eq!(compute(total_node_balance), 10);
+    }
+
+    #[test]
+    fn custody_requirement_caps_at_number_of_custody_groups() {
+        let total_node_balance = 10_000u128 * BALANCE_PER_ADDITIONAL_CUSTODY_GROUP as u128;
+        assert_eq!(compute(total_node_balance), NUMBER_OF_CUSTODY_GROUPS);
+    }
 }

--- a/crates/common/consensus/beacon/src/custody_group.rs
+++ b/crates/common/consensus/beacon/src/custody_group.rs
@@ -112,26 +112,26 @@ mod tests {
     }
 
     #[test]
-    fn custody_requirement_respects_minimum_for_empty_balance() {
-        assert_eq!(compute(0), VALIDATOR_CUSTODY_REQUIREMENT);
-    }
+    fn custody_requirement_matches_consensus_spec_boundaries() {
+        let balance_per_group = BALANCE_PER_ADDITIONAL_CUSTODY_GROUP as u128;
+        let cases = [
+            (0, VALIDATOR_CUSTODY_REQUIREMENT),
+            (8 * balance_per_group - 1, VALIDATOR_CUSTODY_REQUIREMENT),
+            (8 * balance_per_group, VALIDATOR_CUSTODY_REQUIREMENT),
+            (9 * balance_per_group, 9),
+            (10 * balance_per_group, 10),
+            (
+                NUMBER_OF_CUSTODY_GROUPS as u128 * balance_per_group,
+                NUMBER_OF_CUSTODY_GROUPS,
+            ),
+            (
+                (NUMBER_OF_CUSTODY_GROUPS as u128 + 1) * balance_per_group,
+                NUMBER_OF_CUSTODY_GROUPS,
+            ),
+        ];
 
-    #[test]
-    fn custody_requirement_respects_minimum_for_low_balance() {
-        let total_node_balance = (VALIDATOR_CUSTODY_REQUIREMENT - 1) as u128
-            * BALANCE_PER_ADDITIONAL_CUSTODY_GROUP as u128;
-        assert_eq!(compute(total_node_balance), VALIDATOR_CUSTODY_REQUIREMENT);
-    }
-
-    #[test]
-    fn custody_requirement_scales_with_effective_balance() {
-        let total_node_balance = 10u128 * BALANCE_PER_ADDITIONAL_CUSTODY_GROUP as u128;
-        assert_eq!(compute(total_node_balance), 10);
-    }
-
-    #[test]
-    fn custody_requirement_caps_at_number_of_custody_groups() {
-        let total_node_balance = 10_000u128 * BALANCE_PER_ADDITIONAL_CUSTODY_GROUP as u128;
-        assert_eq!(compute(total_node_balance), NUMBER_OF_CUSTODY_GROUPS);
+        for (total_node_balance, expected) in cases {
+            assert_eq!(compute(total_node_balance), expected);
+        }
     }
 }


### PR DESCRIPTION
### What was wrong?

Closes #1460.

Ream currently has custody group helpers, but it was missing the Fulu DAS helper for computing how many custody groups a node with attached validators must custody based on validator effective balance.

### How was it fixed?

Added `get_validators_custody_requirement` to the beacon custody group module. The helper sums the effective balances of the provided validator indices, computes the custody requirement using the Fulu network-spec values, and clamps the result between `validator_custody_requirement` and `number_of_custody_groups`.

Added unit tests for the minimum requirement, balance-based scaling, and max custody group cap.

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).