### PR TITLE
fix(gossip): align data column sidecar validation with spec

### DIFF
--- a/crates/networking/manager/src/gossipsub/handle.rs
+++ b/crates/networking/manager/src/gossipsub/handle.rs
@@ -1,3 +1,5 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use libp2p::gossipsub::Message;
 use ream_chain_beacon::beacon_chain::BeaconChain;
 use ream_consensus_beacon::{
@@ -468,9 +470,18 @@ pub async fn handle_gossipsub_message(
                     }
                 };
 
+                let current_time_ms = match SystemTime::now().duration_since(UNIX_EPOCH) {
+                    Ok(duration) => u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+                    Err(err) => {
+                        error!("Failed to get current time for data column validation: {err}");
+                        return;
+                    }
+                };
+
                 let validation_result = match validate_data_column_sidecar_full(
                     &data_column_sidecar,
                     beacon_chain,
+                    current_time_ms,
                     subnet_id,
                     cached_db,
                 )

--- a/crates/networking/manager/src/gossipsub/validate/data_column_sidecar.rs
+++ b/crates/networking/manager/src/gossipsub/validate/data_column_sidecar.rs
@@ -1,8 +1,15 @@
 use anyhow::anyhow;
+use ream_bls::traits::Verifiable;
 use ream_chain_beacon::beacon_chain::BeaconChain;
