### PR TITLE
fix: deserialize engine_getPayloadV4 response

### DIFF
--- a/crates/common/execution/rpc_types/src/get_payload.rs
+++ b/crates/common/execution/rpc_types/src/get_payload.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{B256, Bytes};
+use alloy_primitives::{Bytes, U256};
 use ream_consensus_misc::polynomial_commitments::kzg_commitment::KZGCommitment;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -25,8 +25,14 @@ pub struct BlobsBundleV1 {
 #[serde(rename_all = "camelCase")]
 pub struct PayloadV4 {
     pub execution_payload: ExecutionPayloadV3,
-    pub block_value: B256,
+    // EL `blockValue` is a QUANTITY (minimal hex like "0x0"), not a 32-byte hash. It was typed
+    // B256, which fails to deserialize any spec-compliant getPayloadV4 response.
+    #[serde(with = "serde_utils::u256_hex_be")]
+    pub block_value: U256,
     pub blobs_bundle: BlobsBundleV1,
+    // Wire field is `shouldOverrideBuilder`; the Rust field name is misspelled ("overide"),
+    // so the derived camelCase name (`shouldOverideBuilder`) did not match the EL response.
+    #[serde(rename = "shouldOverrideBuilder")]
     pub should_overide_builder: bool,
     pub execution_requests: Vec<Bytes>,
 }

--- a/crates/rpc/beacon/src/handlers/validator.rs
+++ b/crates/rpc/beacon/src/handlers/validator.rs
@@ -4,7 +4,7 @@ use actix_web::{
     HttpResponse, Responder, get, post,
     web::{Data, Json, Path, Query},
 };
-use alloy_primitives::{Address, B256, U256, aliases::B32};
+use alloy_primitives::{Address, B256, aliases::B32};
 use ream_api_types_beacon::{
     block::{FullBlockData, ProduceBlockData, ProduceBlockResponse},
     committee::{BeaconCommitteeSubscription, SyncCommitteeSubscription},
@@ -1315,7 +1315,8 @@ async fn get_local_execution_payload(
         .await
         .map_err(|err| ApiError::InternalError(format!("Failed to get payload: {err}")))?;
 
-    let execution_value: u64 = U256::from_be_bytes(payload_v4.block_value.0)
+    let execution_value: u64 = payload_v4
+        .block_value
         .try_into()
         .map_err(|err| ApiError::InternalError(format!("Block value too large: {err}")))?;
 


### PR DESCRIPTION
`PayloadV4` fails to deserialize a spec-compliant `engine_getPayloadV4` response from a real EL:

- `block_value` is the EL `blockValue` **QUANTITY** (e.g. `"0x0"`), not a 32-byte hash. Typed `B256` it never deserializes; changed to `U256` with `serde_utils::u256_hex_be`.
- the field `should_overide_builder` is misspelled, so its derived camelCase name (`shouldOverideBuilder`) does not match the EL's `shouldOverrideBuilder`. Added `#[serde(rename)]`.

Updates the one beacon-side reader accordingly. Marked draft.