### PR TITLE
fix(lean): spec tests for flat justification validator bits

### DIFF
--- a/crates/common/consensus/lean/src/state.rs
+++ b/crates/common/consensus/lean/src/state.rs
@@ -497,13 +497,6 @@ impl LeanState {
                 if is_target_next_valid_justifiable_slot {
                     let delta = (attestation.source().slot - self.latest_finalized.slot) as usize;
                     if delta > 0 {
-                        ensure!(
-                            justifications_map
-                                .keys()
-                                .all(|root| root_to_slot.contains_key(root)),
-                            "Justification root missing from root_to_slot"
-                        );
-
                         let mut new_bitlist =
                             BitList::with_capacity(self.justified_slots.len() - delta)
                                 .map_err(|err| anyhow!("Failed to create BitList: {err:?}"))?;
@@ -517,6 +510,8 @@ impl LeanState {
                         }
                         self.justified_slots = new_bitlist;
 
+                        // Drop pending tallies for roots that are no longer on the canonical
+                        // finalized window. Roots outside root_to_slot are off-chain here.
                         justifications_map.retain(|root, _| match root_to_slot.get(root) {
                             Some(slots) => *slots > attestation.source().slot,
                             None => false,

--- a/testing/lean-spec-tests/src/types/fork_choice.rs
+++ b/testing/lean-spec-tests/src/types/fork_choice.rs
@@ -127,22 +127,16 @@ impl TryFrom<State> for LeanState {
             .map_err(|err| anyhow!("Failed to create justifications_roots VariableList: {err}"))?;
 
         let justifications_validators = {
-            let validator_count = validators.len();
-            let total_bits = state.justifications_validators.data.len() * validator_count;
+            let bits = &state.justifications_validators.data;
 
-            let mut bitlist = ssz_types::BitList::with_capacity(total_bits).map_err(|err| {
+            let mut bitlist = ssz_types::BitList::with_capacity(bits.len()).map_err(|err| {
                 anyhow!("Failed to create BitList for justifications_validators: {err:?}")
             })?;
 
-            for (root_index, validator_list) in
-                state.justifications_validators.data.iter().enumerate()
-            {
-                for &validator_index in validator_list {
-                    let flat_index = root_index * validator_count + validator_index as usize;
-                    bitlist.set(flat_index, true).map_err(|err| {
-                        anyhow!("Failed to set bit at flat index {flat_index}: {err:?}")
-                    })?;
-                }
+            for (index, &bit) in bits.iter().enumerate() {
+                bitlist
+                    .set(index, bit)
+                    .map_err(|err| anyhow!("Failed to set bit at index {index}: {err:?}"))?;
             }
             bitlist
         };

--- a/testing/lean-spec-tests/src/types/mod.rs
+++ b/testing/lean-spec-tests/src/types/mod.rs
@@ -161,7 +161,7 @@ pub struct State {
     pub justified_slots: DataList<bool>,
     pub validators: DataList<Validator>,
     pub justifications_roots: DataList<B256>,
-    pub justifications_validators: DataList<Vec<u64>>,
+    pub justifications_validators: DataList<bool>,
 }
 
 impl<T> DataList<T> {


### PR DESCRIPTION
### What was wrong?

The latest upstream `leanSpec` fixtures - https://github.com/leanEthereum/leanSpec/releases/tag/latest - now encode `justificationsValidators` as a flat boolean bitlist, while the Rust lean spec test harness still expected per-root validator index lists.
=> This lead to `lean-specs-tests` ci failed

The updated fixtures also exposed a mismatch in stale pending justification handling. When finalization moves forward, leanSpec removes stale votes for off-chain roots, but Ream returned an error. This has been fixed.

### How was it fixed?

- Updated lean spec fixture parsing so `justifications_validators` is read as `DataList<bool>`.
- Updated the fork-choice fixture conversion to build the `BitList` directly from the flat boolean list.
- Updated Lean state transition finalization rebase to retain only pending justification tallies whose roots remain on the canonical unfinalized window, dropping off-chain roots.

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
