### PR TITLE
feat: ensure attestation source slot does not exceed target

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -2493,6 +2493,12 @@ impl Store {
         if head_state.latest_block_header.slot == 0 {
             source.root = head_root;
         }
+
+        let target = self.get_attestation_target().await?;
+        ensure!(
+            source.slot <= target.slot,
+            "Source must be older or equal to the target"
+        );
         Ok(AttestationData {
             slot,
             head: Checkpoint {
@@ -2503,7 +2509,7 @@ impl Store {
                     .block
                     .slot,
             },
-            target: self.get_attestation_target().await?,
+            target,
             source,
         })
     }

--- a/testing/lean-spec-tests/src/fork_choice.rs
+++ b/testing/lean-spec-tests/src/fork_choice.rs
@@ -7,7 +7,7 @@ use alloy_primitives::hex;
 use anyhow::{anyhow, bail, ensure};
 use ream_consensus_lean::{
     attestation::{
-        MultiMessageAggregate, SignedAggregatedAttestation, SignedAttestation,
+        AttestationData, MultiMessageAggregate, SignedAggregatedAttestation, SignedAttestation,
         SingleMessageAggregate,
     },
     block::{Block, SignedBlock},
@@ -30,11 +30,10 @@ use ssz_types::{
     typenum::{U4096, U524288},
 };
 use tracing::{debug, info};
-use tree_hash::TreeHash;
 
 use crate::types::{
     TestFixture,
-    fork_choice::{ForkChoiceStep, ForkChoiceTest, StoreChecks},
+    fork_choice::{AttestationCheck, ForkChoiceStep, ForkChoiceTest, StoreChecks},
 };
 
 /// Load a fork choice test fixture from a JSON file
@@ -129,7 +128,7 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
         state,
         db,
         None,
-        None,
+        Some(0),
     );
 
     // Current fixtures encode invalid-anchor checks as step-less tests. Treat
@@ -295,6 +294,7 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
                 valid,
                 attestation,
                 checks,
+                is_aggregator,
             } => {
                 debug!(
                     "  Step {index}: Attestation from validator {} (expect valid: {valid})",
@@ -317,11 +317,11 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
                     signature,
                 };
 
-                // Run the full gossip pipeline so the test exercises the same
-                // validity checks the spec specifies for `on_gossip_attestation`:
-                // (1) attestation-data validation, (2) validator-id range check,
-                // (3) signature verification.
-                let result = run_attestation_pipeline(&mut store, &signed_attestation).await;
+                // Ingest the gossip vote via the full spec path (validate, verify signature,
+                // and record it in the store) so later checks can read the stored vote back.
+                let result = store
+                    .on_gossip_attestation(signed_attestation, is_aggregator.unwrap_or(false))
+                    .await;
 
                 if *valid {
                     result.map_err(|err| {
@@ -410,6 +410,75 @@ async fn validate_checks(store: &Store, checks: &StoreChecks) -> anyhow::Result<
         debug!("Finalized checkpoint: slot {}", actual_finalized.slot);
     }
 
+    // Per-validator attestation checks.
+    let signature_checks: Vec<&AttestationCheck> = checks
+        .attestation_checks
+        .iter()
+        .filter(|check| check.location == "signatures")
+        .collect();
+
+    if !signature_checks.is_empty() {
+        // Map each validator to its highest-slot vote in the named pool.
+        let signatures_provider = db.attestation_signatures_provider();
+        let data_by_root_provider = db.attestation_data_by_root_provider();
+        let mut best_by_validator: HashMap<u64, AttestationData> = HashMap::new();
+        for key in signatures_provider.get_keys()? {
+            let data = data_by_root_provider.get(key.data_root)?.ok_or_else(|| {
+                anyhow!(
+                    "attestation_signatures key for validator {} references data root {} \
+                     missing from attestation_data_by_root",
+                    key.validator_id,
+                    key.data_root
+                )
+            })?;
+            match best_by_validator.get(&key.validator_id) {
+                Some(existing) if existing.slot >= data.slot => continue,
+                _ => {
+                    let _ = best_by_validator.insert(key.validator_id, data);
+                }
+            }
+        }
+
+        for check in signature_checks {
+            let data = best_by_validator.get(&check.validator).ok_or_else(|| {
+                anyhow!(
+                    "validator {} not found in attestation_signatures pool",
+                    check.validator
+                )
+            })?;
+
+            // Ensure all validators have the expected head slot.
+            if let Some(expected) = check.head_slot {
+                ensure!(
+                    data.head.slot == expected,
+                    "Attestation head slot mismatch for validator {}: expected {expected}, got {}",
+                    check.validator,
+                    data.head.slot
+                );
+            }
+
+            // Ensure all validators have the expected source slot.
+            if let Some(expected) = check.source_slot {
+                ensure!(
+                    data.source.slot == expected,
+                    "Attestation source slot mismatch for validator {}: expected {expected}, got {}",
+                    check.validator,
+                    data.source.slot
+                );
+            }
+
+            // Ensure all validators have the expected target slot.
+            if let Some(expected) = check.target_slot {
+                ensure!(
+                    data.target.slot == expected,
+                    "Attestation target slot mismatch for validator {}: expected {expected}, got {}",
+                    check.validator,
+                    data.target.slot
+                );
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -417,45 +486,4 @@ async fn validate_checks(store: &Store, checks: &StoreChecks) -> anyhow::Result<
 fn decode_hex_bytes(value: &str) -> anyhow::Result<Vec<u8>> {
     hex::decode(value.trim_start_matches("0x"))
         .map_err(|err| anyhow!("Failed to decode hex bytes: {err}"))
-}
-
-/// Run the validation portion of `on_gossip_attestation` so the runner can
-/// distinguish accepted vs rejected attestations:
-///   1. attestation-data validation
-///   2. validator-id range check
-///   3. signature verification (using the attestation public key)
-async fn run_attestation_pipeline(
-    store: &mut Store,
-    signed_attestation: &SignedAttestation,
-) -> anyhow::Result<()> {
-    store.validate_attestation(signed_attestation).await?;
-
-    let key_state = {
-        let db = store.store.lock().await;
-        db.state_provider()
-            .get(signed_attestation.message.target.root)?
-    }
-    .ok_or_else(|| {
-        anyhow!(
-            "No state available to verify attestation signature for target {}",
-            signed_attestation.message.target.root
-        )
-    })?;
-
-    ensure!(
-        signed_attestation.validator_id < key_state.validators.len() as u64,
-        "Validator {} not found in state",
-        signed_attestation.validator_id,
-    );
-
-    let attestation_key =
-        key_state.validators[signed_attestation.validator_id as usize].attestation_public_key;
-    let signature_valid = signed_attestation.signature.verify(
-        &attestation_key,
-        signed_attestation.message.slot as u32,
-        &signed_attestation.message.tree_hash_root(),
-    )?;
-    ensure!(signature_valid, "Signature verification failed");
-
-    Ok(())
 }

--- a/testing/lean-spec-tests/src/types/fork_choice.rs
+++ b/testing/lean-spec-tests/src/types/fork_choice.rs
@@ -51,6 +51,8 @@ pub enum ForkChoiceStep {
         valid: bool,
         checks: Option<StoreChecks>,
         attestation: Attestation,
+        #[serde(default, rename = "isAggregator")]
+        is_aggregator: Option<bool>,
     },
     GossipAggregatedAttestation {
         #[serde(default)]
@@ -83,6 +85,7 @@ pub struct StoreChecks {
 #[serde(rename_all = "camelCase")]
 pub struct AttestationCheck {
     pub validator: u64,
+    pub head_slot: Option<u64>,
     pub source_slot: Option<u64>,
     pub target_slot: Option<u64>,
     pub location: String,


### PR DESCRIPTION
### What was wrong?

<!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Ream already uses source from the head chain for voting. But we are missing:
1. `source.slot <= target.slot` sanity guard in `produce_attestation_data`
2. running the new consensus vector

Closes #1448.

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

- sanity guard added in `produce_attestation_data`
- per-validator attestation checks in `validate_checks`
- existing `run_attestation_pipeline` validation replaced with `store.on_gossip_attestation` because `validate_checks` depend on voting state recorded in `attestation_signatures`.
- `is_aggregator` is added to `ForkChoiceStep::Attestation` type which is used in the test vector
- `validator_id` is set to `0` to enable the store to become aggregator
- enable devnet5 fork_choice suite filtered to `test_honest_vote_sources_from_head_chain_not_store` vector introduced in lean spec upstream.

<details>
<summary>Click to see screenshot of tests</summary>

Devnet 5 test vector passing:
<img width="820" height="404" alt="Screenshot 2026-07-02 at 12 26 03 AM" src="https://github.com/user-attachments/assets/7234e495-08d2-4e19-afb8-d397dd0ff73e" />


Devnet 4 tests remain unaffected:
<img width="922" height="218" alt="Screenshot 2026-07-02 at 12 04 40 AM" src="https://github.com/user-attachments/assets/6dab6a18-03f6-40ab-8457-5caa53cafa6e" />


</details>


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
