### PR TITLE
fix(fork_choice): apply devnet5 block attestations to fork choice

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1580,7 +1580,6 @@ impl Store {
         let block_provider = db.block_provider();
         let latest_justified_provider = db.latest_justified_provider();
         let attestation_data_by_root_provider = db.attestation_data_by_root_provider();
-        #[cfg(feature = "devnet4")]
         let latest_known_aggregated_payloads_provider =
             db.latest_known_aggregated_payloads_provider();
         drop(db);
@@ -1663,6 +1662,22 @@ impl Store {
             for attestation in aggregated_attestations.iter() {
                 let data_root = attestation.message.tree_hash_root();
                 attestation_data_by_root_provider.insert(data_root, attestation.message.clone())?;
+
+                let payload =
+                    PayloadProof::new(attestation.aggregation_bits.clone(), VariableList::empty());
+
+                for (validator_id, participated) in attestation.aggregation_bits.iter().enumerate()
+                {
+                    if !participated {
+                        continue;
+                    }
+                    let key = SignatureKey::from_parts(validator_id as u64, data_root);
+                    let mut existing_proofs = latest_known_aggregated_payloads_provider
+                        .get(key.clone())?
+                        .unwrap_or_default();
+                    existing_proofs.push(payload.clone());
+                    latest_known_aggregated_payloads_provider.insert(key, existing_proofs)?;
+                }
             }
         }
 

--- a/testing/lean-spec-tests/src/fork_choice.rs
+++ b/testing/lean-spec-tests/src/fork_choice.rs
@@ -7,7 +7,7 @@ use alloy_primitives::hex;
 use anyhow::{anyhow, bail, ensure};
 use ream_consensus_lean::{
     attestation::{
-        MultiMessageAggregate, SignatureKey, SignedAggregatedAttestation, SignedAttestation,
+        MultiMessageAggregate, SignedAggregatedAttestation, SignedAttestation,
         SingleMessageAggregate,
     },
     block::{Block, SignedBlock},
@@ -285,15 +285,6 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
                     );
                 }
 
-                // A blank block proof carries no votes, so `on_block` gives the
-                // block's own body attestations zero fork-choice weight. Mirror the
-                // node's post-import reaggregation: rebuild each attestation's
-                // participant set from `aggregation_bits`, fold it into the known
-                // pool, and recompute the head so block-borne votes count.
-                if import_ok {
-                    attribute_block_attestations(&store, block).await?;
-                }
-
                 // Validate checks if present
                 if let Some(checks) = checks {
                     validate_checks(&store, checks).await?;
@@ -426,55 +417,6 @@ async fn validate_checks(store: &Store, checks: &StoreChecks) -> anyhow::Result<
 fn decode_hex_bytes(value: &str) -> anyhow::Result<Vec<u8>> {
     hex::decode(value.trim_start_matches("0x"))
         .map_err(|err| anyhow!("Failed to decode hex bytes: {err}"))
-}
-
-/// Fold a freshly imported block's body attestations into the known-vote pool.
-///
-/// Fixture blocks carry a blank proof, so `on_block` gives their body
-/// attestations no fork-choice weight. Mirror the node's post-import
-/// reaggregation: rebuild each attestation's participant set from its
-/// `aggregation_bits` (fork choice reads only the participants, not the proof
-/// bytes), record it in the known pool per validator, then recompute the head
-/// so block-borne votes are reflected.
-async fn attribute_block_attestations(
-    store: &Store,
-    block: &crate::types::Block,
-) -> anyhow::Result<()> {
-    let ream_block =
-        Block::try_from(block).map_err(|err| anyhow!("Failed to convert block: {err}"))?;
-
-    {
-        let db = store.store.lock().await;
-        let attestation_data_by_root_provider = db.attestation_data_by_root_provider();
-        let latest_known_aggregated_payloads_provider =
-            db.latest_known_aggregated_payloads_provider();
-
-        for attestation in ream_block.body.attestations.iter() {
-            let data_root = attestation.message.tree_hash_root();
-            attestation_data_by_root_provider.insert(data_root, attestation.message.clone())?;
-
-            // Empty proof bytes: only the participant set drives fork-choice weight.
-            let payload = SingleMessageAggregate::new(
-                attestation.aggregation_bits.clone(),
-                VariableList::empty(),
-            );
-
-            for (validator_id, participated) in attestation.aggregation_bits.iter().enumerate() {
-                if !participated {
-                    continue;
-                }
-                let key = SignatureKey::from_parts(validator_id as u64, data_root);
-                let mut existing_proofs = latest_known_aggregated_payloads_provider
-                    .get(key.clone())?
-                    .unwrap_or_default();
-                existing_proofs.push(payload.clone());
-                latest_known_aggregated_payloads_provider.insert(key, existing_proofs)?;
-            }
-        }
-    }
-
-    store.update_head().await?;
-    Ok(())
 }
 
 /// Validate an aggregated attestation whose cryptographic proof is mocked.


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

A lean node can receive other validator votes from gossip or `block.body.attestations` in a recently proposed lean block.

In case of devnet 5, `latest_known_aggregated_payloads` is only updated in case of gossip but the `block.body.attestations` is skipped. This causes miscalculation in the head selection in `compute_lmd_ghost_head`. 


This results in the following `fork_choice_reorgs` tests failing on [hive](https://hive.leanroadmap.org/?devnet=devnet5):
- test_back_and_forth_reorg_oscillation
- test_reorg_depth_across_deep_chain_split
- test_reorg_on_newly_justified_slot
- test_reorg_prevention_heavy_fork_resists_light_competition
- test_reorg_with_slot_gaps
- test_simple_one_block_reorg
- test_three_block_deep_reorg
- test_three_way_fork_competition
- test_two_block_reorg_progressive_building

Note that the local tests pass in the ream codebase because of the `attribute_block_attestations` workaround added in PR 1476 https://github.com/ReamLabs/ream/pull/1476/changes#diff-0a386a8dee36ad0f84214d5f8126e1c454f4cc669a7014ca6035f00745198a2bR431-R442 (ctrl click to go to the exact diff, simple click doesnt seem to navigate due to some github ui bug)

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

- Update `on_block` to process the attestations included in devnet5 block into the `latest_known_aggregated_payloads_provider`.
- Remove the workaround added in the ream tests suite.

### Screenshots

Before the fix 9 tests failing:
<img width="1568" height="832" alt="Screenshot 2026-07-07 at 1 30 47 AM" src="https://github.com/user-attachments/assets/78ad593a-02d5-4099-8554-3707773bedc7" />


After the fix the 9 tests pass=true
<img width="1536" height="813" alt="Screenshot 2026-07-07 at 1 29 40 AM" src="https://github.com/user-attachments/assets/c7ed05fb-a130-4af6-aad4-10dc9f77d616" />









### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