-use ream_consensus_beacon::data_column_sidecar::DataColumnSidecar;
-use ream_consensus_misc::misc::compute_start_slot_at_epoch;
-use ream_polynomial_commitments::handlers::verify_cell_kzg_proof_batch;
+use ream_consensus_beacon::{
+    data_column_sidecar::DataColumnSidecar, electra::beacon_state::BeaconState,
+};
+use ream_consensus_misc::{
+    constants::beacon::{DOMAIN_BEACON_PROPOSER, GENESIS_SLOT},
+    misc::{compute_epoch_at_slot, compute_signing_root, compute_start_slot_at_epoch},
+};
+use ream_network_spec::networks::beacon_network_spec;
+use ream_polynomial_commitments::handlers::verify_data_column_sidecar_kzg_proofs;
 use ream_storage::{
     cache::BeaconCacheDB,
     tables::{field::REDBField, table::REDBTable},
@@ -13,9 +20,27 @@ use super::result::ValidationResult;
 pub async fn validate_data_column_sidecar_full(
     data_column_sidecar: &DataColumnSidecar,
     beacon_chain: &BeaconChain,
+    current_time_ms: u64,
     subnet_id: u64,
     cached_db: &BeaconCacheDB,
 ) -> anyhow::Result<ValidationResult> {
+    let header = &data_column_sidecar.signed_block_header.message;
+    let tuple = (
+        header.slot,
+        header.proposer_index,
+        data_column_sidecar.index,
+    );
+    if cached_db
+        .seen_data_column_sidecars
+        .read()
+        .await
+        .contains(&tuple)
+    {
+        return Ok(ValidationResult::Ignore(
+            "Already seen sidecar from this proposer for this slot and index".to_string(),
+        ));
+    }
+
     if !data_column_sidecar.verify() {
         return Ok(ValidationResult::Reject(
             "Data column sidecar failed basic verification".to_string(),
@@ -28,23 +53,21 @@ pub async fn validate_data_column_sidecar_full(
         ));
     }
 
-    let header = &data_column_sidecar.signed_block_header.message;
     let store = beacon_chain.store.lock().await;
+    let head_root = store.get_head()?;
+    let state: BeaconState = store
+        .db
+        .state_provider()
+        .get(head_root)?
+        .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
 
-    if header.slot > store.get_current_slot()? {
+    if !is_not_from_future_slot(&state, header.slot, current_time_ms) {
         return Ok(ValidationResult::Ignore(
             "The sidecar is from a future slot".to_string(),
         ));
     }
 
     let finalized_checkpoint = store.db.finalized_checkpoint_provider().get()?;
-    let head_root = store.get_head()?;
-    let state = store
-        .db
-        .state_provider()
-        .get(head_root)?
-        .ok_or_else(|| anyhow!("No beacon state found for head root: {head_root}"))?;
-
     if header.slot <= compute_start_slot_at_epoch(finalized_checkpoint.epoch) {
         return Ok(ValidationResult::Ignore(
             "The sidecar is from a slot less than or equal to the latest finalized slot"
@@ -52,18 +75,41 @@ pub async fn validate_data_column_sidecar_full(
         ));
     }
 
-    if !state.verify_block_header_signature(&data_column_sidecar.signed_block_header)? {
+    let Some(proposer) = usize::try_from(header.proposer_index)
+        .ok()
+        .and_then(|proposer_index| state.validators.get(proposer_index))
+    else {
+        return Ok(ValidationResult::Reject(
+            "Sidecar proposer index out of range".to_string(),
+        ));
+    };
+
+    let domain = state.get_domain(
+        DOMAIN_BEACON_PROPOSER,
+        Some(compute_epoch_at_slot(header.slot)),
+    );
+    let signing_root = compute_signing_root(header.clone(), domain);
+    if !matches!(
+        data_column_sidecar
+            .signed_block_header
+            .signature
+            .verify(&proposer.public_key, signing_root.as_ref()),
+        Ok(true)
+    ) {
         return Ok(ValidationResult::Reject(
             "Invalid proposer signature on data column sidecar's block header".to_string(),
         ));
     }
 
-    // The sidecar's block's parent (defined by block_header.parent_root) passes validation.
-    // Blocks are only added to block_provider after passing full validation (ST func)
-    // so existence in the store implies validation passed. If parent is not in store, we IGNORE.
     let Some(parent_block) = store.db.block_provider().get(header.parent_root)? else {
         return Ok(ValidationResult::Ignore(
             "Parent block not seen".to_string(),
+        ));
+    };
+
+    let Some(mut parent_state) = store.db.state_provider().get(header.parent_root)? else {
+        return Ok(ValidationResult::Reject(
+            "Sidecar's parent failed validation".to_string(),
         ));
     };
 
@@ -87,32 +133,22 @@ pub async fn validate_data_column_sidecar_full(
         ));
     }
 
-    if !verify_cell_kzg_proof_batch(
-        &data_column_sidecar.kzg_commitments,
-        &vec![data_column_sidecar.index; data_column_sidecar.column.len()],
-        &data_column_sidecar.column,
-        &data_column_sidecar.kzg_proofs,
-    )? {
+    if !matches!(
+        verify_data_column_sidecar_kzg_proofs(data_column_sidecar),
+        Ok(true)
+    ) {
         return Ok(ValidationResult::Reject(
             "Invalid KZG proofs for data column sidecar".to_string(),
         ));
     }
 
-    let tuple = (
-        header.slot,
-        header.proposer_index,
-        data_column_sidecar.index,
-    );
-    let mut seen = cached_db.seen_data_column_sidecars.write().await;
-    if seen.contains(&tuple) {
-        return Ok(ValidationResult::Ignore(
-            "Duplicate data column sidecar for (slot, proposer_index, index)".to_string(),
-        ));
+    if let Err(err) = parent_state.process_slots(header.slot) {
+        return Ok(ValidationResult::Ignore(format!(
+            "Could not advance parent state to sidecar slot: {err:?}"
+        )));
     }
-    seen.put(tuple, ());
-    drop(seen);
 
-    match state.get_beacon_proposer_index(Some(header.slot)) {
+    match parent_state.get_beacon_proposer_index(None) {
         Ok(expected_index) => {
             if expected_index != header.proposer_index {
                 return Ok(ValidationResult::Reject(format!(
@@ -122,11 +158,32 @@ pub async fn validate_data_column_sidecar_full(
             }
         }
         Err(err) => {
-            return Ok(ValidationResult::Reject(format!(
+            return Ok(ValidationResult::Ignore(format!(
                 "Could not get proposer index: {err:?}"
             )));
         }
     }
 
+    // Re-check under the write lock in case another validation inserted the tuple
+    // after the initial duplicate check.
+    let mut seen = cached_db.seen_data_column_sidecars.write().await;
+    if seen.contains(&tuple) {
+        return Ok(ValidationResult::Ignore(
+            "Duplicate data column sidecar for (slot, proposer_index, index)".to_string(),
+        ));
+    }
+    seen.put(tuple, ());
+
     Ok(ValidationResult::Accept)
+}
+
+fn is_not_from_future_slot(state: &BeaconState, slot: u64, current_time_ms: u64) -> bool {
+    let network_spec = beacon_network_spec();
+    let slots_since_genesis = slot.saturating_sub(GENESIS_SLOT);
+    let slot_time_ms = state
+        .genesis_time
+        .saturating_mul(1000)
+        .saturating_add(slots_since_genesis.saturating_mul(network_spec.slot_duration_ms));
+
+    current_time_ms.saturating_add(network_spec.maximum_gossip_clock_disparity) >= slot_time_ms
 }


### PR DESCRIPTION
### What was wrong?

`validate_data_column_sidecar_full` derived the expected proposer from the current head state instead of the sidecar block header's parent state, which is different from the consensus specification - [`validate_data_column_sidecar_gossip`](https://github.com/ethereum/consensus-specs/blob/master/specs/fulu/p2p-interface.md?plain=1#L357-L444)

It has been found in Hans' PR in our work: https://github.com/ream-collective/ream/pull/2#pullrequestreview-4744572781

### How was it fixed?

- Load the parent state from `block_header.parent_root`, advance it to `block_header.slot`, and use that state to validate the expected proposer. 
- The validation flow was also aligned with the spec for slot timing, proposer signatures, KZG proofs, and duplicate handling.

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).