### PR TITLE
feat: add local genesis bootstrap support + fix node identity compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ CARGO_INSTALL_EXTRA_FLAGS ?=
 
 CARGO_TARGET_DIR ?= target
 
+IMAGE ?= ream-local
+TAG ?= dev
+
 ##@ Help
 
 .PHONY: help
@@ -139,3 +142,12 @@ docker-build-push:
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		--provenance=false \
 		--push
+
+.PHONY: docker-local
+docker-local:
+	docker build \
+		-f Dockerfile \
+		--build-arg BUILD_PROFILE=release \
+		--build-arg FEATURES="$(FEATURES)" \
+		-t $(IMAGE):$(TAG) \
+		.

--- a/bin/ream/src/cli/beacon_node.rs
+++ b/bin/ream/src/cli/beacon_node.rs
@@ -12,7 +12,6 @@ use crate::cli::constants::{
     DEFAULT_HTTP_ALLOW_ORIGIN, DEFAULT_HTTP_PORT, DEFAULT_NETWORK, DEFAULT_SOCKET_ADDRESS,
     DEFAULT_SOCKET_PORT,
 };
-
 #[derive(Debug, Parser)]
 pub struct BeaconNodeConfig {
     #[arg(
@@ -59,6 +58,17 @@ pub struct BeaconNodeConfig {
         help = "Weak subjectivity checkpoint in format <0xblock_root>:<epoch>"
     )]
     pub weak_subjectivity_checkpoint: Option<Checkpoint>,
+
+    #[arg(
+        long,
+        help = "Path to an SSZ-encoded genesis BeaconState file. Bootstraps the database directly \
+            from genesis, skipping checkpoint sync entirely. Use this for local devnets (e.g. \
+            Kurtosis) where no already-synced peer exists to checkpoint-sync from. Mutually \
+            exclusive with --checkpoint-sync-url in practice — if both are unset and the network \
+            has no default checkpoint sync sources (dev, custom), startup will fail.",
+        conflicts_with = "checkpoint_sync_url"
+    )]
+    pub genesis_state_path: Option<PathBuf>,
 
     #[arg(
         long,

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -33,7 +33,9 @@ use ream_chain_beacon::beacon_chain::BeaconChain;
 use ream_chain_lean::{
     messages::LeanChainServiceMessage, p2p_request::LeanP2PRequest, service::LeanChainService,
 };
-use ream_checkpoint_sync_beacon::initialize_db_from_checkpoint;
+use ream_checkpoint_sync_beacon::{
+    initialize_db_from_checkpoint, initialize_db_from_genesis_state,
+};
 use ream_checkpoint_sync_lean::{LeanCheckpointClient, verify_checkpoint_state};
 #[cfg(feature = "devnet5")]
 use ream_consensus_lean::attestation::MultiMessageAggregate;
