### PR TITLE
fix: prevents the prune_old_state() from deleting unfinalized history

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -2882,7 +2882,7 @@ impl LeanChainService {
     }
 
     async fn prune_old_state(&self, tick_count: u64) -> anyhow::Result<()> {
-        let (head, block_provider, slot_index_provider, state_provider) = {
+        let (slot_index_provider, state_provider, latest_finalized_slot) = {
             let fork_choice = self.store.read().await;
             let store = fork_choice.store.lock().await;
 
@@ -2892,21 +2892,14 @@ impl LeanChainService {
                 warn!("Failed to report storage metrics: {err:?}");
             }
             (
-                store.head_provider().get()?,
-                store.block_provider(),
                 store.slot_index_provider(),
                 store.state_provider(),
+                store.latest_finalized_provider().get()?.slot,
             )
         };
 
-        let head_slot = block_provider
-            .get(head)?
-            .ok_or_else(|| anyhow!("State not found for head: {head}"))?
-            .block
-            .slot;
-
-        if head_slot > STATE_RETENTION_SLOTS {
-            let prune_target_slot = head_slot - STATE_RETENTION_SLOTS;
+        if latest_finalized_slot > STATE_RETENTION_SLOTS {
+            let prune_target_slot = latest_finalized_slot - STATE_RETENTION_SLOTS;
             let mut scan = prune_target_slot;
             let mut prune_root = None;
             loop {

--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -2899,7 +2899,7 @@ impl LeanChainService {
         };
 
         if latest_finalized_slot > STATE_RETENTION_SLOTS {
-            let prune_target_slot = latest_finalized_slot - STATE_RETENTION_SLOTS;
+            let prune_target_slot = latest_finalized_slot - 1;
             let mut scan = prune_target_slot;
             let mut prune_root = None;
             loop {


### PR DESCRIPTION
### What was wrong?

<img width="421" height="117" alt="image" src="https://github.com/user-attachments/assets/2ff87e9c-0ee0-4dd1-90f4-b8379dec8396" />

### How was it fixed?
Moves pruning behind finalization so the unfinalized active state history is not deleted.

Uses latest_finalized_slot instead of head_slot because using the latest_finalized_slot prevents the prune_old_state() function from pruning the state before the network has officially finalized it. Before, using head_slot caused the pruner to target unfinalized moving blocks which deleted active history and triggered the deeper than 128 slot reorg crash mega had mentioned

