### PR TITLE
perf: activate `unprefixed_malloc_on_supported_platforms` on `tikv-jemallocator`

### DIFF
--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -45,7 +45,9 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 ssz_types.workspace = true
-tikv-jemallocator.workspace = true
+tikv-jemallocator = { workspace = true, features = [
+    "unprefixed_malloc_on_supported_platforms",
+] }
 tokio.workspace = true
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }


### PR DESCRIPTION
### What was wrong?

 <!-- Describe in a sentence or two of the reason for this PR. Link to the issue if possible.  -->

 | Client | Start | 30 min | 1 hr | Peak |
  |---|---|---|---|---|
  | ream (master branch) | 1461 MB | 2496 MB | 2881 MB | 3370 MB |
  | ream (this PR) | 603 MB | 726 MB | 832 MB | 1773 MB |
  | ethlambda | 469 MB | 480 MB | 589 MB | 1537 MB |


### How was it fixed?

 <!-- List the approach you used, and/or changes made to the codebase  -->

Activates `unprefixed_malloc_on_supported_platforms` feature on `tikv-jemallocator`.

I've found that ethlambda also uses this. https://github.com/lambdaclass/ethlambda/blob/c61165a2456f8ea91843a2104a63834e5fc712b4/Cargo.toml#L79

### To-Do

 <!-- Stay ahead of things, add list items here!  -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [ ] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
