### PR TITLE
fix: close table transactions before return

### DIFF
--- a/crates/storage/src/tables/lean/latest_new_attestations.rs
+++ b/crates/storage/src/tables/lean/latest_new_attestations.rs
@@ -39,13 +39,15 @@ impl LeanLatestNewAttestationsTable {
     ) -> Result<impl Iterator<Item = anyhow::Result<SignedAttestation>>, StoreError> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(Self::TABLE_DEFINITION)?;
-        Ok(table
-            .range::<<u64 as redb::Value>::SelfType<'_>>(..)?
-            .map(|result| {
-                result
-                    .map(|(_, value)| value.value())
-                    .map_err(|err| StoreError::from(err).into())
-            }))
+        let mut values = Vec::new();
+
+        for result in table.range::<<u64 as redb::Value>::SelfType<'_>>(..)? {
+            values.push(result.map(|(_, value)| value.value()));
+        }
+
+        Ok(values
+            .into_iter()
+            .map(|result| result.map_err(|err| StoreError::from(err).into())))
     }
 
     pub fn drain(&self) -> Result<HashMap<u64, SignedAttestation>, StoreError> {

--- a/crates/storage/src/tables/lean/pending_blocks.rs
+++ b/crates/storage/src/tables/lean/pending_blocks.rs
@@ -45,13 +45,15 @@ impl LeanPendingBlocksTable {
     > {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(Self::TABLE_DEFINITION)?;
-        Ok(table
-            .range::<<SSZEncoding<B256> as redb::Value>::SelfType<'_>>(..)?
-            .map(|result| {
-                result
-                    .map(|(key, value)| (key.value(), value.value()))
-                    .map_err(StoreError::from)
-            }))
+        let mut entries = Vec::new();
+
+        for result in table.range::<<SSZEncoding<B256> as redb::Value>::SelfType<'_>>(..)? {
+            entries.push(result.map(|(key, value)| (key.value(), value.value())));
+        }
+
+        Ok(entries
+            .into_iter()
+            .map(|result| result.map_err(StoreError::from)))
     }
 
     pub fn retain<F>(&self, mut f: F) -> Result<(), crate::errors::StoreError>

--- a/crates/storage/src/tables/lean/state.rs
+++ b/crates/storage/src/tables/lean/state.rs
@@ -108,12 +108,14 @@ impl LeanStateTable {
     ) -> Result<impl Iterator<Item = anyhow::Result<LeanState>>, StoreError> {
         let read_txn = self.db.begin_read()?;
         let table = read_txn.open_table(Self::TABLE_DEFINITION)?;
-        Ok(table
-            .range::<<SSZEncoding<B256> as redb::Value>::SelfType<'_>>(..)?
-            .map(|result| {
-                result
-                    .map(|(_, value)| value.value())
-                    .map_err(|err| StoreError::from(err).into())
-            }))
+        let mut values = Vec::new();
+
+        for result in table.range::<<SSZEncoding<B256> as redb::Value>::SelfType<'_>>(..)? {
+            values.push(result.map(|(_, value)| value.value()));
+        }
+
+        Ok(values
+            .into_iter()
+            .map(|result| result.map_err(|err| StoreError::from(err).into())))
     }
 }


### PR DESCRIPTION
### What was wrong?

Currently there exists a race condition between backfill sync and the pruning of pending blocks where a select few functions are called and return an open transaction to a redb table instead of the passing along the data associated with the transaction. This under certain circumstances can lead to an attempt to read an old but open transaction during the sync process, which is blocked in redb causing an error in the library that results in a panic crashing Ream. 
Noted in Ream crash log:
<img width="1416" height="259" alt="image" src="https://github.com/user-attachments/assets/02919c8a-ee59-482d-bc56-cac550397173" />


### How was it fixed?

The solution is to ensure the transaction to a given redb table is closed through the use of inherent scope closure and just return the requested data.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
