### PR TITLE
Implement Fulu fork support in execution engine

### DIFF
--- a/crates/common/consensus/beacon/src/electra/beacon_state.rs
+++ b/crates/common/consensus/beacon/src/electra/beacon_state.rs
@@ -53,6 +53,7 @@ use ream_consensus_misc::{
     deposit_request::DepositRequest,
     eth_1_data::Eth1Data,
     fork::Fork,
+    fork_name::ForkName,
     indexed_attestation::IndexedAttestation,
     misc::{
         bytes_to_int64, compute_activation_exit_epoch, compute_committee, compute_domain,
@@ -3095,4 +3096,34 @@ pub fn is_valid_deposit_signature(
     signature
         .verify(public_key, signing_root.as_ref())
         .map_err(|err| anyhow!("Invalid deposit signature: {err:?}"))
+}
+
+pub fn fork_name_at_epoch(epoch: u64) -> ForkName {
+    if epoch >= beacon_network_spec().fulu_fork_epoch {
+        ForkName::Fulu
+    } else if epoch >= beacon_network_spec().electra_fork_epoch {
+        ForkName::Electra
+    } else if epoch >= beacon_network_spec().deneb_fork_epoch {
+        ForkName::Deneb
+    } else if epoch >= beacon_network_spec().capella_fork_epoch {
+        ForkName::Capella
+    } else if epoch >= beacon_network_spec().bellatrix_fork_epoch {
+        ForkName::Bellatrix
+    } else if epoch >= beacon_network_spec().altair_fork_epoch {
+        ForkName::Altair
+    } else {
+        ForkName::Base
+    }
+}
+
+pub fn fork_name_from_version(version: [u8; 4]) -> ForkName {
+    match version {
+        _ if version == beacon_network_spec().electra_fork_version => ForkName::Electra,
+        _ if version == beacon_network_spec().fulu_fork_version => ForkName::Fulu,
+        _ if version == beacon_network_spec().deneb_fork_version => ForkName::Deneb,
+        _ if version == beacon_network_spec().capella_fork_version => ForkName::Capella,
+        _ if version == beacon_network_spec().bellatrix_fork_version => ForkName::Bellatrix,
+        _ if version == beacon_network_spec().altair_fork_version => ForkName::Altair,
+        _ => ForkName::Base,
+    }
 }

--- a/crates/common/consensus/misc/src/fork_name.rs
+++ b/crates/common/consensus/misc/src/fork_name.rs
@@ -1,0 +1,136 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
+
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+
+#[derive(
+    Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
+#[ssz(enum_behaviour = "tag")]
+pub enum ForkName {
+    Base,
+    Altair,
+    Bellatrix,
+    Capella,
+    Deneb,
+    Electra,
+    Fulu,
+}
+
+impl ForkName {
+    pub fn list_all() -> Vec<ForkName> {
+        vec![
+            ForkName::Base,
+            ForkName::Altair,
+            ForkName::Bellatrix,
+            ForkName::Capella,
+            ForkName::Deneb,
+            ForkName::Electra,
+            ForkName::Fulu,
+        ]
+    }
+
+    /// Return the name of the fork immediately prior to the current one.
+    pub fn previous_fork(self) -> Option<ForkName> {
+        match self {
+            ForkName::Base => None,
+            ForkName::Altair => Some(ForkName::Base),
+            ForkName::Bellatrix => Some(ForkName::Altair),
+            ForkName::Capella => Some(ForkName::Bellatrix),
+            ForkName::Deneb => Some(ForkName::Capella),
+            ForkName::Electra => Some(ForkName::Deneb),
+            ForkName::Fulu => Some(ForkName::Electra),
+        }
+    }
+
+    /// Return the name of the fork immediately after the current one.
+    pub fn next_fork(self) -> Option<ForkName> {
+        match self {
+            ForkName::Base => Some(ForkName::Altair),
+            ForkName::Altair => Some(ForkName::Bellatrix),
+            ForkName::Bellatrix => Some(ForkName::Capella),
+            ForkName::Capella => Some(ForkName::Deneb),
+            ForkName::Deneb => Some(ForkName::Electra),
+            ForkName::Electra => Some(ForkName::Fulu),
+            ForkName::Fulu => None,
+        }
+    }
+
+    pub fn altair_enabled(self) -> bool {
+        self >= ForkName::Altair
+    }
+
+    pub fn bellatrix_enabled(self) -> bool {
+        self >= ForkName::Bellatrix
+    }
+
+    pub fn capella_enabled(self) -> bool {
+        self >= ForkName::Capella
+    }
+
+    pub fn deneb_enabled(self) -> bool {
+        self >= ForkName::Deneb
+    }
+
+    pub fn electra_enabled(self) -> bool {
+        self >= ForkName::Electra
+    }
+
+    pub fn fulu_enabled(self) -> bool {
+        self >= ForkName::Fulu
+    }
+
+    pub fn is_enabled_at(&self, fork: ForkName) -> bool {
+        *self >= fork
+    }
+}
+
+impl FromStr for ForkName {
+    type Err = String;
+
+    fn from_str(fork_name: &str) -> Result<Self, String> {
+        Ok(match fork_name.to_lowercase().as_ref() {
+            "phase0" | "base" => ForkName::Base,
+            "altair" => ForkName::Altair,
+            "bellatrix" | "merge" => ForkName::Bellatrix,
+            "capella" => ForkName::Capella,
+            "deneb" => ForkName::Deneb,
+            "electra" => ForkName::Electra,
+            "fulu" => ForkName::Fulu,
+            _ => return Err(format!("unknown fork name: {fork_name}")),
+        })
+    }
+}
+
+impl Display for ForkName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            ForkName::Base => "phase0".fmt(f),
+            ForkName::Altair => "altair".fmt(f),
+            ForkName::Bellatrix => "bellatrix".fmt(f),
+            ForkName::Capella => "capella".fmt(f),
+            ForkName::Deneb => "deneb".fmt(f),
+            ForkName::Electra => "electra".fmt(f),
+            ForkName::Fulu => "fulu".fmt(f),
+        }
+    }
+}
+
+impl From<ForkName> for String {
+    fn from(fork: ForkName) -> String {
+        fork.to_string()
+    }
+}
+
+impl TryFrom<String> for ForkName {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_str(&s)
+    }
+}

