### PR TITLE
fix: re-propagate gossip instead of gating on manual validation

### DIFF
--- a/crates/networking/p2p/src/gossipsub/lean/configurations.rs
+++ b/crates/networking/p2p/src/gossipsub/lean/configurations.rs
@@ -32,7 +32,6 @@ impl Default for LeanGossipsubConfig {
                     * lean_network_spec().seconds_per_slot
                     * 2,
             ))
-            .validate_messages()
             .validation_mode(ValidationMode::Anonymous)
             .allow_self_origin(true)
             .flood_publish(false)


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

The lean gossipsub config set validate_messages(), which puts gossipsub in manual validation mode so a received message is not forwarded to the rest of the mesh until the app calls report_message_validation_result. 

### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
