### PR TITLE
fix: backfill race condition and lean-spec-tests in hive

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -1003,7 +1003,29 @@ impl LeanChainService {
             );
         }
 
-        self.choose_weighted_peer(&fallback_candidates)
+        if let Some(peer_id) = self.choose_weighted_peer(&fallback_candidates) {
+            return Some(peer_id);
+        }
+
+        // Last resort: reuse the avoided peer only when it is genuinely the sole peer we are
+        // connected to. A `Reset` job avoids the peer that just failed it, but if that peer
+        // is now the only connected candidate (e.g. after a pause collapses every other
+        // connection during recovery), refusing it here deadlocks backfill forever. 
+        if avoid_peer_id.is_some()
+            && self.network_state.connected_peer_count() <= 1
+            && candidates
+                .iter()
+                .any(|(peer_id, _)| Some(*peer_id) == avoid_peer_id)
+        {
+            debug!(
+                connected = candidates.len(),
+                avoid_peer_id = ?avoid_peer_id,
+                "Only the avoided peer is connected; reusing it to avoid stalling backfill"
+            );
+            return self.choose_weighted_peer(candidates);
+        }
+
+        None
     }
 
     async fn assignable_peer_id(&self, avoid_peer_id: Option<PeerId>) -> Option<PeerId> {
@@ -2791,6 +2813,7 @@ impl LeanChainService {
     }
 
     async fn queue_pending_job_requests(&mut self) -> anyhow::Result<()> {
+        let mut deferred: Vec<PendingJobRequest> = Vec::new();
         while let Some(pending_job_request) = self.pending_job_requests.pop_front() {
             let avoid_peer_id = match &pending_job_request {
                 PendingJobRequest::Reset { peer_id } => Some(*peer_id),
@@ -2827,8 +2850,11 @@ impl LeanChainService {
                         peers_in_use = self.peers_in_use.len(),
                         "No assignable peer available for pending backfill job request",
                     );
-                    self.pending_job_requests.push_back(pending_job_request);
-                    return Ok(());
+                    // Defer instead of returning: draining the rest of the queue keeps a
+                    // single unplaceable request (e.g. a `Reset` avoiding a peer) from
+                    // head-of-line blocking other placeable requests behind it in the FIFO.
+                    deferred.push(pending_job_request);
+                    continue;
                 }
             };
             match pending_job_request {
@@ -2885,6 +2911,11 @@ impl LeanChainService {
                 }
             }
             self.peers_in_use.insert(non_queued_peer_id);
+        }
+        // Restore requests that could not be placed this tick, preserving their order, so
+        // they are retried next tick without starving the requests we just drained past.
+        for request in deferred {
+            self.pending_job_requests.push_back(request);
         }
         Ok(())
     }

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -1010,7 +1010,7 @@ impl LeanChainService {
         // Last resort: reuse the avoided peer only when it is genuinely the sole peer we are
         // connected to. A `Reset` job avoids the peer that just failed it, but if that peer
         // is now the only connected candidate (e.g. after a pause collapses every other
-        // connection during recovery), refusing it here deadlocks backfill forever. 
+        // connection during recovery), refusing it here deadlocks backfill forever.
         if avoid_peer_id.is_some()
             && self.network_state.connected_peer_count() <= 1
             && candidates

--- a/crates/common/fork_choice/lean/src/store.rs
+++ b/crates/common/fork_choice/lean/src/store.rs
@@ -1856,6 +1856,28 @@ impl Store {
         &mut self,
         signed_attestation: SignedAggregatedAttestation,
     ) -> anyhow::Result<()> {
+        self.on_gossip_aggregated_attestation_core(signed_attestation, true)
+            .await
+    }
+
+    /// Process a gossiped aggregated attestation WITHOUT verifying its
+    /// cryptographic proof.
+    ///
+    /// Only for spec-test fixtures whose proofs are mocked placeholders
+    /// (`proofSetting == 0`, carrying leanSpec's `MOCK_PROOF_PREFIX`);
+    pub async fn on_gossip_aggregated_attestation_without_verification(
+        &mut self,
+        signed_attestation: SignedAggregatedAttestation,
+    ) -> anyhow::Result<()> {
+        self.on_gossip_aggregated_attestation_core(signed_attestation, false)
+            .await
+    }
+
+    async fn on_gossip_aggregated_attestation_core(
+        &mut self,
+        signed_attestation: SignedAggregatedAttestation,
+        verify: bool,
+    ) -> anyhow::Result<()> {
         match self
             .validate_attestation(&SignedAttestation {
                 validator_id: 0,
@@ -1891,6 +1913,11 @@ impl Store {
             let data_root = data.tree_hash_root();
             let validator_ids = proof.to_validator_indices();
 
+            ensure!(
+                !validator_ids.is_empty(),
+                "Aggregated attestation has no participants"
+            );
+
             let state = self
                 .store
                 .lock()
@@ -1910,28 +1937,31 @@ impl Store {
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
-            let verification_timer =
-                start_timer(&PQ_SIG_AGGREGATED_SIGNATURES_VERIFICATION_TIME, &[]);
+            // Mocked spec-test proofs (`verify == false`) cannot be checked
+            if verify {
+                let verification_timer =
+                    start_timer(&PQ_SIG_AGGREGATED_SIGNATURES_VERIFICATION_TIME, &[]);
 
-            #[cfg(feature = "devnet5")]
-            let verification_result = type_1_from_wire(proof.proof.as_ref(), &public_keys)
-                .and_then(|type_one| type_1_verify(&type_one));
+                #[cfg(feature = "devnet5")]
+                let verification_result = type_1_from_wire(proof.proof.as_ref(), &public_keys)
+                    .and_then(|type_one| type_1_verify(&type_one));
 
-            match verification_result {
-                Ok(()) => {
-                    stop_timer(verification_timer);
-                    inc_int_counter_vec(&PQ_SIG_AGGREGATED_SIGNATURES_VALID_TOTAL, &[]);
-                    for _ in &validator_ids {
-                        inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_VALID_TOTAL, &[]);
+                match verification_result {
+                    Ok(()) => {
+                        stop_timer(verification_timer);
+                        inc_int_counter_vec(&PQ_SIG_AGGREGATED_SIGNATURES_VALID_TOTAL, &[]);
+                        for _ in &validator_ids {
+                            inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_VALID_TOTAL, &[]);
+                        }
                     }
-                }
-                Err(err) => {
-                    stop_timer(verification_timer);
-                    inc_int_counter_vec(&PQ_SIG_AGGREGATED_SIGNATURES_INVALID_TOTAL, &[]);
-                    for _ in &validator_ids {
-                        inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_INVALID_TOTAL, &[]);
+                    Err(err) => {
+                        stop_timer(verification_timer);
+                        inc_int_counter_vec(&PQ_SIG_AGGREGATED_SIGNATURES_INVALID_TOTAL, &[]);
+                        for _ in &validator_ids {
+                            inc_int_counter_vec(&PQ_SIG_ATTESTATION_SIGNATURES_INVALID_TOTAL, &[]);
+                        }
+                        return Err(anyhow!("Aggregated signature verification failed: {err}"));
                     }
-                    return Err(anyhow!("Aggregated signature verification failed: {err}"));
                 }
             }
 

--- a/crates/rpc/lean/src/handlers/test_driver.rs
+++ b/crates/rpc/lean/src/handlers/test_driver.rs
@@ -25,6 +25,8 @@ use ream_fork_choice_lean::{
     store::{LeanStoreWriter, Store},
 };
 use ream_network_spec::networks::lean_network_spec;
+#[cfg(feature = "devnet5")]
+use ream_post_quantum_crypto::lean_multisig::type_2::type_2_setup_verifier;
 use ream_post_quantum_crypto::leansig::{public_key::PublicKey, signature::Signature};
 use ream_storage::{
     db::ReamDB,
@@ -38,6 +40,11 @@ use ssz_types::{BitList, VariableList, typenum::U4096};
 use tree_hash::TreeHash;
 
 const TEST_DRIVER_ENV: &str = "HIVE_LEAN_TEST_DRIVER";
+
+/// leanSpec's mocked prover (`proofSetting: 0` fixtures) emits placeholder aggregate proofs
+/// prefixed with this sentinel and expects verifiers to accept them without cryptographic checks
+#[cfg(feature = "devnet5")]
+const MOCK_PROOF_PREFIX: &[u8] = b"\x00MOCKED-AGGREGATION-PROOF\x00";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -71,7 +78,8 @@ pub struct GenesisParams {
 pub struct StateTransitionRunRequest {
     pre: FixtureState,
     blocks: Vec<FixtureBlock>,
-    #[serde(default)]
+    // devnet4 fixtures use `expectException`; devnet5 uses `rejectionReason`. Accept both
+    #[serde(default, alias = "rejectionReason")]
     expect_exception: Option<String>,
 }
 
@@ -326,6 +334,15 @@ async fn build_genesis_store(params: Option<&GenesisParams>) -> Result<Store, Ap
         .map_err(|err| driver_error("failed to initialize fork-choice store", err))
 }
 
+/// Whether the fixture's aggregate proof is a leanSpec mock (placeholder bytes prefixed with
+/// [`MOCK_PROOF_PREFIX`]) rather than a genuine cryptographic proof.
+#[cfg(feature = "devnet5")]
+fn is_mock_aggregate_proof(fixture: &GossipAggregatedAttestationStep) -> bool {
+    hex::decode(fixture.proof.proof_data.data.trim_start_matches("0x"))
+        .map(|bytes| bytes.starts_with(MOCK_PROOF_PREFIX))
+        .unwrap_or(false)
+}
+
 fn convert_gossip_aggregate(
     fixture: &GossipAggregatedAttestationStep,
 ) -> anyhow::Result<SignedAggregatedAttestation> {
@@ -465,10 +482,18 @@ async fn apply_fork_choice_step(store: &mut Store, step: ForkChoiceStep) -> anyh
             }
             (None, None) => Err(anyhow!("tick missing time or interval")),
         },
-        ForkChoiceStep::Block { block, .. } => {
-            let block = ReamBlock::try_from(&block)?;
-            advance_to_block_slot(store, &block, true, true).await?;
-            let signed_block = blank_signed_block(block)?;
+        ForkChoiceStep::Block {
+            block,
+            tick_to_slot,
+            ..
+        } => {
+            let ream_block = ReamBlock::try_from(&block)?;
+            // Advance the store clock to the block's slot unless the fixture pins the clock
+            // (`tickToSlot: false`) to test importing a block ahead of the store clock.
+            if tick_to_slot.unwrap_or(true) {
+                advance_to_block_slot(store, &ream_block, true, true).await?;
+            }
+            let signed_block = blank_signed_block(ream_block)?;
             store.on_block(&signed_block, false).await
         }
         ForkChoiceStep::Attestation { attestation, .. } => {
@@ -480,12 +505,25 @@ async fn apply_fork_choice_step(store: &mut Store, step: ForkChoiceStep) -> anyh
             store.on_gossip_attestation(signed, false).await
         }
         ForkChoiceStep::GossipAggregatedAttestation { attestation, .. } => {
-            if let Some(attestation) = attestation {
-                store
-                    .on_gossip_aggregated_attestation(convert_gossip_aggregate(&attestation)?)
-                    .await
-            } else {
-                Ok(())
+            let Some(attestation) = attestation else {
+                return Ok(());
+            };
+            #[cfg(feature = "devnet5")]
+            {
+                // Mocked proofs (proofSetting=0) carry the MOCK_PROOF_PREFIX sentinel and
+                // can't be verified; apply the attestation to the store without the proof
+                // check so it still folds into the aggregated pool and can move the head
+                // Genuine proofs run the full pipeline after compiling the verifier bytecode.
+                let is_mocked = is_mock_aggregate_proof(&attestation);
+                let signed = convert_gossip_aggregate(&attestation)?;
+                if is_mocked {
+                    store
+                        .on_gossip_aggregated_attestation_without_verification(signed)
+                        .await
+                } else {
+                    type_2_setup_verifier();
+                    store.on_gossip_aggregated_attestation(signed).await
+                }
             }
         }
         ForkChoiceStep::Checks { .. } => Ok(()),

--- a/testing/lean-spec-tests/src/fork_choice.rs
+++ b/testing/lean-spec-tests/src/fork_choice.rs
@@ -214,7 +214,11 @@ pub async fn run_fork_choice_test(test_name: &str, test: ForkChoiceTest) -> anyh
                     type_2_setup_verifier();
                     store.on_gossip_aggregated_attestation(signed).await
                 } else {
-                    validate_mock_aggregated_attestation(&mut store, &signed).await
+                    // Mock proofs (proofSetting != 1) can't be verified, but the
+                    // attestation must still be applied so it can move the head
+                    store
+                        .on_gossip_aggregated_attestation_without_verification(signed)
+                        .await
                 };
 
                 match valid {
@@ -413,47 +417,6 @@ async fn validate_checks(store: &Store, checks: &StoreChecks) -> anyhow::Result<
 fn decode_hex_bytes(value: &str) -> anyhow::Result<Vec<u8>> {
     hex::decode(value.trim_start_matches("0x"))
         .map_err(|err| anyhow!("Failed to decode hex bytes: {err}"))
-}
-
-/// Validate an aggregated attestation whose cryptographic proof is mocked.
-///
-/// Runs the attestation-data validation that the spec's
-/// `on_gossip_aggregated_attestation` performs, plus the structural participant
-/// checks, while skipping the cryptographic proof verification.
-async fn validate_mock_aggregated_attestation(
-    store: &mut Store,
-    signed: &SignedAggregatedAttestation,
-) -> anyhow::Result<()> {
-    store
-        .validate_attestation(&SignedAttestation {
-            validator_id: 0,
-            message: signed.data.clone(),
-            signature: Signature::blank(),
-        })
-        .await?;
-
-    let validator_ids = signed.proof.to_validator_indices();
-    ensure!(
-        !validator_ids.is_empty(),
-        "Aggregated attestation has no participants"
-    );
-
-    let validator_count = {
-        let db = store.store.lock().await;
-        db.state_provider()
-            .get(signed.data.target.root)?
-            .ok_or_else(|| anyhow!("No state available for target {}", signed.data.target.root))?
-            .validators
-            .len()
-    };
-    for validator in validator_ids {
-        ensure!(
-            (validator as usize) < validator_count,
-            "Participant {validator} outside validator registry of size {validator_count}"
-        );
-    }
-
-    Ok(())
 }
 
 /// Run the validation portion of `on_gossip_attestation` so the runner can

--- a/testing/lean-spec-tests/src/types/fork_choice.rs
+++ b/testing/lean-spec-tests/src/types/fork_choice.rs
@@ -34,7 +34,7 @@ pub enum ForkChoiceStep {
         time: Option<u64>,
         #[serde(default)]
         interval: Option<u64>,
-        #[serde(default)]
+        #[serde(default, rename = "hasProposal")]
         has_proposal: Option<bool>,
     },
     Block {


### PR DESCRIPTION
### What was wrong?

All the changes mentioned in the [Hive ream tests doc](https://hackmd.io/@Ayhm2-FHQhSLkoc1OEcr9g/Bkoz3IwXzl)

### How was it fixed?

- adding the check for preventing the race condition, if the only peer available is the one in Reset rather than earlier going into an infinite loop and get stuck in syncing, try to reuse it if it is the only one available rather than hard rejection on the peer
- use the MOCK_PROOF_PREFIX from the leanSpec for mock proof aggregation in the test driver
- adding proper alias for relevant exception fields and tick related fields. 


All 117 fork choice spec tests and all the state transition tests are now passing, earlier about 39 of these in total were failing on hive. 

[Fork Choice]
<img width="1448" height="677" alt="image" src="https://github.com/user-attachments/assets/8df51fd5-e1a8-4de3-827b-810a0694e822" />


[State Transition]
<img width="1462" height="774" alt="image" src="https://github.com/user-attachments/assets/e37a2d69-65e1-478f-8216-4fc4520db11f" />


### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