@@ -508,13 +510,18 @@ async fn run_beacon_node_inner(
 
     info!("ream beacon database has been initialized");
 
-    let _is_ws_verified = initialize_db_from_checkpoint(
-        beacon_db.clone(),
-        config.checkpoint_sync_url.clone(),
-        config.weak_subjectivity_checkpoint,
-    )
-    .await
-    .expect("Unable to initialize database from checkpoint");
+    if let Some(genesis_state_path) = &config.genesis_state_path {
+        initialize_db_from_genesis_state(beacon_db.clone(), genesis_state_path)
+            .expect("Unable to initialize database from genesis state");
+    } else {
+        let _is_ws_verified = initialize_db_from_checkpoint(
+            beacon_db.clone(),
+            config.checkpoint_sync_url.clone(),
+            config.weak_subjectivity_checkpoint,
+        )
+        .await
+        .expect("Unable to initialize database from checkpoint");
+    }
 
     info!("Database Initialization completed");
 

--- a/book/cli/ream/beacon_node.md
+++ b/book/cli/ream/beacon_node.md
@@ -31,6 +31,8 @@ Options:
           Trusted RPC URL to initiate Checkpoint Sync.
       --weak-subjectivity-checkpoint <WEAK_SUBJECTIVITY_CHECKPOINT>
           Weak subjectivity checkpoint in format <0xblock_root>:<epoch>
+      --genesis-state-path <GENESIS_STATE_PATH>
+          Path to an SSZ-encoded genesis BeaconState file. Bootstraps the database directly from genesis, skipping checkpoint sync entirely. Use this for local devnets (e.g. Kurtosis) where no already-synced peer exists to checkpoint-sync from. Mutually exclusive with --checkpoint-sync-url in practice — if both are unset and the network has no default checkpoint sync sources (dev, custom), startup will fail.
       --execution-endpoint <EXECUTION_ENDPOINT>
           The URL of the execution endpoint. This is used to send requests to the engine api.
       --execution-jwt-secret <EXECUTION_JWT_SECRET>

--- a/crates/common/checkpoint_sync/beacon/src/lib.rs
+++ b/crates/common/checkpoint_sync/beacon/src/lib.rs
@@ -1,12 +1,17 @@
 pub mod checkpoint;
 pub mod weak_subjectivity;
 
+use std::{fs, path::Path};
+
 use alloy_primitives::B256;
 use anyhow::{anyhow, ensure};
 use checkpoint::get_checkpoint_sync_sources;
 use ream_consensus_beacon::{
     blob_sidecar::{BlobIdentifier, BlobSidecar},
-    electra::{beacon_block::SignedBeaconBlock, beacon_state::BeaconState},
+    electra::{
+        beacon_block::{BeaconBlock, SignedBeaconBlock},
+        beacon_state::BeaconState,
+    },
 };
 use ream_consensus_misc::checkpoint::Checkpoint;
 use ream_execution_rpc_types::get_blobs::BlobAndProofV1;
@@ -23,6 +28,7 @@ use reqwest::{
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
 use tracing::{info, warn};
+use tree_hash::TreeHash;
 use weak_subjectivity::{WeakSubjectivityState, verify_state_from_weak_subjectivity_checkpoint};
 
 /// Entry point for checkpoint sync.
@@ -56,7 +62,15 @@ pub async fn initialize_db_from_checkpoint(
         return Ok(WeakSubjectivityState::CheckpointAlreadyVerified);
     }
 
-    let checkpoint_sync_url = get_checkpoint_sync_sources(checkpoint_sync_url).remove(0);
+    let sources = get_checkpoint_sync_sources(checkpoint_sync_url);
+    ensure!(
+        !sources.is_empty(),
+        "No checkpoint sync source available for network {:?}. Pass --checkpoint-sync-url \
+         explicitly, use --genesis-state-path for a fresh local devnet, or use a network with \
+         default checkpoint sync sources (mainnet, sepolia, hoodi).",
+        beacon_network_spec().network
+    );
+    let checkpoint_sync_url = sources.into_iter().next().expect("checked non-empty above");
     info!("Initiating checkpoint sync");
 
     info!("Fetching finalized block...");
@@ -102,6 +116,57 @@ pub async fn initialize_db_from_checkpoint(
         return Ok(WeakSubjectivityState::None);
     }
     Ok(WeakSubjectivityState::CheckpointAlreadyVerified)
+}
+
+// Bootstrap the database directly from a local genesis state file (SSZ-encoded BeaconState),
+/// skipping checkpoint sync entirely for local devnets (e.g. Kurtosis)
+pub fn initialize_db_from_genesis_state(
+    db: BeaconDB,
+    genesis_state_path: &Path,
+) -> anyhow::Result<()> {
+    if db.is_initialized() {
+        warn!("DB is already initialized. Skipping genesis bootstrap.");
+        return Ok(());
+    }
+
+    info!(
+        "Bootstrapping from local genesis state: {}",
+        genesis_state_path.display()
+    );
+
+    let raw_bytes = fs::read(genesis_state_path).map_err(|err| {
+        anyhow!(
+            "Failed to read genesis state file {}: {err}",
+            genesis_state_path.display()
+        )
+    })?;
+
+    info!("Read {} bytes from genesis.ssz", raw_bytes.len());
+
+    let genesis_state = BeaconState::from_ssz_bytes(&raw_bytes)
+        .map_err(|err| anyhow!("Unable to decode genesis state from ssz bytes: {err:?}"))?;
+
+    let genesis_block = BeaconBlock {
+        slot: genesis_state.slot,
+        proposer_index: 0,
+        parent_root: B256::ZERO,
+        state_root: genesis_state.tree_hash_root(),
+        ..Default::default()
+    };
+
+    info!(
+        "genesis_time={}, genesis_validators_root={}",
+        genesis_state.genesis_time, genesis_state.genesis_validators_root
+    );
+
+    let mut store = get_forkchoice_store(genesis_state.clone(), genesis_block, db)?;
+
+    let time = genesis_state.genesis_time
+        + beacon_network_spec().seconds_per_slot() * (genesis_state.slot + 1);
+    on_tick(&mut store, time)?;
+
+    info!("Genesis bootstrap complete");
+    Ok(())
 }
 
 /// Fetch initial state from trusted RPC

--- a/crates/rpc/beacon/src/handlers/identity.rs
+++ b/crates/rpc/beacon/src/handlers/identity.rs
@@ -12,8 +12,10 @@ use serde::{Deserialize, Serialize};
 pub struct Identity {
     pub peer_id: String,
     pub enr: String,
-    pub p2p_address: Vec<String>,
-    pub discovery_address: Vec<String>,
+    #[serde(alias = "p2p_address")]
+    pub p2p_addresses: Vec<String>,
+    #[serde(alias = "discovery_address")]
+    pub discovery_addresses: Vec<String>,
     pub metadata: GetMetaDataV3,
 }
 
@@ -23,7 +25,7 @@ impl Identity {
         Self {
             peer_id: peer_id.to_string(),
             enr: enr.to_base64(),
-            p2p_address: {
+            p2p_addresses: {
                 let mut addresses = Vec::new();
 
                 if let Some(ip4) = enr.ip4()
@@ -39,7 +41,7 @@ impl Identity {
 
                 addresses
             },
-            discovery_address: {
+            discovery_addresses: {
                 let mut addresses = Vec::new();
 
                 if let Some(ip4) = enr.ip4()


### PR DESCRIPTION
## What does this PR do?

Adds support for running Ream in Kurtosis devnets using local genesis files and improves compatibility with the ethereum-package.

### Changes

- **Genesis support**: 
  - Added `initialize_db_from_genesis_state()` function to bootstrap from `--genesis-state-path` (used by Kurtosis `el_cl_genesis_data/genesis.ssz`).
  - Updated `run_beacon_node` to call genesis bootstrap when provided instead of only checkpoint sync.
  
- **Node Identity**:
  - Updated `/eth/v1/node/identity` response to use standard field names (`p2p_addresses`, `discovery_addresses`) expected by Kurtosis Starlark and other clients.
  - Added serde aliases for backward compatibility.

- **Build / Makefile**:
  - Updated to properly handle genesis artifacts for devnet testing.

 <!-- Stay ahead of things, add list items here!  -->
- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
