### PR TITLE
fix: support checkpoint sync and P2P handshake on post-Fulu networks

### DIFF
--- a/crates/common/chain/beacon/src/beacon_chain.rs
+++ b/crates/common/chain/beacon/src/beacon_chain.rs
@@ -5,7 +5,7 @@ use ream_consensus_beacon::{
     attestation::Attestation, attester_slashing::AttesterSlashing,
     electra::beacon_block::SignedBeaconBlock,
 };
-use ream_consensus_misc::constants::beacon::{FULU_FORK_EPOCH, genesis_validators_root};
+use ream_consensus_misc::constants::beacon::genesis_validators_root;
 use ream_events_beacon::{BeaconEvent, BeaconEventSender, event::chain::BlockEvent};
 use ream_execution_engine::ExecutionEngine;
 use ream_fork_choice_beacon::{
@@ -128,8 +128,10 @@ impl BeaconChain {
         };
 
         Ok(Status {
-            fork_digest: beacon_network_spec()
-                .fork_digest(FULU_FORK_EPOCH, genesis_validators_root()),
+            fork_digest: beacon_network_spec().fork_digest(
+                beacon_network_spec().current_epoch(),
+                genesis_validators_root(),
+            ),
             finalized_root: finalized_checkpoint.root,
             finalized_epoch: finalized_checkpoint.epoch,
             head_root,

--- a/crates/common/checkpoint_sync/beacon/src/lib.rs
+++ b/crates/common/checkpoint_sync/beacon/src/lib.rs
@@ -13,7 +13,7 @@ use ream_consensus_beacon::{
         beacon_state::BeaconState,
     },
 };
-use ream_consensus_misc::checkpoint::Checkpoint;
+use ream_consensus_misc::{checkpoint::Checkpoint, misc::compute_epoch_at_slot};
 use ream_execution_rpc_types::get_blobs::BlobAndProofV1;
 use ream_fork_choice_beacon::{handlers::on_tick, store::get_forkchoice_store};
 use ream_network_spec::networks::beacon_network_spec;
@@ -83,12 +83,18 @@ pub async fn initialize_db_from_checkpoint(
     );
     let slot = block.message.slot;
 
-    info!("Fetching blobs...");
-    initialize_blobs_in_db(&checkpoint_sync_url, db.clone(), block.message.block_root()).await?;
-    info!(
-        "Downloaded blobs for block: {}",
-        block.message.body.execution_payload.block_number
-    );
+    // blob_sidecars only serves pre-Fulu blobs; post-Fulu data comes as data column sidecars.
+    if compute_epoch_at_slot(slot) < beacon_network_spec().fulu_fork_epoch {
+        info!("Fetching blobs...");
+        initialize_blobs_in_db(&checkpoint_sync_url, db.clone(), block.message.block_root())
+            .await?;
+        info!(
+            "Downloaded blobs for block: {}",
+            block.message.body.execution_payload.block_number
+        );
+    } else {
+        info!("Skipping legacy blob_sidecars fetch for post-Fulu checkpoint block");
+    }
 
     info!("Fetching initial state...");
     let state = get_state(&checkpoint_sync_url, slot).await?;

--- a/crates/common/consensus/beacon/src/electra/beacon_state.rs
+++ b/crates/common/consensus/beacon/src/electra/beacon_state.rs
@@ -2705,7 +2705,11 @@ impl BeaconState {
         // Verify commitments are under limit
         ensure!(
             body.blob_kzg_commitments.len()
-                <= get_blob_parameters(self.get_current_epoch()).max_blobs_per_block as usize
+                <= get_blob_parameters(
+                    &beacon_network_spec().blob_schedule,
+                    self.get_current_epoch()
+                )
+                .max_blobs_per_block as usize
         );
 
         // Verify the execution payload is valid

--- a/crates/common/consensus/misc/src/blob_parameters.rs
+++ b/crates/common/consensus/misc/src/blob_parameters.rs
@@ -11,13 +11,9 @@ pub struct BlobParameters {
     pub max_blobs_per_block: u64,
 }
 
-pub fn get_blob_parameters(epoch: u64) -> BlobParameters {
-    let schedule = [BlobParameters {
-        epoch: ELECTRA_FORK_EPOCH,
-        max_blobs_per_block: MAX_BLOBS_PER_BLOCK_ELECTRA,
-    }];
-
-    schedule
+/// Returns the blob parameters in effect at `epoch` per the network's BPO (EIP-7892) schedule.
+pub fn get_blob_parameters(blob_schedule: &[BlobParameters], epoch: u64) -> BlobParameters {
+    blob_schedule
         .iter()
         .rev()
         .find(|entry| epoch >= entry.epoch)

--- a/crates/common/consensus/misc/src/fork_data.rs
+++ b/crates/common/consensus/misc/src/fork_data.rs
@@ -1,10 +1,11 @@
 use alloy_primitives::{B256, aliases::B32};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use ssz_derive::{Decode, Encode};
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
-use crate::blob_parameters::get_blob_parameters;
+use crate::blob_parameters::{BlobParameters, get_blob_parameters};
 
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct ForkData {
@@ -24,11 +25,25 @@ impl ForkData {
 /// Return the 4-byte fork digest for the ``current_version`` and ``genesis_validators_root``.
 /// This is a digest primarily used for domain separation on the p2p layer.
 /// 4-bytes suffices for practical separation of forks/chains.
-pub fn compute_fork_digest(fork_data: ForkData, epoch: u64) -> B32 {
+pub fn compute_fork_digest(
+    fork_data: ForkData,
+    blob_schedule: &[BlobParameters],
+    fulu_fork_epoch: u64,
+    epoch: u64,
+) -> B32 {
     let base_digest = fork_data.compute_fork_data_root();
-    let blob_parameters = get_blob_parameters(epoch);
 
-    let blob_hash = blob_parameters.tree_hash_root();
+    if epoch < fulu_fork_epoch {
+        return B32::from_slice(&base_digest[..4]);
+    }
+
+    let blob_parameters = get_blob_parameters(blob_schedule, epoch);
+
+    // EIP-7892: SHA256 over the raw little-endian uint64 bytes, not the SSZ hash_tree_root.
+    let mut hasher = Sha256::new();
+    hasher.update(blob_parameters.epoch.to_le_bytes());
+    hasher.update(blob_parameters.max_blobs_per_block.to_le_bytes());
+    let blob_hash = hasher.finalize();
 
     let mut result = [0u8; 4];
     for index in 0..4 {

--- a/crates/common/network_spec/src/networks/beacon.rs
+++ b/crates/common/network_spec/src/networks/beacon.rs
@@ -10,7 +10,7 @@ use ream_consensus_misc::{
     constants::beacon::GENESIS_VALIDATORS_ROOT,
     fork::Fork,
     fork_data::{ForkData, compute_fork_digest},
-    misc::checksummed_address,
+    misc::{checksummed_address, compute_epoch_at_slot},
 };
 use serde::Deserialize;
 
@@ -211,7 +211,7 @@ impl BeaconNetworkSpec {
             current_version: self.current_fork_version(epoch),
             genesis_validators_root,
         };
-        compute_fork_digest(fork_data, epoch)
+        compute_fork_digest(fork_data, &self.blob_schedule, self.fulu_fork_epoch, epoch)
     }
 
     pub fn current_fork_version(&self, epoch: u64) -> B32 {
@@ -274,6 +274,11 @@ impl BeaconNetworkSpec {
             .expect("System Time is before the genesis time");
         let current_slot = elapsed.as_millis() as u64 / self.slot_duration_ms;
         current_slot.saturating_sub(n_days_ago * 24 * 60 * 60 * 1000 / self.slot_duration_ms)
+    }
+
+    /// Returns the current wall-clock epoch.
+    pub fn current_epoch(&self) -> u64 {
+        compute_epoch_at_slot(self.slot_n_days_ago(0))
     }
 
     pub fn seconds_per_slot(&self) -> u64 {

--- a/crates/networking/manager/src/gossipsub/handle.rs
+++ b/crates/networking/manager/src/gossipsub/handle.rs
@@ -9,7 +9,7 @@ use ream_consensus_beacon::{
     single_attestation::SingleAttestation,
 };
 use ream_consensus_misc::constants::beacon::{
-    FULU_FORK_EPOCH, MIN_ATTESTATION_INCLUSION_DELAY, genesis_validators_root,
+    MIN_ATTESTATION_INCLUSION_DELAY, genesis_validators_root,
 };
 use ream_execution_rpc_types::get_blobs::BlobAndProofV1;
 use ream_network_spec::networks::beacon_network_spec;
@@ -53,7 +53,10 @@ use crate::{
 
 pub fn init_gossipsub_config_with_topics() -> GossipsubConfig {
     let mut gossipsub_config = GossipsubConfig::default();
-    let fork_digest = beacon_network_spec().fork_digest(FULU_FORK_EPOCH, genesis_validators_root());
+    let fork_digest = beacon_network_spec().fork_digest(
+        beacon_network_spec().current_epoch(),
+        genesis_validators_root(),
+    );
 
     let mut topics = vec![
         GossipTopic {

--- a/crates/networking/p2p/src/gossipsub/beacon/message.rs
+++ b/crates/networking/p2p/src/gossipsub/beacon/message.rs
@@ -5,7 +5,7 @@ use ream_consensus_beacon::{
     electra::beacon_block::SignedBeaconBlock, proposer_slashing::ProposerSlashing,
     single_attestation::SingleAttestation, voluntary_exit::SignedVoluntaryExit,
 };
-use ream_consensus_misc::constants::beacon::{FULU_FORK_EPOCH, genesis_validators_root};
+use ream_consensus_misc::constants::beacon::genesis_validators_root;
 use ream_events_beacon::contribution_and_proof::SignedContributionAndProof;
 use ream_light_client::{
     finality_update::LightClientFinalityUpdate, optimistic_update::LightClientOptimisticUpdate,
@@ -41,7 +41,10 @@ impl GossipsubMessage {
         let gossip_topic = GossipTopic::from_topic_hash(topic)?;
 
         if gossip_topic.fork
-            != beacon_network_spec().fork_digest(FULU_FORK_EPOCH, genesis_validators_root())
+            != beacon_network_spec().fork_digest(
+                beacon_network_spec().current_epoch(),
+                genesis_validators_root(),
+            )
         {
             return Err(GossipsubError::InvalidTopic(format!(
                 "Invalid topic fork: {topic:?}"

--- a/crates/networking/p2p/src/network/beacon/mod.rs
+++ b/crates/networking/p2p/src/network/beacon/mod.rs
@@ -31,7 +31,7 @@ use libp2p_identity::{Keypair, PublicKey, secp256k1};
 use network_state::NetworkState;
 use parking_lot::{Mutex, RwLock};
 use peer::CachedPeer;
-use ream_consensus_misc::constants::beacon::{FULU_FORK_EPOCH, genesis_validators_root};
+use ream_consensus_misc::constants::beacon::genesis_validators_root;
 use ream_discv5::discovery::{Discovery, DiscoveryOutEvent, QueryType};
 use ream_executor::ReamExecutor;
 use ream_network_spec::networks::beacon_network_spec;
@@ -830,8 +830,10 @@ impl Network {
     fn handle_status_req_resp_event(&mut self, peer_id: PeerId, status: Status) {
         if self.network_state.peer_table.read().get(&peer_id).is_some() {
             // We only want to have peers on the same network as us
-            let fork_digest =
-                beacon_network_spec().fork_digest(FULU_FORK_EPOCH, genesis_validators_root());
+            let fork_digest = beacon_network_spec().fork_digest(
+                beacon_network_spec().current_epoch(),
+                genesis_validators_root(),
+            );
             if status.fork_digest != fork_digest {
                 warn!(
                     "Peer {peer_id} is not on the same network as us, removing from peer table, fork_digest: {}, our fork_digest: {fork_digest}",
@@ -904,7 +906,6 @@ mod tests {
     use discv5::enr::CombinedKey;
     use k256::ecdsa::SigningKey;
     use libp2p_identity::{Keypair, PeerId};
-    use ream_consensus_misc::constants::beacon::FULU_FORK_EPOCH;
     use ream_discv5::{
         config::DiscoveryConfig,
         subnet::{AttestationSubnets, CustodyGroupCount, SyncCommitteeSubnets},
@@ -958,8 +959,10 @@ mod tests {
             executor,
             &config,
             Status {
-                fork_digest: beacon_network_spec()
-                    .fork_digest(FULU_FORK_EPOCH, genesis_validators_root()),
+                fork_digest: beacon_network_spec().fork_digest(
+                    beacon_network_spec().current_epoch(),
+                    genesis_validators_root(),
+                ),
                 ..Default::default()
             },
         )

--- a/crates/networking/syncer/src/block_range/block_cache.rs
+++ b/crates/networking/syncer/src/block_range/block_cache.rs
@@ -6,6 +6,7 @@ use ream_consensus_beacon::{
     blob_sidecar::{BlobIdentifier, BlobSidecar},
     electra::beacon_block::SignedBeaconBlock,
 };
+use ream_consensus_misc::misc::compute_epoch_at_slot;
 use ream_network_spec::networks::beacon_network_spec;
 use ssz::Encode;
 use tree_hash::TreeHash;
@@ -223,6 +224,14 @@ impl BlockCache {
         let mut missing_roots = Vec::new();
         for block in self.blocks_and_blobs.values() {
             if block.block.message.slot < slot_17_days_ago {
+                continue;
+            }
+
+            // blob_sidecars_by_root only serves pre-Fulu blobs; post-Fulu data is distributed
+            // as data column sidecars instead, fetched separately via the DA checker.
+            if compute_epoch_at_slot(block.block.message.slot)
+                >= beacon_network_spec().fulu_fork_epoch
+            {
                 continue;
             }
 

--- a/crates/rpc/beacon/src/handlers/block.rs
+++ b/crates/rpc/beacon/src/handlers/block.rs
@@ -29,7 +29,7 @@ use ream_consensus_beacon::{
     genesis::Genesis,
 };
 use ream_consensus_misc::constants::beacon::{
-    FULU_FORK_EPOCH, WHISTLEBLOWER_REWARD_QUOTIENT, genesis_validators_root,
+    WHISTLEBLOWER_REWARD_QUOTIENT, genesis_validators_root,
 };
 use ream_network_manager::p2p_sender::P2PSender;
 use ream_network_spec::networks::beacon_network_spec;
@@ -540,7 +540,10 @@ async fn publish_and_process_block(
         })?;
 
     // Broadcast via P2P
-    let fork_digest = beacon_network_spec().fork_digest(FULU_FORK_EPOCH, genesis_validators_root());
+    let fork_digest = beacon_network_spec().fork_digest(
+        beacon_network_spec().current_epoch(),
+        genesis_validators_root(),
+    );
     let topic = GossipTopic {
         fork: fork_digest,
         kind: GossipTopicKind::BeaconBlock,


### PR DESCRIPTION
### What was wrong?

Fixes https://github.com/ReamLabs/ream/issues/1538

Sepolia has passed Fulu and gone through multiple BPO (EIP-7892) blob-schedule bumps, which broke sync in three ways: checkpoint sync panics fetching blobs via the legacy `blob_sidecars` API (no longer served post-Fulu), fork digest is computed wrong (ignores per-network blob schedule, wrong hash algorithm, hardcoded mainnet epoch) so no peer ever passes the discv5/Status handshake, and forward sync bans peers that correctly return empty legacy blob responses, eventually starving itself of peers.

### How was it fixed?

- Checkpoint sync and the range-syncer now skip the legacy blob API for post-Fulu blocks.
- Fork digest now reads the network's real `blob_schedule` and uses the correct EIP-7892 hash (raw SHA256, not SSZ `hash_tree_root`).
- Added `BeaconNetworkSpec::current_epoch()` and replaced all hardcoded `FULU_FORK_EPOCH` fork-digest call sites with it.
- Verified live on Sepolia: checkpoint sync completes, peers connect and pass Status handshake, gossip flows, forward sync no longer bans peers.

Before changes, checkpoint sync panics fetching blobs for a post-Fulu block:
<img width="985" height="576" alt="image" src="https://github.com/user-attachments/assets/2cc836a8-edc9-4fac-9015-d980ab26c9bb" />

After changes, checkpoint sync completes and peers successfully connect and pass the Status handshake:
<img width="1648" height="603" alt="image" src="https://github.com/user-attachments/assets/200d0303-22ae-4aeb-b0d0-a1c9b217c0e8" />
<img width="1638" height="575" alt="image" src="https://github.com/user-attachments/assets/8f44d018-382c-406c-918b-ad73a6f4a2e7" />


### What's to notice

Found but out of scope (tracked separately): the range-syncer only targets finalized slot (not head) with no backfill mechanism, so the chain gets stuck at the checkpoint and gossip attestations get rejected as "not a member of the committee" (stale RANDAO). Also, `req_resp` context bytes and a couple RPC handlers use a global "current epoch" instead of the epoch of the specific item/state being served wrong for historical (pre-Fulu) queries.