### PR TITLE
 fix: align fork-choice attestation target selection with head checkpoint

### DIFF
--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -568,30 +568,23 @@ impl Store {
     }
 
     pub async fn get_attestation_target(&self) -> anyhow::Result<Checkpoint> {
-        let (
-            head_provider,
-            block_provider,
-            safe_target_provider,
-            latest_justified_provider,
-            state_provider,
-        ) = {
+        let (head_provider, block_provider, safe_target_provider, state_provider) = {
             let db = self.store.lock().await;
             (
                 db.head_provider(),
                 db.block_provider(),
                 db.safe_target_provider(),
-                db.latest_justified_provider(),
                 db.state_provider(),
             )
         };
 
         let head_root = head_provider.get()?;
 
-        let head_finalized_slot = state_provider
+        let head_state = state_provider
             .get(head_root)?
-            .ok_or(anyhow!("Head state not found for attestation target"))?
-            .latest_finalized
-            .slot;
+            .ok_or(anyhow!("Head state not found for attestation target"))?;
+        let head_finalized_slot = head_state.latest_finalized.slot;
+        let head_justified = head_state.latest_justified;
 
         let mut target_block_root = head_root;
 
@@ -636,9 +629,8 @@ impl Store {
             .get(target_block_root)?
             .ok_or(anyhow!("Block not found for target block root"))?;
 
-        let latest_justified = latest_justified_provider.get()?;
-        if target_block.block.slot < latest_justified.slot {
-            return Ok(latest_justified);
+        if target_block.block.slot < head_justified.slot {
+            return Ok(head_justified);
         }
 
         Ok(Checkpoint {

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1096,6 +1096,12 @@ impl Store {
                     continue;
                 }
 
+                if !is_genesis_self_vote
+                    && !is_justifiable_after(data.target.slot, current_finalized_slot)?
+                {
+                    continue;
+                }
+
                 let validator_id = signed_attestation.validator_id;
                 let attestation = AggregatedAttestations {
                     validator_id,

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -568,17 +568,32 @@ impl Store {
     }
 
     pub async fn get_attestation_target(&self) -> anyhow::Result<Checkpoint> {
-        let (head_provider, block_provider, safe_target_provider, latest_finalized_provider) = {
+        let (
+            head_provider,
+            block_provider,
+            safe_target_provider,
+            latest_justified_provider,
+            state_provider,
+        ) = {
             let db = self.store.lock().await;
             (
                 db.head_provider(),
                 db.block_provider(),
                 db.safe_target_provider(),
-                db.latest_finalized_provider(),
+                db.latest_justified_provider(),
+                db.state_provider(),
             )
         };
 
-        let mut target_block_root = head_provider.get()?;
+        let head_root = head_provider.get()?;
+
+        let head_finalized_slot = state_provider
+            .get(head_root)?
+            .ok_or(anyhow!("Head state not found for attestation target"))?
+            .latest_finalized
+            .slot;
+
+        let mut target_block_root = head_root;
 
         for _ in 0..JUSTIFICATION_LOOKBACK_SLOTS {
             if block_provider
@@ -602,14 +617,13 @@ impl Store {
             }
         }
 
-        let latest_finalized_slot = latest_finalized_provider.get()?.slot;
         while !is_justifiable_after(
             block_provider
                 .get(target_block_root)?
                 .ok_or(anyhow!("Block not found for target block root"))?
                 .block
                 .slot,
-            latest_finalized_slot,
+            head_finalized_slot,
         )? {
             target_block_root = block_provider
                 .get(target_block_root)?
@@ -621,6 +635,11 @@ impl Store {
         let target_block = block_provider
             .get(target_block_root)?
             .ok_or(anyhow!("Block not found for target block root"))?;
+
+        let latest_justified = latest_justified_provider.get()?;
+        if target_block.block.slot < latest_justified.slot {
+            return Ok(latest_justified);
+        }
 
         Ok(Checkpoint {
             root: target_block_root,


### PR DESCRIPTION
### What was wrong?

Fork-choice attestation target selection and block-attestation packing judged justifiability against the **store's** `latest_finalized_provider` /
`latest_justified_provider`. Those are monotonic maxima over every processed block's parent-state checkpoints, so they can **exceed** the head chain's real finalized/justified (observed: store justified = 65 while head-state justified = 20).

The proposer's state transition (`process_attestations`) judges votes against the **head state's** `latest_finalized` / `latest_justified`. So attesters produced targets that looked valid under the higher store values but were rejected at block processing as "Target slot not justifiable" votes were silently dropped and **justification/finalization froze** (finalized plateaus while justified climbs).

### How was it fixed?

Reference the head state's checkpoints everywhere target selection and attestation packing happen, so attesters, the block builder, and block processing agree on the justifiable-slot set.

### To-Do
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).