### PR TITLE
feat: Implements the build the block one interval early optimization 

### DIFF
--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -435,7 +435,9 @@ pub async fn run_lean_node(config: LeanNodeConfig, executor: ReamExecutor, ream_
     )
     .await;
 
-    let validator_service = LeanValidatorService::new(keystores, chain_sender).await;
+    let arc_keystores: Vec<Arc<_>> = keystores.into_iter().map(Arc::new).collect();
+
+    let validator_service = LeanValidatorService::new(arc_keystores, chain_sender).await;
 
     let server_config = RpcServerConfig::new(
         config.http_address,

--- a/crates/common/validator/lean/src/service.rs
+++ b/crates/common/validator/lean/src/service.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use anyhow::anyhow;
 use ream_chain_lean::{
@@ -29,9 +29,17 @@ use ream_post_quantum_crypto::lean_multisig::type_2::{
 };
 #[cfg(feature = "devnet5")]
 use ssz_types::VariableList;
-use tokio::sync::{mpsc, oneshot};
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
 use tracing::{Level, debug, enabled, info, warn};
 use tree_hash::TreeHash;
+
+pub enum BlockAction {
+    Continue,
+    Success(Box<SignedBlock>),
+}
 
 /// ValidatorService is responsible for managing validator operations
 /// such as proposing blocks and submitting attestations on them. This service also holds the
@@ -40,22 +48,24 @@ use tree_hash::TreeHash;
 /// Every second tick (t=1/4) it attestations on the proposed block.
 /// NOTE: Other ticks should be handled by the other services, such as [LeanChainService].
 pub struct ValidatorService {
-    keystores: Vec<ValidatorKeystore>,
+    keystores: Vec<Arc<ValidatorKeystore>>,
     chain_sender: mpsc::UnboundedSender<LeanChainServiceMessage>,
+    block: Option<JoinHandle<anyhow::Result<BlockAction>>>,
 }
 
 impl ValidatorService {
     pub async fn new(
-        keystores: Vec<ValidatorKeystore>,
+        keystores: Vec<Arc<ValidatorKeystore>>,
         chain_sender: mpsc::UnboundedSender<LeanChainServiceMessage>,
     ) -> Self {
         ValidatorService {
             keystores,
             chain_sender,
+            block: None,
         }
     }
 
-    pub async fn start(self) -> anyhow::Result<()> {
+    pub async fn start(mut self) -> anyhow::Result<()> {
         info!(
             genesis_time = lean_network_spec().genesis_time,
             "ValidatorService started with {} validator(s)",
@@ -75,61 +85,39 @@ impl ValidatorService {
                 _ = interval.tick() => {
                     let slot = tick_count / INTERVALS_PER_SLOT;
                     match tick_count % INTERVALS_PER_SLOT {
+                        3 => {
+                            let slot = slot + 1;
+                            // First tick (t=0): Propose a block.
+                            if slot > 0 && let Some(keystore) = self.is_proposer(slot) {
+                                info!(slot, tick = tick_count, "Building block by Validator {}", keystore.index);
+                                let chain_sender = self.chain_sender.clone();
+                                let keystore = keystore.clone();
+                                self.block = Some(tokio::spawn(async move {build_block(chain_sender, slot, keystore).await}));
+                            }
+                        }
                         0 => {
                             // First tick (t=0): Propose a block.
                             if slot > 0 && let Some(keystore) = self.is_proposer(slot) {
                                 info!(slot, tick = tick_count, "Proposing block by Validator {}", keystore.index);
-                                let (tx, rx) = oneshot::channel();
 
-                                self.chain_sender
-                                    .send(LeanChainServiceMessage::ProduceBlock { slot, sender: tx })
-                                    .expect("Failed to send produce block to LeanChainService");
-
-                                // Wait for the block to be produced.
-                                let block_with_signatures = match rx.await {
-                                    Ok(ServiceResponse::Ok(block_with_signatures)) => block_with_signatures,
-                                    Ok(ServiceResponse::Syncing) => {
-                                        warn!("LeanChainService is syncing, cannot produce block for slot {slot}");
-                                        tick_count += 1;
-                                        continue;
-                                    }
-                                    Ok(ServiceResponse::Err(err)) => {
-                                        warn!("Failed to produce block for slot {slot}: {err}");
-                                        tick_count += 1;
-                                        continue;
-                                    }
-                                    Err(err) => {
-                                        return Err(anyhow!("Failed to receive block from LeanChainService: {err:?}"));
-                                    }
-                                };
-
-                                let block = block_with_signatures.block.clone();
-
-                                info!(
-                                    slot = block.slot,
-                                    block_root = ?block.tree_hash_root(),
-                                    "Building block finished by Validator {}",
-                                    keystore.index,
-                                );
-
-                                let signed_block = match self.sign_block(keystore, block_with_signatures, slot) {
-                                    Ok(signed_block) => signed_block,
-                                    Err(err) => {
-                                        warn!("Failed to sign block for slot {slot}: {err}");
-                                        tick_count += 1;
-                                        continue;
+                                let signed_block = match self.block.take() {
+                                    Some(block) => match block.await?? {
+                                        BlockAction::Continue => continue,
+                                        BlockAction::Success(block) => block,
+                                    },
+                                    None => match  build_block(self.chain_sender.clone(), slot, keystore.clone()).await? {
+                                        BlockAction::Continue => continue,
+                                        BlockAction::Success(block) => block,
                                     }
                                 };
 
                                 // Send block to the LeanChainService.
                                 self.chain_sender
-                                    .send(LeanChainServiceMessage::ProcessBlock { signed_block: Box::new(signed_block), need_gossip: true })
+                                    .send(LeanChainServiceMessage::ProcessBlock { signed_block: Box::new(*signed_block), need_gossip: true })
                                     .map_err(|err| anyhow!("Failed to send block to LeanChainService: {err:?}"))?;
                             } else {
-
                                 let proposer_index = slot % lean_network_spec().num_validators;
                                 info!("Not proposer for slot {slot} (proposer is validator {proposer_index}), skipping");
-
                             }
                         }
                         1 => {
@@ -235,96 +223,142 @@ impl ValidatorService {
     }
 
     /// Determine if one of the keystores is the proposer for the current slot.
-    fn is_proposer(&self, slot: u64) -> Option<&ValidatorKeystore> {
+    fn is_proposer(&self, slot: u64) -> Option<Arc<ValidatorKeystore>> {
         let proposer_index = slot % lean_network_spec().num_validators;
 
         self.keystores
             .iter()
             .find(|keystore| keystore.index == proposer_index as u64)
+            .cloned()
     }
+}
 
-    #[cfg(feature = "devnet4")]
-    fn sign_block(
-        &self,
-        keystore: &ValidatorKeystore,
-        block_with_signatures: BlockWithSignatures,
-        slot: u64,
-    ) -> anyhow::Result<SignedBlock> {
-        let BlockWithSignatures { block, signatures } = block_with_signatures;
+pub async fn build_block(
+    chain_sender: mpsc::UnboundedSender<LeanChainServiceMessage>,
+    slot: u64,
+    keystore: Arc<ValidatorKeystore>,
+) -> anyhow::Result<BlockAction> {
+    let (tx, rx) = oneshot::channel();
 
-        let timer = start_timer(&PQ_SIG_ATTESTATION_SIGNING_TIME, &[]);
-        let proposer_signature = keystore
-            .proposal_private_key
-            .sign(&block.tree_hash_root(), slot as u32)?;
-        stop_timer(timer);
-        inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_TOTAL, &[]);
+    chain_sender
+        .send(LeanChainServiceMessage::ProduceBlock { slot, sender: tx })
+        .expect("Failed to send produce block to LeanChainService");
 
-        Ok(SignedBlock {
-            block,
-            signature: BlockSignatures {
-                attestation_signatures: signatures,
-                proposer_signature,
-            },
-        })
-    }
-
-    #[cfg(feature = "devnet5")]
-    fn sign_block(
-        &self,
-        keystore: &ValidatorKeystore,
-        block_with_signatures: BlockWithSignatures,
-        slot: u64,
-    ) -> anyhow::Result<SignedBlock> {
-        let BlockWithSignatures {
-            block,
-            signatures,
-            attestation_public_keys,
-        } = block_with_signatures;
-
-        if signatures.len() != attestation_public_keys.len() {
+    // Wait for the block to be produced.
+    let block_with_signatures = match rx.await {
+        Ok(ServiceResponse::Ok(block_with_signatures)) => block_with_signatures,
+        Ok(ServiceResponse::Syncing) => {
+            warn!("LeanChainService is syncing, cannot produce block for slot {slot}");
+            return Ok(BlockAction::Continue);
+        }
+        Ok(ServiceResponse::Err(err)) => {
+            warn!("Failed to produce block for slot {slot}: {err}");
+            return Ok(BlockAction::Continue);
+        }
+        Err(err) => {
             return Err(anyhow!(
-                "Attestation proof count ({}) does not match public-key-set count ({})",
-                signatures.len(),
-                attestation_public_keys.len()
+                "Failed to receive block from LeanChainService: {err:?}"
             ));
         }
+    };
 
-        let block_root = block.tree_hash_root();
-        let block_root_bytes: [u8; 32] = block_root.into();
+    let block = block_with_signatures.block.clone();
 
-        let timer = start_timer(&PQ_SIG_ATTESTATION_SIGNING_TIME, &[]);
-        let proposer_signature = keystore
-            .proposal_private_key
-            .sign(&block_root, slot as u32)?;
-        stop_timer(timer);
-        inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_TOTAL, &[]);
+    info!(
+        slot = block.slot,
+        block_root = ?block.tree_hash_root(),
+        "Building block finished by Validator {}",
+        keystore.index,
+    );
 
-        let mut components = Vec::with_capacity(signatures.len() + 1);
-        for (proof, public_keys) in signatures.iter().zip(attestation_public_keys.iter()) {
-            let component = type_1_from_wire(&proof.proof, public_keys).map_err(|err| {
-                anyhow!("Failed to reconstruct attestation single-message aggregate proof: {err}")
-            })?;
-            components.push(component);
+    match sign_block(keystore, block_with_signatures, slot) {
+        Ok(signed_block) => Ok(BlockAction::Success(Box::new(signed_block))),
+        Err(err) => {
+            warn!("Failed to sign block for slot {slot}: {err}");
+            Ok(BlockAction::Continue)
         }
-
-        let proposer_type_1 = type_1_aggregate(
-            &[],
-            &[(keystore.proposal_public_key, proposer_signature)],
-            &block_root_bytes,
-            slot as u32,
-        )
-        .map_err(|err| anyhow!("Failed to build proposer single-message aggregate proof: {err}"))?;
-        components.push(proposer_type_1);
-
-        let merged = type_2_merge(components)
-            .map_err(|err| anyhow!("Failed to merge block multi-message aggregate proof: {err}"))?;
-
-        Ok(SignedBlock {
-            block,
-            proof: MultiMessageAggregate::new(
-                VariableList::new(type_2_to_wire(&merged))
-                    .map_err(|err| anyhow!("Block proof exceeds size limit: {err:?}"))?,
-            ),
-        })
     }
+}
+
+#[cfg(feature = "devnet4")]
+fn sign_block(
+    keystore: Arc<ValidatorKeystore>,
+    block_with_signatures: BlockWithSignatures,
+    slot: u64,
+) -> anyhow::Result<SignedBlock> {
+    let BlockWithSignatures { block, signatures } = block_with_signatures;
+
+    let timer = start_timer(&PQ_SIG_ATTESTATION_SIGNING_TIME, &[]);
+    let proposer_signature = keystore
+        .proposal_private_key
+        .sign(&block.tree_hash_root(), slot as u32)?;
+    stop_timer(timer);
+    inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_TOTAL, &[]);
+
+    Ok(SignedBlock {
+        block,
+        signature: BlockSignatures {
+            attestation_signatures: signatures,
+            proposer_signature,
+        },
+    })
+}
+
+#[cfg(feature = "devnet5")]
+fn sign_block(
+    keystore: Arc<ValidatorKeystore>,
+    block_with_signatures: BlockWithSignatures,
+    slot: u64,
+) -> anyhow::Result<SignedBlock> {
+    let BlockWithSignatures {
+        block,
+        signatures,
+        attestation_public_keys,
+    } = block_with_signatures;
+
+    if signatures.len() != attestation_public_keys.len() {
+        return Err(anyhow!(
+            "Attestation proof count ({}) does not match public-key-set count ({})",
+            signatures.len(),
+            attestation_public_keys.len()
+        ));
+    }
+
+    let block_root = block.tree_hash_root();
+    let block_root_bytes: [u8; 32] = block_root.into();
+
+    let timer = start_timer(&PQ_SIG_ATTESTATION_SIGNING_TIME, &[]);
+    let proposer_signature = keystore
+        .proposal_private_key
+        .sign(&block_root, slot as u32)?;
+    stop_timer(timer);
+    inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_TOTAL, &[]);
+
+    let mut components = Vec::with_capacity(signatures.len() + 1);
+    for (proof, public_keys) in signatures.iter().zip(attestation_public_keys.iter()) {
+        let component = type_1_from_wire(&proof.proof, public_keys).map_err(|err| {
+            anyhow!("Failed to reconstruct attestation single-message aggregate proof: {err}")
+        })?;
+        components.push(component);
+    }
+
+    let proposer_type_1 = type_1_aggregate(
+        &[],
+        &[(keystore.proposal_public_key, proposer_signature)],
+        &block_root_bytes,
+        slot as u32,
+    )
+    .map_err(|err| anyhow!("Failed to build proposer single-message aggregate proof: {err}"))?;
+    components.push(proposer_type_1);
+
+    let merged = type_2_merge(components)
+        .map_err(|err| anyhow!("Failed to merge block multi-message aggregate proof: {err}"))?;
+
+    Ok(SignedBlock {
+        block,
+        proof: MultiMessageAggregate::new(
+            VariableList::new(type_2_to_wire(&merged))
+                .map_err(|err| anyhow!("Block proof exceeds size limit: {err:?}"))?,
+        ),
+    })
 }


### PR DESCRIPTION
### What was wrong?

Fixes: https://github.com/ReamLabs/ream/issues/1491

### How was it fixed?

Implements the build the block one interval early optimization by building blocks one interval early in a background thread so they are ready to gossip instantly at the start of a slot

I tested the pr by running a devnet using lean start on the master branch and then comparing my local branch with the change and it finalizes just as good as the master branch and reaches finalization over 180 slots

<img width="1061" height="532" alt="image" src="https://github.com/user-attachments/assets/423aa38f-daa1-41b7-bbb1-4c850be78d1d" />
 
