### PR TITLE
fix: finalization bug for tiered attestation scoring

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1275,16 +1275,6 @@ impl Store {
                         continue;
                     }
 
-                    if is_projected_slot_justified(
-                        &justified_slots,
-                        finalized_slot,
-                        candidate_data.target.slot,
-                    ) {
-                        if processed_data_roots.contains(data_root) {
-                            continue;
-                        }
-                    }
-
                     if !is_justifiable_after(candidate_data.target.slot, finalized_slot)? {
                         continue;
                     }

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1280,7 +1280,9 @@ impl Store {
                         finalized_slot,
                         candidate_data.target.slot,
                     ) {
-                        continue;
+                        if processed_data_roots.contains(data_root) {
+                            continue;
+                        }
                     }
 
                     if !is_justifiable_after(candidate_data.target.slot, finalized_slot)? {


### PR DESCRIPTION
### What was wrong?

fix's dropping attestation payloads early targeting the same slot

before:
<img width="1028" height="270" alt="image" src="https://github.com/user-attachments/assets/40942224-6e87-4cf0-8edf-33dcce4022bd" />


after the fix 

<img width="1534" height="489" alt="image" src="https://github.com/user-attachments/assets/6e0a3d8c-0412-4c89-84c5-09b775accb48" />
