### PR TITLE
fix(lean): reject malformed justification state with typed errors

### DIFF
--- a/crates/common/consensus/lean/src/slot.rs
+++ b/crates/common/consensus/lean/src/slot.rs
@@ -1,14 +1,14 @@
-use anyhow::ensure;
+pub fn is_justifiable_after(candidate_slot: u64, finalized_slot: u64) -> bool {
+    if candidate_slot < finalized_slot {
+        return false;
+    }
 
-pub fn is_justifiable_after(candidate_slot: u64, finalized_slot: u64) -> anyhow::Result<bool> {
-    ensure!(
-        candidate_slot >= finalized_slot,
-        "Candidate slot ({candidate_slot}) must be more than or equal to finalized slot ({finalized_slot})"
-    );
     let delta = candidate_slot - finalized_slot;
-    Ok(delta <= 5
+    let pronic_discriminant = 4u128 * u128::from(delta) + 1;
+    let discriminant_root = pronic_discriminant.isqrt();
+    delta <= 5
         || delta.isqrt().pow(2) == delta
-        || (4 * delta + 1).isqrt().pow(2) == 4 * delta + 1 && (4 * delta + 1).isqrt() % 2 == 1)
+        || discriminant_root.pow(2) == pronic_discriminant && discriminant_root % 2 == 1
 }
 
 pub fn justified_index_after(candidate_slot: u64, finalized_slot: u64) -> Option<u64> {
@@ -17,4 +17,19 @@ pub fn justified_index_after(candidate_slot: u64, finalized_slot: u64) -> Option
     }
 
     Some(candidate_slot - finalized_slot - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_justifiable_after;
+
+    #[test]
+    fn test_below_finalized_slot_returns_false() {
+        assert!(!is_justifiable_after(9, 10));
+    }
+
+    #[test]
+    fn test_far_below_finalized_slot_returns_false() {
+        assert!(!is_justifiable_after(90, 100));
+    }
 }

--- a/crates/common/consensus/lean/src/slot.rs
+++ b/crates/common/consensus/lean/src/slot.rs
@@ -24,12 +24,12 @@ mod tests {
     use super::is_justifiable_after;
 
     #[test]
-    fn test_below_finalized_slot_returns_false() {
+    fn test_slot_one_before_finalized_not_justifiable() {
         assert!(!is_justifiable_after(9, 10));
     }
 
     #[test]
-    fn test_far_below_finalized_slot_returns_false() {
+    fn test_slot_far_before_finalized_not_justifiable() {
         assert!(!is_justifiable_after(90, 100));
     }
 }

--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -286,16 +286,29 @@ impl LeanState {
              maximum is {MAX_ATTESTATIONS_DATA}",
         );
 
-        ensure!(
-            !self.justifications_roots.contains(&B256::ZERO),
-            "zero hash is not allowed in justifications roots"
-        );
-
         let mut justifications_map = HashMap::new();
 
-        if !self.justifications_roots.is_empty() {
-            let validator_count = self.validators.len();
+        let validator_count = self.validators.len();
+        ensure!(
+            validator_count > 0,
+            "State holds no validators to segment justification votes against"
+        );
 
+        let expected_justification_votes = self.justifications_roots.len() * validator_count;
+        let actual_justification_votes = self.justifications_validators.len();
+        ensure!(
+            actual_justification_votes == expected_justification_votes,
+            "justifications_validators length mismatch: expected {expected_justification_votes} \
+             bits ({} roots x {validator_count} validators), got {actual_justification_votes}",
+            self.justifications_roots.len(),
+        );
+
+        ensure!(
+            !self.justifications_roots.contains(&B256::ZERO),
+            "Tracked justification roots contain the zero hash"
+        );
+
+        if !self.justifications_roots.is_empty() {
             let flat_votes = self.justifications_validators.iter().collect::<Vec<_>>();
 
             for (i, root) in self.justifications_roots.iter().enumerate() {
@@ -406,7 +419,7 @@ impl LeanState {
                 continue;
             }
 
-            if !is_justifiable_after(attestation.target().slot, self.latest_finalized.slot)? {
+            if !is_justifiable_after(attestation.target().slot, self.latest_finalized.slot) {
                 info!(
                     reason = "Target slot not justifiable",
                     source_slot = attestation.source().slot,
@@ -478,9 +491,8 @@ impl LeanState {
                 // hash after the source
                 let is_target_next_valid_justifiable_slot = attestation.source().slot
                     > self.latest_finalized.slot
-                    && !((attestation.source().slot + 1)..attestation.target().slot).any(|slot| {
-                        is_justifiable_after(slot, self.latest_finalized.slot).unwrap_or(false)
-                    });
+                    && !((attestation.source().slot + 1)..attestation.target().slot)
+                        .any(|slot| is_justifiable_after(slot, self.latest_finalized.slot));
 
                 if is_target_next_valid_justifiable_slot {
                     let delta = (attestation.source().slot - self.latest_finalized.slot) as usize;

--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -618,6 +618,34 @@ mod test {
     };
 
     #[test]
+    fn test_justification_votes_length_mismatch_rejects_attestations() -> anyhow::Result<()> {
+        let mut state = LeanState::generate_genesis(0, Some(generate_default_validators(4)));
+
+        state.justifications_roots.push(B256::repeat_byte(0x11))?;
+        state.justifications_validators =
+            BitList::with_capacity(2).map_err(|err| anyhow!("{err:?}"))?;
+
+        let result = state.process_attestations(&[]);
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_zero_hash_justification_root_rejects_attestations() -> anyhow::Result<()> {
+        let mut state = LeanState::generate_genesis(0, Some(generate_default_validators(4)));
+
+        state.justifications_roots.push(B256::ZERO)?;
+        state.justifications_validators =
+            BitList::with_capacity(4).map_err(|err| anyhow!("{err:?}"))?;
+
+        let result = state.process_attestations(&[]);
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
     fn test_justified_slots_rebases_when_finalization_advances() -> anyhow::Result<()> {
         let mut state = LeanState::generate_genesis(0, Some(generate_default_validators(3)));
 

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -685,7 +685,7 @@ impl Store {
                 .block
                 .slot,
             head_finalized_slot,
-        )? {
+        ) {
             target_block_root = block_provider
                 .get(target_block_root)?
                 .ok_or(anyhow!("Block not found for target block root"))?
@@ -1140,7 +1140,7 @@ impl Store {
                 }
 
                 if !is_genesis_self_vote
-                    && !is_justifiable_after(data.target.slot, current_finalized_slot)?
+                    && !is_justifiable_after(data.target.slot, current_finalized_slot)
                 {
                     continue;
                 }
@@ -1343,7 +1343,7 @@ impl Store {
                         continue;
                     }
 
-                    if !is_justifiable_after(candidate_data.target.slot, finalized_slot)? {
+                    if !is_justifiable_after(candidate_data.target.slot, finalized_slot) {
                         continue;
                     }
                 }
@@ -1368,16 +1368,14 @@ impl Store {
                 let total_voters = prior_voters.len() + new_voters.len();
                 let crosses_two_thirds = 3 * total_voters >= 2 * validator_count;
                 // finalizes_source: source finalizes only if no slot strictly between
-                // source and target is still justifiable (3SF-mini). We loop instead of
-                // .any() so an is_justifiable_after error propagates (?) instead of being
-                // swallowed -- same as the target check above.
+                // source and target is still justifiable (3SF-mini).
                 let finalizes_source =
                     if crosses_two_thirds && candidate_data.source.slot > finalized_slot {
                         let mut no_intermediate_justifiable = true;
                         for intermediate_slot in
                             candidate_data.source.slot + 1..candidate_data.target.slot
                         {
-                            if is_justifiable_after(intermediate_slot, finalized_slot)? {
+                            if is_justifiable_after(intermediate_slot, finalized_slot) {
                                 no_intermediate_justifiable = false;
                                 break;
                             }

--- a/testing/lean-spec-tests/src/justifiability.rs
+++ b/testing/lean-spec-tests/src/justifiability.rs
@@ -25,21 +25,14 @@ pub fn run_justifiability_test(test_name: &str, test: &JustifiabilityTest) -> an
         test.slot, test.finalized_slot, test.output.delta, test.output.is_justifiable,
     );
 
+    let actual_delta = i128::from(test.slot) - i128::from(test.finalized_slot);
     ensure!(
-        test.slot >= test.finalized_slot,
-        "Fixture has slot ({}) < finalized_slot ({})",
-        test.slot,
-        test.finalized_slot,
-    );
-
-    let actual_delta = test.slot - test.finalized_slot;
-    ensure!(
-        actual_delta == test.output.delta,
+        actual_delta == i128::from(test.output.delta),
         "Delta mismatch: expected {}, got {actual_delta}",
         test.output.delta,
     );
 
-    let actual = is_justifiable_after(test.slot, test.finalized_slot)?;
+    let actual = is_justifiable_after(test.slot, test.finalized_slot);
     ensure!(
         actual == test.output.is_justifiable,
         "is_justifiable mismatch: expected {}, got {actual}",

--- a/testing/lean-spec-tests/src/types/justifiability.rs
+++ b/testing/lean-spec-tests/src/types/justifiability.rs
@@ -12,6 +12,6 @@ pub struct JustifiabilityTest {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JustifiabilityOutput {
-    pub delta: u64,
+    pub delta: i64,
     pub is_justifiable: bool,
 }


### PR DESCRIPTION
### What was wrong?

Address leanSpec [#1178](https://github.com/leanEthereum/leanSpec/pull/1178)

**TLDR**: 
- `is_justifiable_after` is now total: below-finalized slots return `false` instead of erroring, and the fixture runner supports signed deltas for those cases.
- `process_attestations` now rejects malformed justification bookkeeping before unpacking, including vote-list length mismatch and zero-hash roots.

### How was it fixed?

- Made `is_justifiable_after` total by returning `false` for slots before finalization.
- Updated the justifiability runner to support signed deltas from leanSpec 1178.
- Added malformed justification-state guards for vote-list length mismatch and zero-hash roots.
- Added direct tests for below-finalized slots and attestation senarios.

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).