### PR TITLE
feat: move aggregation off the hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6238,6 +6238,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "itertools 0.14.0",
+ "rayon",
  "ream-consensus-misc",
  "ream-metrics",
  "ream-post-quantum-crypto",

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -2985,20 +2985,38 @@ impl LeanChainService {
     }
     async fn handle_process_block(&mut self, signed_block: &SignedBlock) -> anyhow::Result<()> {
         let parent_root = signed_block.block.parent_root;
-        let has_parent_state = {
+        let parent_state = {
             let fork_choice = self.store.read().await;
             let store = fork_choice.store.lock().await;
-            store.state_provider().get(parent_root)?.is_some()
+            store.state_provider().get(parent_root)?
         };
-        if !has_parent_state {
+        let Some(_parent_state) = parent_state else {
             warn!(
                 root = ?signed_block.block.tree_hash_root(),
                 parent_root = ?parent_root,
                 "Missing parent state while processing synced block; routing block to backfill path"
             );
             return self.handle_syncing_process_block(signed_block).await;
-        }
+        };
 
+        #[cfg(feature = "devnet5")]
+        {
+            let block_for_verify = signed_block.clone();
+            let verified = tokio::task::spawn_blocking(move || {
+                block_for_verify.verify_signatures(&_parent_state, true)
+            })
+            .await
+            .map_err(|err| anyhow!("block verify join error: {err:?}"))??;
+            if !verified {
+                return Err(anyhow!("Block signature verification failed"));
+            }
+            self.store
+                .write()
+                .await
+                .on_block(signed_block, false)
+                .await?;
+        }
+        #[cfg(feature = "devnet4")]
         self.store
             .write()
             .await

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "devnet5")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     pin::Pin,
@@ -24,6 +26,8 @@ use ream_consensus_lean::{
 };
 use ream_consensus_misc::constants::lean::{INTERVALS_PER_SLOT, attestation_committee_count};
 use ream_fork_choice_lean::store::LeanStoreWriter;
+#[cfg(feature = "devnet5")]
+use ream_fork_choice_lean::store::prove_aggregation_jobs;
 use ream_metrics::{
     ATTESTATION_COMMITTEE_COUNT as ATTESTATION_COMMITTEE_COUNT_METRIC,
     BLOCK_BUILDING_FAILURES_TOTAL, CURRENT_SLOT, IS_AGGREGATOR, LEAN_AGGREGATOR_SKIPPED_TOTAL,
@@ -258,6 +262,8 @@ pub struct LeanChainService {
     telemetry: SyncTelemetry,
     #[cfg(feature = "devnet5")]
     pending_block_aggregates: Arc<Mutex<Vec<SignedAggregatedAttestation>>>,
+    #[cfg(feature = "devnet5")]
+    aggregation_in_flight: Arc<AtomicBool>,
 }
 
 impl LeanChainService {
@@ -287,6 +293,8 @@ impl LeanChainService {
             telemetry: SyncTelemetry::from_env(),
             #[cfg(feature = "devnet5")]
             pending_block_aggregates: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "devnet5")]
+            aggregation_in_flight: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -344,6 +352,59 @@ impl LeanChainService {
                     if self.sync_status == SyncStatus::Synced {
                         self.store.write().await.tick_interval(tick_count.is_multiple_of(INTERVALS_PER_SLOT), self.is_aggregator()).await?;
                         self.step_head_sync(tick_count).await?;
+
+                        #[cfg(feature = "devnet5")]
+                        if self.is_aggregator()
+                            && tick_count % INTERVALS_PER_SLOT == 2
+                            && !self.aggregation_in_flight.swap(true, Ordering::AcqRel)
+                        {
+                            let store = self.store.clone();
+                            let in_flight = self.aggregation_in_flight.clone();
+                            let outbound = self.outbound_p2p.clone();
+                            let agg_start = Instant::now();
+                            const AGG_DEADLINE: Duration = Duration::from_millis(750);
+                            let deadline = agg_start + AGG_DEADLINE;
+                            tokio::spawn(async move {
+                                let result = async {
+                                    let jobs = store.write().await.aggregate_prepare().await?;
+                                    let total = jobs.len();
+                                    let mut produced = 0usize;
+                                    for job in jobs {
+                                        if produced > 0 && Instant::now() >= deadline {
+                                            break;
+                                        }
+                                        let signed = tokio::task::spawn_blocking(move || {
+                                            prove_aggregation_jobs(vec![job])
+                                        })
+                                        .await
+                                        .map_err(|err| anyhow!("aggregation join error: {err:?}"))??;
+                                        store.write().await.aggregate_apply(&signed).await?;
+                                        for aggregate in signed {
+                                            produced += 1;
+                                            if let Err(err) = outbound.send(
+                                                LeanP2PRequest::GossipAggregatedAttestation(Box::new(
+                                                    aggregate,
+                                                )),
+                                            ) {
+                                                warn!("Failed to gossip aggregated attestation: {err:?}");
+                                            }
+                                        }
+                                    }
+                                    let elapsed_ms = agg_start.elapsed().as_millis() as u64;
+                                    if produced < total {
+                                        warn!(elapsed_ms, produced, total, "AGG_TIMING partial batch (deadline)");
+                                    } else {
+                                        info!(elapsed_ms, produced, "AGG_TIMING aggregation complete");
+                                    }
+                                    anyhow::Ok(())
+                                }
+                                .await;
+                                if let Err(err) = result {
+                                    warn!("Off-loop committee aggregation failed: {err:?}");
+                                }
+                                in_flight.store(false, Ordering::Release);
+                            });
+                        }
                     }
 
                     tick_count += 1;

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -2907,20 +2907,31 @@ impl LeanChainService {
 
         if head_slot > STATE_RETENTION_SLOTS {
             let prune_target_slot = head_slot - STATE_RETENTION_SLOTS;
-            let block_root = slot_index_provider
-                .get(prune_target_slot)?
-                .ok_or_else(|| anyhow!("Block root not found for slot: {prune_target_slot}"))?;
+            let mut scan = prune_target_slot;
+            let mut prune_root = None;
+            loop {
+                if let Some(root) = slot_index_provider.get(scan)? {
+                    prune_root = Some((scan, root));
+                    break;
+                }
+                if scan == 0 {
+                    break;
+                }
+                scan -= 1;
+            }
 
-            info!(
-                slot = get_current_slot(),
-                tick = tick_count,
-                prune_slot = prune_target_slot,
-                prune_block_root = ?block_root,
-                "Pruning old lean state"
-            );
+            if let Some((prune_slot, block_root)) = prune_root {
+                info!(
+                    slot = get_current_slot(),
+                    tick = tick_count,
+                    prune_slot,
+                    prune_block_root = ?block_root,
+                    "Pruning old lean state"
+                );
 
-            if let Err(err) = state_provider.remove(block_root) {
-                warn!("Failed to prune old lean state: {err:?}");
+                if let Err(err) = state_provider.remove(block_root) {
+                    warn!("Failed to prune old lean state: {err:?}");
+                }
             }
         }
         Ok(())

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -130,6 +130,50 @@ struct BuildContext {
     latest_known_aggregated_payloads_provider: LeanLatestKnownAggregatedPayloadsTable,
 }
 
+#[cfg(feature = "devnet5")]
+pub struct AggregationJob {
+    data: AttestationData,
+    data_root: B256,
+    child_wires: Vec<(Vec<u8>, Vec<PublicKey>)>,
+    raw_xmss: Vec<(PublicKey, Signature)>,
+    bits: BitList<U4096>,
+    raw_count: u64,
+}
+
+#[cfg(feature = "devnet5")]
+pub fn prove_aggregation_jobs(
+    jobs: Vec<AggregationJob>,
+) -> anyhow::Result<Vec<SignedAggregatedAttestation>> {
+    let mut results = Vec::with_capacity(jobs.len());
+    for job in jobs {
+        let building_timer = start_timer(&PQ_SIG_AGGREGATED_SIGNATURES_BUILDING_TIME, &[]);
+        let children = job
+            .child_wires
+            .iter()
+            .map(|(wire, public_keys)| type_1_from_wire(wire, public_keys))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let type_one =
+            type_1_aggregate(&children, &job.raw_xmss, &job.data_root.0, job.data.slot as u32)?;
+        let proof = PayloadProof {
+            participants: job.bits.clone(),
+            proof: VariableList::new(type_1_to_wire(&type_one))
+                .map_err(|err| anyhow!("Failed to create proof_data: {err:?}"))?,
+        };
+        stop_timer(building_timer);
+        inc_int_counter_vec(&PQ_SIG_AGGREGATED_SIGNATURES_TOTAL, &[]);
+        inc_int_counter_vec_by(
+            &PQ_SIG_ATTESTATIONS_IN_AGGREGATED_SIGNATURES_TOTAL,
+            job.raw_count,
+            &[],
+        );
+        results.push(SignedAggregatedAttestation {
+            data: job.data.clone(),
+            proof,
+        });
+    }
+    Ok(results)
+}
+
 /// [Store] represents the state that the Lean node should maintain.
 #[derive(Debug, Clone)]
 pub struct Store {
@@ -419,10 +463,12 @@ impl Store {
                 self.accept_new_attestations().await?;
             }
         } else if current_interval == 2 {
-            // Interval 2: Only aggregate signatures if aggregator
+            #[cfg(feature = "devnet4")]
             if is_aggregator {
                 self.aggregate().await?;
             }
+            #[cfg(feature = "devnet5")]
+            let _ = is_aggregator;
         } else if current_interval == 3 {
             // Interval 3: Update safe target
             self.update_safe_target().await?;
@@ -2066,6 +2112,194 @@ impl Store {
             .retain(|key| !aggregated_data_roots.contains(&key.data_root))?;
 
         Ok(signed_attestations)
+    }
+
+    #[cfg(feature = "devnet5")]
+    pub async fn aggregate_prepare(&self) -> anyhow::Result<Vec<AggregationJob>> {
+        let (
+            state_provider,
+            attestation_signatures_provider,
+            head_root,
+            latest_new_aggregated_payloads_provider,
+            latest_known_aggregated_payloads_provider,
+            attestation_data_by_root_provider,
+        ) = {
+            let db = self.store.lock().await;
+            (
+                db.state_provider(),
+                db.attestation_signatures_provider(),
+                db.head_provider().get()?,
+                db.latest_new_aggregated_payloads_provider(),
+                db.latest_known_aggregated_payloads_provider(),
+                db.attestation_data_by_root_provider(),
+            )
+        };
+
+        let head_state = state_provider
+            .get(head_root)?
+            .ok_or_else(|| anyhow!("Head state not found"))?;
+
+        let signature_keys = attestation_signatures_provider.get_keys()?;
+        set_int_gauge_vec(&GOSSIP_SIGNATURES, signature_keys.len() as i64, &[]);
+
+        let mut groups: HashMap<AttestationData, Vec<u64>> = HashMap::new();
+        for signature_key in &signature_keys {
+            if let Some(attestation_data) =
+                attestation_data_by_root_provider.get(signature_key.data_root)?
+            {
+                groups
+                    .entry(attestation_data)
+                    .or_default()
+                    .push(signature_key.validator_id);
+            }
+        }
+
+        let mut new_payloads: HashMap<AttestationData, HashSet<PayloadProof>> = HashMap::new();
+        for (signature_key, proofs) in latest_new_aggregated_payloads_provider.iter()? {
+            if let Some(attestation_data) =
+                attestation_data_by_root_provider.get(signature_key.data_root)?
+            {
+                new_payloads.entry(attestation_data).or_default().extend(proofs);
+            }
+        }
+
+        let mut known_payloads: HashMap<AttestationData, HashSet<PayloadProof>> = HashMap::new();
+        for (signature_key, proofs) in latest_known_aggregated_payloads_provider.iter()? {
+            if let Some(attestation_data) =
+                attestation_data_by_root_provider.get(signature_key.data_root)?
+            {
+                known_payloads.entry(attestation_data).or_default().extend(proofs);
+            }
+        }
+
+        let mut keys: HashSet<AttestationData> = groups.keys().cloned().collect();
+        keys.extend(new_payloads.keys().cloned());
+
+        let mut jobs = Vec::new();
+        for data in keys {
+            let data_root = data.tree_hash_root();
+            let mut child_proofs = Vec::new();
+            let mut covered_validators = HashSet::new();
+
+            head_state.extend_proofs_greedily(
+                new_payloads.get(&data),
+                &mut child_proofs,
+                &mut covered_validators,
+            );
+            head_state.extend_proofs_greedily(
+                known_payloads.get(&data),
+                &mut child_proofs,
+                &mut covered_validators,
+            );
+
+            let mut raw_entries = Vec::new();
+            if let Some(validator_ids) = groups.get(&data) {
+                let mut sorted_ids = validator_ids.clone();
+                sorted_ids.sort();
+                for &validator_id in &sorted_ids {
+                    if covered_validators.contains(&validator_id) {
+                        continue;
+                    }
+                    if let Ok(Some(signature)) = attestation_signatures_provider
+                        .get(SignatureKey::from_parts(validator_id, data_root))
+                        && let Some(validator) = head_state.validators.get(validator_id as usize)
+                    {
+                        raw_entries.push((validator_id, validator.attestation_public_key, signature));
+                        covered_validators.insert(validator_id);
+                    }
+                }
+            }
+
+            if raw_entries.is_empty() && child_proofs.len() < 2 {
+                continue;
+            }
+            raw_entries.sort_by_key(|entry| entry.0);
+
+            let mut bits = BitList::<U4096>::with_capacity(head_state.validators.len())
+                .map_err(|err| anyhow!("BitList error: {err:?}"))?;
+            for id in &covered_validators {
+                bits.set(*id as usize, true)
+                    .map_err(|err| anyhow!("Failed to set bits: {err:?}"))?;
+            }
+
+            let mut child_wires = Vec::with_capacity(child_proofs.len());
+            for child in &child_proofs {
+                let public_keys = child
+                    .to_validator_indices()
+                    .into_iter()
+                    .map(|validator_id| {
+                        head_state
+                            .validators
+                            .get(validator_id as usize)
+                            .map(|validator| validator.attestation_public_key)
+                            .ok_or_else(|| {
+                                anyhow!("Validator index {validator_id} out of range during aggregation")
+                            })
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                child_wires.push((child.proof.to_vec(), public_keys));
+            }
+
+            let raw_xmss = raw_entries
+                .iter()
+                .map(|(_, public_key, signature)| (*public_key, *signature))
+                .collect();
+            let raw_count = raw_entries.len() as u64;
+
+            jobs.push(AggregationJob {
+                data,
+                data_root,
+                child_wires,
+                raw_xmss,
+                bits,
+                raw_count,
+            });
+        }
+        Ok(jobs)
+    }
+
+    #[cfg(feature = "devnet5")]
+    pub async fn aggregate_apply(
+        &self,
+        signed_attestations: &[SignedAggregatedAttestation],
+    ) -> anyhow::Result<()> {
+        let (latest_new_aggregated_payloads_provider, attestation_signatures_provider) = {
+            let db = self.store.lock().await;
+            (
+                db.latest_new_aggregated_payloads_provider(),
+                db.attestation_signatures_provider(),
+            )
+        };
+
+        let mut aggregated_data_roots = HashSet::new();
+        let mut next_new_payloads: HashMap<SignatureKey, Vec<PayloadProof>> = HashMap::new();
+        for signed_attestation in signed_attestations {
+            let data_root = signed_attestation.data.tree_hash_root();
+            aggregated_data_roots.insert(data_root);
+            for validator_id in signed_attestation.proof.to_validator_indices() {
+                next_new_payloads
+                    .entry(SignatureKey::from_parts(validator_id, data_root))
+                    .or_default()
+                    .push(signed_attestation.proof.clone());
+            }
+        }
+
+        for (key, proofs) in next_new_payloads {
+            let mut existing = latest_new_aggregated_payloads_provider
+                .get(key.clone())?
+                .unwrap_or_default();
+            for proof in proofs {
+                if !existing.contains(&proof) {
+                    existing.push(proof);
+                }
+            }
+            latest_new_aggregated_payloads_provider.insert(key, existing)?;
+        }
+
+        attestation_signatures_provider
+            .retain(|key| !aggregated_data_roots.contains(&key.data_root))?;
+
+        Ok(())
     }
 
     pub async fn compute_block_weights(&self) -> anyhow::Result<HashMap<B256, u64>> {

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -152,8 +152,12 @@ pub fn prove_aggregation_jobs(
             .iter()
             .map(|(wire, public_keys)| type_1_from_wire(wire, public_keys))
             .collect::<anyhow::Result<Vec<_>>>()?;
-        let type_one =
-            type_1_aggregate(&children, &job.raw_xmss, &job.data_root.0, job.data.slot as u32)?;
+        let type_one = type_1_aggregate(
+            &children,
+            &job.raw_xmss,
+            &job.data_root.0,
+            job.data.slot as u32,
+        )?;
         let proof = PayloadProof {
             participants: job.bits.clone(),
             proof: VariableList::new(type_1_to_wire(&type_one))
@@ -414,11 +418,16 @@ impl Store {
     }
 
     pub async fn accept_new_attestations(&mut self) -> anyhow::Result<()> {
-        let (latest_new_aggregated_payloads_provider, latest_known_aggregated_payloads_provider) = {
+        let (
+            latest_new_aggregated_payloads_provider,
+            latest_known_aggregated_payloads_provider,
+            attestation_data_by_root_provider,
+        ) = {
             let db = self.store.lock().await;
             (
                 db.latest_new_aggregated_payloads_provider(),
                 db.latest_known_aggregated_payloads_provider(),
+                db.attestation_data_by_root_provider(),
             )
         };
 
@@ -433,6 +442,29 @@ impl Store {
             existing_proofs.append(&mut new_proofs);
 
             latest_known_aggregated_payloads_provider.insert(signature_key, existing_proofs)?;
+        }
+
+        let known = latest_known_aggregated_payloads_provider.iter()?;
+        let mut validator_max_slot: HashMap<u64, u64> = HashMap::new();
+        let mut key_slots: Vec<(SignatureKey, u64)> = Vec::with_capacity(known.len());
+        for (key, _) in &known {
+            let slot = attestation_data_by_root_provider
+                .get(key.data_root)?
+                .map(|data| data.slot)
+                .unwrap_or(0);
+            key_slots.push((key.clone(), slot));
+            validator_max_slot
+                .entry(key.validator_id)
+                .and_modify(|max| *max = (*max).max(slot))
+                .or_insert(slot);
+        }
+        let superseded: HashSet<SignatureKey> = key_slots
+            .into_iter()
+            .filter(|(key, slot)| *slot < validator_max_slot[&key.validator_id])
+            .map(|(key, _)| key)
+            .collect();
+        if !superseded.is_empty() {
+            latest_known_aggregated_payloads_provider.retain(|key, _| !superseded.contains(key))?;
         }
 
         set_int_gauge_vec(
@@ -2159,7 +2191,10 @@ impl Store {
             if let Some(attestation_data) =
                 attestation_data_by_root_provider.get(signature_key.data_root)?
             {
-                new_payloads.entry(attestation_data).or_default().extend(proofs);
+                new_payloads
+                    .entry(attestation_data)
+                    .or_default()
+                    .extend(proofs);
             }
         }
 
@@ -2168,7 +2203,10 @@ impl Store {
             if let Some(attestation_data) =
                 attestation_data_by_root_provider.get(signature_key.data_root)?
             {
-                known_payloads.entry(attestation_data).or_default().extend(proofs);
+                known_payloads
+                    .entry(attestation_data)
+                    .or_default()
+                    .extend(proofs);
             }
         }
 
@@ -2208,7 +2246,11 @@ impl Store {
                         .get(SignatureKey::from_parts(validator_id, data_root))
                         && let Some(validator) = head_state.validators.get(validator_id as usize)
                     {
-                        raw_entries.push((validator_id, validator.attestation_public_key, signature));
+                        raw_entries.push((
+                            validator_id,
+                            validator.attestation_public_key,
+                            signature,
+                        ));
                         covered_validators.insert(validator_id);
                     }
                 }
@@ -2237,7 +2279,9 @@ impl Store {
                             .get(validator_id as usize)
                             .map(|validator| validator.attestation_public_key)
                             .ok_or_else(|| {
-                                anyhow!("Validator index {validator_id} out of range during aggregation")
+                                anyhow!(
+                                    "Validator index {validator_id} out of range during aggregation"
+                                )
                             })
                     })
                     .collect::<anyhow::Result<Vec<_>>>()?;

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -2175,6 +2175,10 @@ impl Store {
         let mut keys: HashSet<AttestationData> = groups.keys().cloned().collect();
         keys.extend(new_payloads.keys().cloned());
 
+        const AGG_RECENT_SLOTS: u64 = 16;
+        let head_slot = head_state.slot;
+        keys.retain(|data| data.slot + AGG_RECENT_SLOTS >= head_slot);
+
         let mut jobs = Vec::new();
         for data in keys {
             let data_root = data.tree_hash_root();
@@ -2255,6 +2259,7 @@ impl Store {
                 raw_count,
             });
         }
+        jobs.sort_by(|a, b| b.data.slot.cmp(&a.data.slot));
         Ok(jobs)
     }
 


### PR DESCRIPTION
### What was wrong?
The expensive committee-signature aggregation and block signature verification ran inline on the consensus loop while holding the store lock. Each slot the loop blocked for the full proof time, so block import, attestation handling, and safe_target updates all froze. safe_target fell behind head and finalization plateaued. 

### How was it fixed?
Move the heavy work off the loop and off the store lock, and bound it:
- Off-loop committee aggregation
- Off-lock block-signature verification
- Bound aggregation to recent slots + prove recent-first
- Evict superseded known payloads

### To-Do
- [z] I have read [[CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md)](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/).