--- a/crates/common/consensus/misc/src/lib.rs
+++ b/crates/common/consensus/misc/src/lib.rs
@@ -14,6 +14,7 @@ pub mod eth_1_data;
 pub mod execution_requests;
 pub mod fork;
 pub mod fork_data;
+pub mod fork_name;
 pub mod historical_batch;
 pub mod indexed_attestation;
 pub mod misc;

--- a/crates/common/execution/engine/src/engine_trait.rs
+++ b/crates/common/execution/engine/src/engine_trait.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::B256;
 use async_trait::async_trait;
-use ream_execution_rpc_types::get_blobs::BlobAndProofV1;
+use ream_execution_rpc_types::get_blobs::{BlobAndProofV1, BlobAndProofV2};
 
 use super::new_payload_request::NewPayloadRequest;
 
@@ -17,4 +17,14 @@ pub trait ExecutionApi {
         &self,
         blob_version_hashes: Vec<B256>,
     ) -> anyhow::Result<Vec<Option<BlobAndProofV1>>>;
+
+    async fn engine_get_blobs_v2(
+        &self,
+        blob_version_hashes: Vec<B256>,
+    ) -> anyhow::Result<Option<Vec<BlobAndProofV2>>>;
+
+    async fn engine_get_blobs_v3(
+        &self,
+        blob_version_hashes: Vec<B256>,
+    ) -> anyhow::Result<Option<Vec<Option<BlobAndProofV2>>>>;
 }

--- a/crates/common/execution/engine/src/lib.rs
+++ b/crates/common/execution/engine/src/lib.rs
@@ -12,14 +12,15 @@ use ream_consensus_misc::{
         CONSOLIDATION_REQUEST_TYPE, DEPOSIT_REQUEST_TYPE, WITHDRAWAL_REQUEST_TYPE,
     },
     execution_requests::ExecutionRequests,
+    fork_name::ForkName,
 };
 use ream_execution_rpc_types::{
     electra::execution_payload::ExecutionPayload,
     eth_syncing::EthSyncing,
     execution_payload::ExecutionPayloadV3,
     forkchoice_update::{ForkchoiceStateV1, ForkchoiceUpdateResult, PayloadAttributesV3},
-    get_blobs::BlobAndProofV1,
-    get_payload::PayloadV4,
+    get_blobs::{BlobAndProofV1, BlobAndProofV2},
+    get_payload::{Payload, PayloadV4, PayloadV5},
     payload_status::{PayloadStatus, PayloadStatusV1},
 };
 use reqwest::{Client, Request, Url};
