### PR TITLE
build: pin the host binary to x86-64-v3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.'cfg(target_os = "zkvm")']
 rustflags = ['--cfg', 'getrandom_backend="custom"']
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ['-C', 'target-cpu=x86-64-v3']


### PR DESCRIPTION


 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

Our current build was too slow at WHIR/XMSS signature aggregation. This optimization was shared in the PQ interop call by some of the teams I think 6 months ago. 

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Build the native (non-zkvm) binary for the x86-64-v3 microarchitecture level (AVX2 + FMA + BMI2). This is a large speedup for the WHIR/XMSS signature aggregation hot path.
### What was wrong?

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
