### PR TITLE
feat: implement fulu enr support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ actix-web = "4.11.0"
 actix-web-lab = "0.24.3"
 aes = "0.8.4"
 alloy-consensus = { version = "1.0.41", default-features = false }
-alloy-primitives = { version = "1.4.1", features = ['serde'] }
+alloy-primitives = { version = "1.4.1", features = ['serde', 'rlp'] }
 alloy-rlp = { version = "0.3.12", default-features = false, features = [
     "derive",
 ] }

--- a/crates/common/network_spec/src/networks/beacon.rs
+++ b/crates/common/network_spec/src/networks/beacon.rs
@@ -208,10 +208,20 @@ pub struct BeaconNetworkSpec {
 impl BeaconNetworkSpec {
     pub fn fork_digest(&self, epoch: u64, genesis_validators_root: B256) -> B32 {
         let fork_data = ForkData {
-            current_version: self.fulu_fork_version,
+            current_version: self.current_fork_version(epoch),
             genesis_validators_root,
         };
         compute_fork_digest(fork_data, epoch)
+    }
+
+    pub fn current_fork_version(&self, epoch: u64) -> B32 {
+        self.fork_schedule()
+            .0
+            .iter()
+            .rev()
+            .find(|fork| fork.epoch <= epoch)
+            .map(|fork| fork.current_version)
+            .unwrap_or(self.genesis_fork_version)
     }
 
     pub fn fork_schedule(&self) -> ForkSchedule {

--- a/crates/networking/discv5/src/discovery.rs
+++ b/crates/networking/discv5/src/discovery.rs
@@ -33,8 +33,8 @@ use crate::{
     eth2::{ENR_ETH2_KEY, EnrForkId},
     subnet::{
         ATTESTATION_BITFIELD_ENR_KEY, AttestationSubnets, CUSTODY_GROUP_COUNT_ENR_KEY,
-        EPOCHS_PER_SUBNET_SUBSCRIPTION, NEXT_FORK_DIGEST_ENR_KEY, NextForkDigest,
-        SYNC_COMMITTEE_BITFIELD_ENR_KEY, attestation_subnet_predicate, compute_subscribed_subnets,
+        EPOCHS_PER_SUBNET_SUBSCRIPTION, NEXT_FORK_DIGEST_ENR_KEY, SYNC_COMMITTEE_BITFIELD_ENR_KEY,
+        attestation_subnet_predicate, compute_subscribed_subnets, next_fork_digest,
         sync_committee_subnet_predicate,
     },
 };
@@ -91,6 +91,7 @@ impl Discovery {
     ) -> anyhow::Result<Self> {
         let enr_local =
             convert_to_enr(local_key).map_err(|err| anyhow!("Failed to convert key: {err:?}"))?;
+        let current_epoch = compute_epoch_at_slot(current_slot);
 
         let mut enr_builder = Enr::builder();
         enr_builder.ip(config.socket_address);
@@ -98,14 +99,17 @@ impl Discovery {
         enr_builder.udp4(config.discovery_port);
 
         let enr = enr_builder
-            .add_value(ENR_ETH2_KEY, &EnrForkId::electra(genesis_validators_root()))
+            .add_value(
+                ENR_ETH2_KEY,
+                &EnrForkId::current(genesis_validators_root(), current_epoch),
+            )
             .add_value(ATTESTATION_BITFIELD_ENR_KEY, &config.attestation_subnets)
             .add_value(
                 SYNC_COMMITTEE_BITFIELD_ENR_KEY,
                 &config.sync_committee_subnets,
             )
             .add_value(CUSTODY_GROUP_COUNT_ENR_KEY, &config.custody_group_count)
-            .add_value(NEXT_FORK_DIGEST_ENR_KEY, &NextForkDigest::default())
+            .add_value(NEXT_FORK_DIGEST_ENR_KEY, &next_fork_digest(current_epoch))
             .build(&enr_local)
             .map_err(|err| anyhow!("Failed to build ENR: {err}"))?;
 
@@ -126,8 +130,7 @@ impl Discovery {
         }
 
         // Compute and set attestation subnets
-        let subnets =
-            compute_subscribed_subnets(enr.node_id(), compute_epoch_at_slot(current_slot))?;
+        let subnets = compute_subscribed_subnets(enr.node_id(), current_epoch)?;
         let mut config = config.clone();
         config.attestation_subnets = AttestationSubnets::new();
         for subnet_id in subnets {
@@ -136,7 +139,7 @@ impl Discovery {
                 .enable_attestation_subnet(subnet_id)?;
         }
 
-        let subscription_epoch = compute_epoch_at_slot(current_slot);
+        let subscription_epoch = current_epoch;
 
         let event_stream = if !config.disable_discovery {
             discv5

--- a/crates/networking/discv5/src/eth2.rs
+++ b/crates/networking/discv5/src/eth2.rs
@@ -1,9 +1,6 @@
 use alloy_primitives::{B256, aliases::B32};
 use alloy_rlp::{BufMut, Decodable, Encodable, bytes::Bytes};
-use ream_consensus_misc::{
-    constants::beacon::{ELECTRA_FORK_EPOCH, FAR_FUTURE_EPOCH},
-    fork_data::{ForkData, compute_fork_digest},
-};
+use ream_consensus_misc::constants::beacon::FAR_FUTURE_EPOCH;
 use ream_network_spec::networks::beacon_network_spec;
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
@@ -19,17 +16,32 @@ pub struct EnrForkId {
 }
 
 impl EnrForkId {
-    pub fn electra(genesis_validators_root: B256) -> Self {
-        let current_fork_version = beacon_network_spec().electra_fork_version;
-        let next_fork_version = current_fork_version;
-        let next_fork_epoch = FAR_FUTURE_EPOCH;
+    pub fn current(genesis_validators_root: B256, epoch: u64) -> Self {
+        let spec = beacon_network_spec();
 
-        let fork_data = ForkData {
-            current_version: current_fork_version,
-            genesis_validators_root,
+        let fork_digest = spec.fork_digest(epoch, genesis_validators_root);
+
+        let fork_schedule = spec.fork_schedule();
+
+        let current_version = spec.current_fork_version(epoch);
+
+        let next_regular_fork = fork_schedule.0.iter().find(|fork| fork.epoch > epoch);
+
+        let next_bpo_epoch = spec
+            .blob_schedule
+            .iter()
+            .map(|params| params.epoch)
+            .filter(|&bpo_epoch| bpo_epoch > epoch)
+            .min();
+
+        let (next_fork_version, next_fork_epoch) = match (next_regular_fork, next_bpo_epoch) {
+            (Some(regular), Some(bpo)) if regular.epoch <= bpo => {
+                (regular.current_version, regular.epoch)
+            }
+            (Some(regular), None) => (regular.current_version, regular.epoch),
+            (_, Some(bpo)) => (current_version, bpo),
+            (None, None) => (current_version, FAR_FUTURE_EPOCH),
         };
-
-        let fork_digest = compute_fork_digest(fork_data, ELECTRA_FORK_EPOCH);
 
         Self {
             fork_digest,

--- a/crates/networking/discv5/src/subnet.rs
+++ b/crates/networking/discv5/src/subnet.rs
@@ -2,7 +2,11 @@ use alloy_primitives::{B256, aliases::B32};
 use alloy_rlp::{BufMut, Decodable, Encodable, bytes::Bytes};
 use anyhow::{anyhow, ensure};
 use discv5::{Enr, enr::NodeId};
-use ream_consensus_misc::misc::compute_shuffled_index;
+use ream_consensus_misc::{
+    constants::beacon::{FAR_FUTURE_EPOCH, genesis_validators_root},
+    misc::compute_shuffled_index,
+};
+use ream_network_spec::networks::beacon_network_spec;
 use sha2::{Digest, Sha256};
 use ssz::{Decode, Encode};
 use ssz_types::{
@@ -10,6 +14,8 @@ use ssz_types::{
     typenum::{U4, U64},
 };
 use tracing::{error, trace};
+
+use crate::eth2::EnrForkId;
 
 pub const ATTESTATION_BITFIELD_ENR_KEY: &str = "attnets";
 pub const ATTESTATION_SUBNET_COUNT: usize = 64;
@@ -203,6 +209,18 @@ impl Decodable for NextForkDigest {
             ))
         })?;
         Ok(Self(digest))
+    }
+}
+
+pub fn next_fork_digest(current_epoch: u64) -> NextForkDigest {
+    let fork_id = EnrForkId::current(genesis_validators_root(), current_epoch);
+
+    if fork_id.next_fork_epoch == FAR_FUTURE_EPOCH {
+        NextForkDigest::default()
+    } else {
+        let digest =
+            beacon_network_spec().fork_digest(fork_id.next_fork_epoch, genesis_validators_root());
+        NextForkDigest(digest)
     }
 }
 


### PR DESCRIPTION
### What was wrong?

Implements the remaining Fulu discovery ENR changes required by spec.

Previously, discovery ENRs always advertised the Electra fork digest and did not account for upcoming fork. 

### How was it fixed?

- Made `ENRForkID` generation fork-aware instead of hardcoding Electra.
- Updated ENR construction to compute the current fork digest from the active fork schedule.
- Added support for the Fulu discovery ENR fields required by the specification.
- Computed and advertised the next fork digest (`nfd`) when applicable.
- Updated discovery ENR generation to reflect current and upcoming forks.

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
