### PR TITLE
test(lean): stabilize serial devnet5 tests

### DIFF
--- a/.github/workflows/tests-matrix.yml
+++ b/.github/workflows/tests-matrix.yml
@@ -92,10 +92,10 @@ jobs:
               cargo test \
                 --package ream \
                 --bin ream \
-                ${{ matrix.test_name }} \
+                "tests::${{ matrix.test_name }}" \
                 --no-default-features \
                 --features devnet5 \
-                -- --nocapture
+                -- --exact --nocapture
               ;;
             *)
               echo "Unknown network: ${{ inputs.network }}" >&2

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -954,6 +954,7 @@ mod tests {
         Cli, Commands, beacon_node::BeaconNodeConfig, lean_node::LeanNodeConfig,
         verbosity::Verbosity,
     };
+    use ream_checkpoint_sync_lean::LeanCheckpointClient;
     use ream_consensus_beacon::electra::{
         beacon_block::SignedBeaconBlock, beacon_state::BeaconState,
     };
@@ -972,6 +973,7 @@ mod tests {
     use ssz::Decode;
     use tokio::time::{sleep, timeout};
     use tracing::{info, warn};
+    use url::Url;
 
     use crate::{APP_NAME, run_beacon_node_for_test, run_lean_node};
 
@@ -1282,6 +1284,23 @@ mod tests {
         lean_db.state_provider().get(head).ok().flatten()
     }
 
+    async fn wait_for_checkpoint_source(url: &Url) {
+        let client = LeanCheckpointClient::new();
+        timeout(Duration::from_secs(30), async {
+            loop {
+                match client.fetch_finalized_anchor(url).await {
+                    Ok(_) => break,
+                    Err(err) => {
+                        warn!("Checkpoint source is not ready: {err}");
+                        sleep(Duration::from_millis(250)).await;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("Checkpoint source did not become ready within 30 seconds");
+    }
+
     fn run_checkpoint_sync_scenario(scenario: CheckpointSyncScenario) {
         init_test_tracing();
 
@@ -1469,6 +1488,11 @@ mod tests {
 
                     let node_3_p2p_port = base_p2p_port + port_offset + 2;
                     let node_3_http_port = base_http_port + port_offset + 2;
+                    let checkpoint_sync_url =
+                        Url::parse(&format!("http://127.0.0.1:{node_1_http_port}"))
+                            .expect("Failed to parse checkpoint sync URL");
+
+                    wait_for_checkpoint_source(&checkpoint_sync_url).await;
 
                     let node_3_args = vec![
                         "ream".to_string(),
@@ -1488,7 +1512,7 @@ mod tests {
                         "--private-key-path".to_string(),
                         key_paths[2].to_string_lossy().to_string(),
                         "--checkpoint-sync-url".to_string(),
-                        format!("http://127.0.0.1:{node_1_http_port}"),
+                        checkpoint_sync_url.to_string(),
                         "--bootnodes".to_string(),
                         format!("{},{}", node_addresses[0], node_addresses[1]),
                     ];
@@ -1872,20 +1896,13 @@ mod tests {
 
         let cloned_db = db.clone();
         executor.runtime().block_on(async move {
-            let handle = tokio::spawn(async move {
+            let mut handle = tokio::spawn(async move {
                 run_lean_node(*config, executor_handle, cloned_db).await;
             });
 
-            let result = timeout(Duration::from_secs(120), async {
-                sleep(Duration::from_secs(120)).await;
-                Ok::<_, ()>(())
-            })
-            .await;
-
-            match result {
-                Ok(Ok(())) => {}
-                Err(err) => panic!("lean_node panicked or exited early {err:?}"),
-                Ok(Err(err)) => panic!("internal error {err:?}"),
+            tokio::select! {
+                result = &mut handle => panic!("lean_node exited early: {result:?}"),
+                _ = sleep(Duration::from_secs(120)) => {}
             }
 
             handle.abort();

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -1894,35 +1894,44 @@ mod tests {
         let executor = ReamExecutor::new().unwrap();
         let executor_handle = executor.clone();
 
+        let justification_lag = 2;
+        let finalization_lag = 2;
         let cloned_db = db.clone();
-        executor.runtime().block_on(async move {
+        let monitor_db = db.clone();
+        let head_state = executor.runtime().block_on(async move {
             let mut handle = tokio::spawn(async move {
                 run_lean_node(*config, executor_handle, cloned_db).await;
             });
 
-            tokio::select! {
-                result = &mut handle => panic!("lean_node exited early: {result:?}"),
-                _ = sleep(Duration::from_secs(120)) => {}
-            }
+            let head_state = timeout(Duration::from_secs(120), async {
+                loop {
+                    if let Some(head_state) = read_head_state(&monitor_db)
+                        && head_state.slot > finalization_lag
+                        && head_state.latest_finalized.slot > 0
+                        && head_state.latest_justified.slot + justification_lag <= head_state.slot
+                        && head_state.latest_finalized.slot + finalization_lag <= head_state.slot
+                    {
+                        break head_state;
+                    }
+
+                    tokio::select! {
+                        result = &mut handle => panic!("lean_node exited early: {result:?}"),
+                        _ = sleep(Duration::from_millis(250)) => {}
+                    }
+                }
+            })
+            .await
+            .expect("lean node did not reach a finalized head within 120 seconds");
 
             handle.abort();
 
             sleep(Duration::from_secs(2)).await;
+            head_state
         });
 
-        let lean_db = db.init_lean_db().unwrap();
-        let head = lean_db.head_provider().get().unwrap();
-        let head_state = lean_db.state_provider().get(head).unwrap().unwrap();
-
-        let justfication_lag = 2;
-        let finalization_lag = 2;
-
         info!(
-            "Test results: head_slot={}, justified_slot={}, finalized_slot={}, head_root={:?}",
-            head_state.slot,
-            head_state.latest_justified.slot,
-            head_state.latest_finalized.slot,
-            head
+            "Test results: head_slot={}, justified_slot={}, finalized_slot={}",
+            head_state.slot, head_state.latest_justified.slot, head_state.latest_finalized.slot,
         );
 
         assert!(
@@ -1936,8 +1945,8 @@ mod tests {
             head_state.latest_finalized.slot
         );
         assert!(
-            head_state.latest_justified.slot + justfication_lag <= head_state.slot,
-            "Expected the head to be at least {justfication_lag} slots ahead of the justified checkpoint {:?} + {justfication_lag} vs {:?}",
+            head_state.latest_justified.slot + justification_lag <= head_state.slot,
+            "Expected the head to be at least {justification_lag} slots ahead of the justified checkpoint {:?} + {justification_lag} vs {:?}",
             head_state.latest_justified.slot,
             head_state.slot
         );


### PR DESCRIPTION
🔴  **Closed due to the <code>checkpoint sync from fresh source</code> passed but some running tests result is not stable yet**
As far as I'm concerned, `mesh_2_2_2`, `late_joiner`, `existing_data_dir` will pass stablely when the #1541 is merged

### What was wrong?

Serial CI used substring matching, so `test_lean_node_finalizes` also ran tests with similar names.

Two tests in `main.rs` were timing-sensitive:

- The finalization test checked the head after a fixed 120-second wait. The node could finalize earlier but have a different, reorg-mutable head at the final snapshot.
- The fresh checkpoint-sync test could start node 3 before node 1's checkpoint endpoint was ready.

### How was it fixed?

- Run serial tests using fully qualified names and `--exact`.
- Poll for a head satisfying all finalization invariants, while keeping the 120-second timeout and early node-exit detection.
- Wait for a valid checkpoint response before starting node 3.

### To-Do

- [x] I have read [CONTRIBUTING.md](https://github.com/ReamLabs/ream/blob/master/CONTRIBUTING.md).
- [x] This PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).