### PR TITLE
fix(lean): make equal-slot equivocation tie-break deterministic

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1076,7 +1076,12 @@ impl Store {
         let mut processed_attestation_data: HashSet<AttestationData> = HashSet::new();
 
         let mut sorted_candidates: Vec<_> = ctx.available_signed_attestations.values().collect();
-        sorted_candidates.sort_by_key(|signed_attestation| signed_attestation.message.target.slot);
+        sorted_candidates.sort_by_cached_key(|signed_attestation| {
+            (
+                signed_attestation.message.target.slot,
+                signed_attestation.message.tree_hash_root(),
+            )
+        });
 
         let select_start = Instant::now();
         let mut child_payloads_consumed = 0;
@@ -1979,29 +1984,30 @@ impl Store {
         &self,
         aggregated_payloads: &HashMap<SignatureKey, Vec<PayloadProof>>,
     ) -> anyhow::Result<HashMap<u64, AttestationData>> {
-        let mut attestations: HashMap<u64, AttestationData> = HashMap::new();
         let attestation_data_by_root_provider =
             self.store.lock().await.attestation_data_by_root_provider();
+        let mut resolved_attestations = Vec::with_capacity(aggregated_payloads.len());
 
         for (signature_key, proofs) in aggregated_payloads {
-            let data_root = signature_key.data_root;
-            let attestation_data = match attestation_data_by_root_provider.get(data_root)? {
-                Some(data) => data,
-                None => continue,
-            };
-
             if proofs.is_empty() {
                 continue;
             }
 
-            let validator = signature_key.validator_id;
-            let is_newer = attestations
-                .get(&validator)
-                .is_none_or(|existing| existing.slot < attestation_data.slot);
+            let data_root = signature_key.data_root;
+            let Some(attestation_data) = attestation_data_by_root_provider.get(data_root)? else {
+                continue;
+            };
 
-            if is_newer {
-                attestations.insert(validator, attestation_data.clone());
-            }
+            resolved_attestations.push((signature_key.validator_id, data_root, attestation_data));
+        }
+
+        resolved_attestations.sort_by_key(|(_validator_id, data_root, data)| {
+            std::cmp::Reverse((data.slot, *data_root))
+        });
+
+        let mut attestations: HashMap<u64, AttestationData> = HashMap::new();
+        for (validator_id, _data_root, attestation_data) in resolved_attestations {
+            attestations.entry(validator_id).or_insert(attestation_data);
         }
         Ok(attestations)
     }


### PR DESCRIPTION
### What was wrong?

Address leanSpec [#1181](https://github.com/leanEthereum/leanSpec/pull/1181) (issue [#1172](https://github.com/leanEthereum/leanSpec/issues/1172))

**TL;DR**:
- Latest-vote extraction now orders attestations by `(slot, attestation_data_root)`: higher slot wins, and same-slot equivocations pick the larger canonical data root. 

Before the implementation, if a validator had two different votes at the same slot, the first one seen stayed as the winner, so the result depended on arrival order.
Specifically, vote arrival order could make honest nodes assign the same equivocator’s weight to different fork branches, causing them to choose different heads.
The fix removes the old arrival-order dependency, so nodes with the same votes resolve the same winner. => Problem solved.

### How was it fixed?

- `extract_attestations_from_aggregated_payloads` function in `ream` already sorted by `(attestation_data.slot, data_root)` => So no changes need.
- on `select_round_based`, attestation candidates from `available_signed_attestations` are sorted by `(attestation_data.slot, data_root)` through new added function `sort_block_attestation_candidates`.
- Four tests are added:
    - `test_equal_slot_equivocation_resolves_to_larger_data_root`: verifies that same-slot equivocations resolve to the vote with the larger attestation-data root.
    - `test_higher_slot_beats_larger_data_root`: verifies that a higher-slot vote still wins even if the lower-slot vote has a larger root.
    - `test_equivocation_head_independent_of_arrival_order_a_then_b`: verifies that fork choice selects the same canonical head when vote A arrives before vote B.
    - `test_equivocation_head_independent_of_arrival_order_b_then_a`: verifies the same head result when the same votes arrive in the opposite order.

### What's to notice

- our current function `latest_known_attestations_provider` is not used anywhere, so `available_signed_attestations`'s always empty.

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