@@ -290,7 +291,9 @@ impl ExecutionEngine {
         let capabilities: Vec<String> = vec![
             "engine_forkchoiceUpdatedV3".to_string(),
             "engine_getBlobsV1".to_string(),
-            "engine_getPayloadV4".to_string(),
+            "engine_getBlobsV2".to_string(),
+            "engine_getBlobsV3".to_string(),
+            "engine_getPayloadV5".to_string(),
             "engine_newPayloadV4".to_string(),
         ];
         let request_body = JsonRpcRequest {
@@ -310,6 +313,24 @@ impl ExecutionEngine {
             .to_result()
     }
 
+    pub async fn engine_get_payload(
+        &self,
+        fork_name: &ForkName,
+        payload_id: B64,
+    ) -> anyhow::Result<Payload> {
+        match fork_name {
+            ForkName::Electra => self
+                .engine_get_payload_v4(payload_id)
+                .await
+                .map(Payload::V4),
+            ForkName::Fulu => self
+                .engine_get_payload_v5(payload_id)
+                .await
+                .map(Payload::V5),
+            _ => Err(anyhow!("Unsupported fork: {fork_name}")),
+        }
+    }
+
     pub async fn engine_get_payload_v4(&self, payload_id: B64) -> anyhow::Result<PayloadV4> {
         let request_body = JsonRpcRequest {
             id: 1,
@@ -324,6 +345,24 @@ impl ExecutionEngine {
             .execute(http_post_request)
             .await?
             .json::<JsonRpcResponse<PayloadV4>>()
+            .await?
+            .to_result()
+    }
+
+    pub async fn engine_get_payload_v5(&self, payload_id: B64) -> anyhow::Result<PayloadV5> {
+        let request_body = JsonRpcRequest {
+            id: 1,
+            jsonrpc: "2.0".to_string(),
+            method: "engine_getPayloadV5".to_string(),
+            params: vec![json!(payload_id)],
+        };
+
+        let http_post_request = self.build_request(request_body)?;
+
+        self.http_client
+            .execute(http_post_request)
+            .await?
+            .json::<JsonRpcResponse<PayloadV5>>()
             .await?
             .to_result()
     }
@@ -469,6 +508,48 @@ impl ExecutionApi for ExecutionEngine {
             .execute(http_post_request)
             .await?
             .json::<JsonRpcResponse<Vec<Option<BlobAndProofV1>>>>()
+            .await?
+            .to_result()
+    }
+
+    async fn engine_get_blobs_v2(
+        &self,
+        blob_version_hashes: Vec<B256>,
+    ) -> anyhow::Result<Option<Vec<BlobAndProofV2>>> {
+        let request = JsonRpcRequest {
+            id: 1,
+            jsonrpc: "2.0".into(),
+            method: "engine_getBlobsV2".into(),
+            params: vec![json!(blob_version_hashes)],
+        };
+
+        let req = self.build_request(request)?;
+
+        self.http_client
+            .execute(req)
+            .await?
+            .json::<JsonRpcResponse<Option<Vec<BlobAndProofV2>>>>()
+            .await?
+            .to_result()
+    }
+
+    async fn engine_get_blobs_v3(
+        &self,
+        blob_version_hashes: Vec<B256>,
+    ) -> anyhow::Result<Option<Vec<Option<BlobAndProofV2>>>> {
+        let request = JsonRpcRequest {
+            id: 1,
+            jsonrpc: "2.0".into(),
+            method: "engine_getBlobsV3".into(),
+            params: vec![json!(blob_version_hashes)],
+        };
+
+        let req = self.build_request(request)?;
+
+        self.http_client
+            .execute(req)
+            .await?
+            .json::<JsonRpcResponse<Option<Vec<Option<BlobAndProofV2>>>>>()
             .await?
             .to_result()
     }

--- a/crates/common/execution/engine/src/mock_engine.rs
+++ b/crates/common/execution/engine/src/mock_engine.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use alloy_primitives::B256;
 use anyhow::Ok;
 use async_trait::async_trait;
-use ream_execution_rpc_types::get_blobs::BlobAndProofV1;
+use ream_execution_rpc_types::get_blobs::{BlobAndProofV1, BlobAndProofV2};
 use serde::Deserialize;
 
 use super::{engine_trait::ExecutionApi, new_payload_request::NewPayloadRequest};
@@ -44,5 +44,21 @@ impl ExecutionApi for MockExecutionEngine {
         blob_version_hashes: Vec<B256>,
     ) -> anyhow::Result<Vec<Option<BlobAndProofV1>>> {
         Ok(blob_version_hashes.into_iter().map(|_| None).collect())
+    }
+
+    async fn engine_get_blobs_v2(
+        &self,
+        blob_version_hashes: Vec<B256>,
+    ) -> anyhow::Result<Option<Vec<BlobAndProofV2>>> {
+        Ok(blob_version_hashes.into_iter().map(|_| None).collect())
+    }
+
+    async fn engine_get_blobs_v3(
+        &self,
+        blob_version_hashes: Vec<B256>,
+    ) -> anyhow::Result<Option<Vec<Option<BlobAndProofV2>>>> {
+        Ok(Some(
+            blob_version_hashes.into_iter().map(|_| None).collect(),
+        ))
     }
 }

--- a/crates/common/execution/rpc_types/src/get_blobs.rs
+++ b/crates/common/execution/rpc_types/src/get_blobs.rs
@@ -3,7 +3,11 @@ use ream_consensus_misc::{
 };
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{FixedVector, serde_utils::hex_fixed_vec, typenum::U131072};
+use ssz_types::{
+    FixedVector,
+    serde_utils::hex_fixed_vec,
+    typenum::{U32, U131072},
+};
 use tree_hash_derive::TreeHash;
 
 #[derive(
@@ -28,4 +32,11 @@ impl Blob {
 pub struct BlobAndProofV1 {
     pub blob: Blob,
     pub proof: KZGProof,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Decode, Encode, TreeHash)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobAndProofV2 {
+    pub blob: Blob,
+    pub proofs: FixedVector<KZGProof, U32>,
 }

--- a/crates/common/execution/rpc_types/src/get_payload.rs
+++ b/crates/common/execution/rpc_types/src/get_payload.rs
@@ -1,24 +1,24 @@
 use alloy_primitives::{B256, Bytes};
-use ream_consensus_misc::polynomial_commitments::kzg_commitment::KZGCommitment;
+use ream_consensus_misc::polynomial_commitments::{
+    kzg_commitment::KZGCommitment, kzg_proof::KZGProof,
+};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
     VariableList,
-    serde_utils::list_of_hex_var_list,
-    typenum::{U96, U1024, U1048576},
+    typenum::{U1024, U32768},
 };
 use tree_hash_derive::TreeHash;
 
 use super::execution_payload::ExecutionPayloadV3;
+use crate::{electra::execution_payload::ExecutionPayload, get_blobs::Blob};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[serde(rename_all = "camelCase")]
 pub struct BlobsBundleV1 {
-    pub blobs: VariableList<KZGCommitment, U1048576>,
-    #[serde(with = "list_of_hex_var_list")]
-    pub commitments: VariableList<VariableList<u8, U96>, U1024>,
-    #[serde(with = "list_of_hex_var_list")]
-    pub proofs: VariableList<VariableList<u8, U96>, U1024>,
+    pub blobs: VariableList<Blob, U1024>,
+    pub commitments: VariableList<KZGCommitment, U1024>,
+    pub proofs: VariableList<KZGProof, U1024>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -27,6 +27,123 @@ pub struct PayloadV4 {
     pub execution_payload: ExecutionPayloadV3,
     pub block_value: B256,
     pub blobs_bundle: BlobsBundleV1,
-    pub should_overide_builder: bool,
+    pub should_override_builder: bool,
     pub execution_requests: Vec<Bytes>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobsBundleV2 {
+    pub commitments: VariableList<KZGCommitment, U1024>,
+    pub proofs: VariableList<KZGProof, U32768>,
+    pub blobs: VariableList<Blob, U1024>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PayloadV5 {
+    pub execution_payload: ExecutionPayloadV3,
+    pub block_value: B256,
+    pub blobs_bundle: BlobsBundleV2,
+    pub should_override_builder: bool,
+    pub execution_requests: Vec<Bytes>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub enum BlobsBundle {
+    V1(BlobsBundleV1),
+    V2(BlobsBundleV2),
+}
+
+impl BlobsBundle {
+    pub fn get_commitments(&self) -> Vec<KZGCommitment> {
+        match self {
+            BlobsBundle::V1(bundle) => bundle.commitments.iter().cloned().collect(),
+            BlobsBundle::V2(bundle) => bundle.commitments.iter().cloned().collect(),
+        }
+    }
+
+    pub fn get_proofs(&self) -> Vec<KZGProof> {
+        match self {
+            BlobsBundle::V1(bundle) => bundle.proofs.iter().cloned().collect(),
+            BlobsBundle::V2(bundle) => bundle.proofs.iter().cloned().collect(),
+        }
+    }
+
+    pub fn get_blobs(&self) -> Vec<Blob> {
+        match self {
+            BlobsBundle::V1(bundle) => bundle.blobs.iter().cloned().collect(),
+            BlobsBundle::V2(bundle) => bundle.blobs.iter().cloned().collect(),
+        }
+    }
+
+    pub fn is_fulu(&self) -> bool {
+        matches!(self, BlobsBundle::V2(_))
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub enum Payload {
+    V4(PayloadV4),
+    V5(PayloadV5),
+}
+
+impl Payload {
+    pub fn execution_payload(&self) -> &ExecutionPayloadV3 {
+        match self {
+            Payload::V4(payload) => &payload.execution_payload,
+            Payload::V5(payload) => &payload.execution_payload,
+        }
+    }
+
+    pub fn execution_requests(&self) -> &Vec<Bytes> {
+        match self {
+            Payload::V4(payload) => &payload.execution_requests,
+            Payload::V5(payload) => &payload.execution_requests,
+        }
+    }
+
+    pub fn should_override_builder(&self) -> bool {
+        match self {
+            Payload::V4(payload) => payload.should_override_builder,
+            Payload::V5(payload) => payload.should_override_builder,
+        }
+    }
+
+    pub fn block_value(&self) -> &B256 {
+        match self {
+            Payload::V4(payload) => &payload.block_value,
+            Payload::V5(payload) => &payload.block_value,
+        }
+    }
+
+    pub fn blobs_bundle(&self) -> BlobsBundle {
+        match self {
+            Payload::V4(payload) => BlobsBundle::V1(payload.blobs_bundle.clone()),
+            Payload::V5(payload) => BlobsBundle::V2(payload.blobs_bundle.clone()),
+        }
+    }
+
+    pub fn to_execution_payload(&self) -> ExecutionPayload {
+        let ep = self.execution_payload();
+        ExecutionPayload {
+            parent_hash: ep.parent_hash,
+            fee_recipient: ep.fee_recipient,
+            state_root: ep.state_root,
+            receipts_root: ep.receipts_root,
+            logs_bloom: ep.logs_bloom.clone(),
+            prev_randao: ep.prev_randao,
+            block_number: ep.block_number,
+            gas_limit: ep.gas_limit,
+            gas_used: ep.gas_used,
+            timestamp: ep.timestamp,
+            extra_data: ep.extra_data.clone(),
+            base_fee_per_gas: ep.base_fee_per_gas,
+            block_hash: ep.block_hash,
+            transactions: ep.transactions.clone(),
+            withdrawals: ep.withdrawals.clone(),
+            blob_gas_used: ep.blob_gas_used,
+            excess_blob_gas: ep.excess_blob_gas,
+        }
+    }
 }

--- a/crates/rpc/beacon/src/handlers/validator.rs
+++ b/crates/rpc/beacon/src/handlers/validator.rs
@@ -22,7 +22,9 @@ use ream_consensus_beacon::{
     beacon_committee_selection::BeaconCommitteeSelection,
     bls_to_execution_change::SignedBLSToExecutionChange,
     electra::{
-        beacon_block::BeaconBlock, beacon_block_body::BeaconBlockBody, beacon_state::BeaconState,
+        beacon_block::BeaconBlock,
+        beacon_block_body::BeaconBlockBody,
+        beacon_state::{BeaconState, fork_name_at_epoch},
         blinded_beacon_block::BlindedBeaconBlock,
         blinded_beacon_block_body::BlindedBeaconBlockBody,
     },
@@ -39,6 +41,7 @@ use ream_consensus_misc::{
         SYNC_COMMITTEE_PROPOSER_REWARD_QUOTIENT, WHISTLEBLOWER_REWARD_QUOTIENT,
     },
     deposit::Deposit,
+    fork_name::ForkName,
     misc::{compute_domain, compute_epoch_at_slot, compute_signing_root},
     polynomial_commitments::{kzg_commitment::KZGCommitment, kzg_proof::KZGProof},
     validator::Validator,
@@ -49,9 +52,8 @@ use ream_events_beacon::{
 };
 use ream_execution_engine::{ExecutionEngine, engine_trait::ExecutionApi};
 use ream_execution_rpc_types::{
-    electra::execution_payload::ExecutionPayload,
     forkchoice_update::{ForkchoiceStateV1, PayloadAttributesV3},
-    get_payload::PayloadV4,
+    get_payload::Payload,
 };
 use ream_fork_choice_beacon::store::Store;
 use ream_network_manager::gossipsub::validate::sync_committee_contribution_and_proof::get_sync_subcommittee_pubkeys;
@@ -1285,9 +1287,10 @@ fn calculate_consensus_block_value(
 
 async fn get_local_execution_payload(
     execution_engine: &ExecutionEngine,
+    fork_name: ForkName,
     forkchoice_state: ForkchoiceStateV1,
     payload_attribute: PayloadAttributesV3,
-) -> Result<(PayloadV4, u64), ApiError> {
+) -> Result<(Payload, u64), ApiError> {
     let result = execution_engine
         .engine_forkchoice_updated_v3(
             ForkchoiceStateV1 {
@@ -1310,16 +1313,16 @@ async fn get_local_execution_payload(
         ApiError::InternalError("No payload id returned from forkchoice update".into())
     })?;
 
-    let payload_v4 = execution_engine
-        .engine_get_payload_v4(payload_id)
+    let payload = execution_engine
+        .engine_get_payload(&fork_name, payload_id)
         .await
         .map_err(|err| ApiError::InternalError(format!("Failed to get payload: {err}")))?;
 
-    let execution_value: u64 = U256::from_be_bytes(payload_v4.block_value.0)
+    let execution_value: u64 = U256::from_be_bytes(payload.block_value().0)
         .try_into()
         .map_err(|err| ApiError::InternalError(format!("Block value too large: {err}")))?;
 
-    Ok((payload_v4, execution_value))
+    Ok((payload, execution_value))
 }
 
 async fn compare_builder_vs_local(
@@ -1405,6 +1408,7 @@ pub async fn get_blocks_v3(
 
     let proposer_public_key = proposer.public_key.clone();
     let epoch = compute_epoch_at_slot(slot);
+    let fork_name = fork_name_at_epoch(epoch);
 
     verify_randao_reveal(
         &state,
@@ -1451,8 +1455,13 @@ pub async fn get_blocks_v3(
         ));
     };
 
-    let (local_payload_v4, local_execution_value) =
-        get_local_execution_payload(&execution_engine, forkchoice_state, payload_attribute).await?;
+    let (local_payload, local_execution_value) = get_local_execution_payload(
+        &execution_engine,
+        fork_name,
+        forkchoice_state,
+        payload_attribute,
+    )
+    .await?;
 
     let builder_client_ref = builder_client.as_ref().map(|bc| bc.as_ref());
     let (use_builder, builder_bid, builder_value) = compare_builder_vs_local(
@@ -1545,7 +1554,7 @@ pub async fn get_blocks_v3(
         };
 
         let response = ProduceBlockResponse {
-            version: "electra".to_string(),
+            version: fork_name.to_string(),
             execution_payload_blinded: true,
             execution_payload_value: builder_value,
             consensus_block_value,
@@ -1553,7 +1562,7 @@ pub async fn get_blocks_v3(
         };
 
         return Ok(HttpResponse::Ok()
-            .insert_header(("Eth-Consensus-Version", "electra"))
+            .insert_header(("Eth-Consensus-Version", fork_name.to_string()))
             .insert_header(("Eth-Execution-Payload-Blinded", "true"))
             .insert_header((
                 "Eth-Execution-Payload-Value",
@@ -1566,61 +1575,11 @@ pub async fn get_blocks_v3(
             .json(response));
     }
 
-    let execution_payload = ExecutionPayload {
-        parent_hash: local_payload_v4.execution_payload.parent_hash,
-        fee_recipient: local_payload_v4.execution_payload.fee_recipient,
-        state_root: local_payload_v4.execution_payload.state_root,
-        receipts_root: local_payload_v4.execution_payload.receipts_root,
-        logs_bloom: local_payload_v4.execution_payload.logs_bloom,
-        prev_randao: local_payload_v4.execution_payload.prev_randao,
-        block_number: local_payload_v4.execution_payload.block_number,
-        gas_limit: local_payload_v4.execution_payload.gas_limit,
-        gas_used: local_payload_v4.execution_payload.gas_used,
-        timestamp: local_payload_v4.execution_payload.timestamp,
-        extra_data: local_payload_v4.execution_payload.extra_data,
-        base_fee_per_gas: local_payload_v4.execution_payload.base_fee_per_gas,
-        block_hash: local_payload_v4.execution_payload.block_hash,
-        transactions: local_payload_v4.execution_payload.transactions,
-        withdrawals: local_payload_v4.execution_payload.withdrawals,
-        blob_gas_used: local_payload_v4.execution_payload.blob_gas_used,
-        excess_blob_gas: local_payload_v4.execution_payload.excess_blob_gas,
-    };
+    let execution_payload = local_payload.to_execution_payload();
 
-    let blob_kzg_commitments: Vec<KZGCommitment> = local_payload_v4
-        .blobs_bundle
-        .commitments
-        .iter()
-        .map(|c| {
-            let vec = c.clone().to_vec();
-            if vec.len() == 48 {
-                let mut bytes = [0u8; 48];
-                bytes.copy_from_slice(&vec);
-                Ok(KZGCommitment(bytes))
-            } else {
-                Err(ApiError::InternalError(
-                    "Invalid KZG commitment length (expected 48 bytes)".into(),
-                ))
-            }
-        })
-        .collect::<Result<_, _>>()?;
+    let blob_kzg_commitments: Vec<KZGCommitment> = local_payload.blobs_bundle().get_commitments();
 
-    let kzg_proofs: Vec<KZGProof> = local_payload_v4
-        .blobs_bundle
-        .proofs
-        .iter()
-        .map(|p| {
-            let vec = p.clone().to_vec();
-            if vec.len() == 48 {
-                let mut bytes = [0u8; 48];
-                bytes.copy_from_slice(&vec);
-                Ok(KZGProof { 0: bytes })
-            } else {
-                Err(ApiError::InternalError(
-                    "Invalid KZG proof length (expected 48 bytes)".into(),
-                ))
-            }
-        })
-        .collect::<Result<_, _>>()?;
+    let kzg_proofs: Vec<KZGProof> = local_payload.blobs_bundle().get_proofs();
 
     if blob_kzg_commitments.len() != kzg_proofs.len() {
         return Err(ApiError::InternalError(
@@ -1629,7 +1588,7 @@ pub async fn get_blocks_v3(
     }
 
     let execution_requests =
-        get_execution_requests(local_payload_v4.execution_requests.clone()).unwrap_or_default();
+        get_execution_requests(local_payload.execution_requests().clone()).unwrap_or_default();
 
     let block_body = BeaconBlockBody {
         randao_reveal: common_block_body_fields.0,
@@ -1687,7 +1646,7 @@ pub async fn get_blocks_v3(
         .collect();
 
     let response = ProduceBlockResponse {
-        version: "electra".to_string(),
+        version: fork_name.to_string(),
         execution_payload_blinded: false,
         execution_payload_value: local_execution_value,
         consensus_block_value,
@@ -1699,7 +1658,7 @@ pub async fn get_blocks_v3(
     };
 
     Ok(HttpResponse::Ok()
-        .insert_header(("Eth-Consensus-Version", "electra"))
+        .insert_header(("Eth-Consensus-Version", fork_name.to_string()))
         .insert_header(("Eth-Execution-Payload-Blinded", "false"))
         .insert_header((
             "Eth-Execution-Payload-Value",


### PR DESCRIPTION
### What was wrong?
The execution engine only supported electra RPC versions, and the validator block production endpoint was hardcoded to electra.

Fixes #1477

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

### How was it fixed?
 - Added Fulu execution engine support by introducing `engine_getPayloadV5`, `engine_getBlobsV2`, and `engine_getBlobsV3​` 
 - Added a `ForkName` enum for fork-aware dispatch.
 - Changed BlobsBundleV1/V2 to use typed KZGCommitment/KZGProof
 - Replace hardcoded fork strings with dynamic fork name from epoch
 <!-- List the approach you used, and/or changes made to the codebase  -->

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
