### PR TITLE
fix(lean): accept rejectionReason in lean state-transition test driver

### DIFF
--- a/crates/rpc/lean/src/handlers/test_driver.rs
+++ b/crates/rpc/lean/src/handlers/test_driver.rs
@@ -77,8 +77,12 @@ pub struct GenesisParams {
 pub struct StateTransitionRunRequest {
     pre: FixtureState,
     blocks: Vec<FixtureBlock>,
+    /// devnet4 fixtures name it `expectException`
     #[serde(default)]
     expect_exception: Option<String>,
+    /// devnet5 fixtures name it `rejectionReason`
+    #[serde(default)]
+    rejection_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -614,7 +618,9 @@ pub async fn run_state_transition(
         .map_err(|err| driver_error("failed to convert pre-state", err))?;
 
     let result = apply_state_transition_blocks(&mut state, &request.blocks).and_then(|()| {
-        if request.blocks.is_empty() && request.expect_exception.is_some() {
+        if request.blocks.is_empty()
+            && (request.expect_exception.is_some() || request.rejection_reason.is_some())
+        {
             let target_slot = state.slot;
             state
                 .process_slots(target_slot)


### PR DESCRIPTION
### What was wrong?

<img width="1389" height="569" alt="image" src="https://github.com/user-attachments/assets/d3980f6c-6feb-4cc4-b994-e54202251ead" />

Currently see that we have two error on two test on `lean-spec-tests-state-transition`:
<img width="1890" height="160" alt="image" src="https://github.com/user-attachments/assets/dcbdc1d6-e547-46a9-937f-1355bbd635fb" />

=> `test_driver.rs` didn't handle rejectionReason (the devnet5 field for expected failures), so those fixtures were treated as successes.

### How was it fixed?

- Add `rejection_reason` to `StateTransitionRunRequest` in `test_driver.rs` and inside `run_state_transition` func.

### Notes:

- The `rejection_reason` is already added to our `StateTransitionTest` on `testing/lean-spec-tests/src/types/state_transition.rs`, that's why when we run:
```
cargo +stable test -p lean-spec-tests --no-default-features --features devnet5 \
  --test tests test_all_state_transition_fixtures -- --nocapture 
```
It passed all without above fix.

- I have re-produced on local and it worked it successfully.
   
### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
