### PR TITLE
feat: publish devnet5 LeanVM image variant

### DIFF
--- a/.github/workflows/core-rust.yml
+++ b/.github/workflows/core-rust.yml
@@ -79,6 +79,21 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
+  build-devnet5-leanvm-main:
+    name: build devnet5-leanvm-main
+    runs-on: ubuntu-latest
+    needs: [format, cargo-clippy]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Build LeanVM v0.9 variant
+        run: cargo build --verbose --package ream --bin ream --no-default-features --features optimized-leanvm
+
   test-devnet5:
     name: test devnet5
     needs: [format, cargo-clippy]

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -9,8 +9,19 @@ permissions:
 
 jobs:
   push:
+    name: push ${{ matrix.variant }}
     runs-on: ubuntu-latest
     if: github.repository == 'reamlabs/ream'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: devnet5
+            features: devnet5
+            tags: latest latest-devnet5 devnet5
+          - variant: devnet5-leanvm-main
+            features: optimized-leanvm
+            tags: devnet5-leanvm-main
     steps:
       - uses: actions/checkout@v6
       - uses: rui314/setup-mold@v1
@@ -29,10 +40,13 @@ jobs:
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
-      - name: Build and push ream image
+      - name: Build and push ream ${{ matrix.variant }} image
         run: |
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           make docker-build-push \
+            FEATURES="${{ matrix.features }}" \
+            EXTRA_FLAGS="--no-default-features" \
+            DOCKER_TAGS="${{ matrix.tags }}" \
             GIT_COMMIT="${{ github.sha }}" \
             GIT_BRANCH="${{ github.ref_name }}" \
             BUILD_DATE="$BUILD_DATE"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "air"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "field",
+ "koala-bear",
+ "poly",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1139,24 @@ dependencies = [
  "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "tracing",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
+]
+
+[[package]]
+name = "backend"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "air",
+ "fiat-shamir",
+ "field",
+ "koala-bear",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "poly",
+ "sumcheck",
+ "symetric",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "whir",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
 ]
 
 [[package]]
@@ -2583,6 +2611,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fiat-shamir"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "field",
+ "koala-bear",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "serde",
+ "symetric",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+]
+
+[[package]]
+name = "field"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "paste",
+ "rand 0.10.2",
+ "serde",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,6 +3876,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "koala-bear"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "field",
+ "paste",
+ "rand 0.10.2",
+ "serde",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+]
+
+[[package]]
 name = "kzg"
 version = "0.1.0"
 source = "git+https://github.com/grandinetech/rust-kzg#bf57df7cdb2e38ecc92332fa2e16b121de2f625e"
@@ -3868,6 +3932,22 @@ dependencies = [
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
+]
+
+[[package]]
+name = "lean-multisig"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "clap",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "rec_aggregation 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "serde_json",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "xmss",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
 ]
 
 [[package]]
@@ -3931,6 +4011,20 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "include_dir",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "pest",
+ "pest_derive",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "xmss",
+]
+
+[[package]]
+name = "lean_compiler"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
@@ -3965,6 +4059,21 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "rand 0.10.2",
+ "serde",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "tracing",
+ "xmss",
+]
+
+[[package]]
+name = "lean_prover"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
@@ -3994,6 +4103,16 @@ dependencies = [
  "serde",
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
+]
+
+[[package]]
+name = "lean_vm"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "tracing",
+ "xmss",
 ]
 
 [[package]]
@@ -5486,6 +5605,14 @@ dependencies = [
 [[package]]
 name = "parallel"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+]
+
+[[package]]
+name = "parallel"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
@@ -5687,6 +5814,21 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "field",
+ "koala-bear",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "rand 0.10.2",
+ "serde",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
 ]
 
 [[package]]
@@ -6941,8 +7083,10 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
+ "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
  "lean-multisig 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
  "leansig",
+ "postcard",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -7257,6 +7401,26 @@ dependencies = [
  "tracing",
  "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
+]
+
+[[package]]
+name = "rec_aggregation"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "include_dir",
+ "lean_compiler 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "lean_prover 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "objc2",
+ "objc2-foundation",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "postcard",
+ "serde",
+ "sub_protocols 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "tracing",
+ "xmss",
 ]
 
 [[package]]
@@ -8386,6 +8550,16 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "lean_vm 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "tracing",
+]
+
+[[package]]
+name = "sub_protocols"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
@@ -8399,6 +8573,32 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sumcheck"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "air",
+ "fiat-shamir",
+ "field",
+ "koala-bear",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "poly",
+ "tracing",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+]
+
+[[package]]
+name = "symetric"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "field",
+ "koala-bear",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+]
 
 [[package]]
 name = "syn"
@@ -8490,6 +8690,14 @@ dependencies = [
 name = "system-info"
 version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553#2498896ca4d32a545a98a1b1cf1ca78f7f13f553"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "system-info"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
 dependencies = [
  "libc",
 ]
@@ -9134,6 +9342,17 @@ dependencies = [
 [[package]]
 name = "utils"
 version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "serde",
+ "tracing-forest",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "utils"
+version = "0.1.0"
 source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026#e2592df4e30fdddbbf8ae26a333116c68cec7026"
 dependencies = [
  "backend 0.1.0 (git+https://github.com/leanEthereum/leanMultisig.git?rev=e2592df4e30fdddbbf8ae26a333116c68cec7026)",
@@ -9371,6 +9590,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whir"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "fiat-shamir",
+ "field",
+ "koala-bear",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "poly",
+ "rand 0.10.2",
+ "sumcheck",
+ "symetric",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "tracing",
+ "utils 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "zk-alloc 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
 ]
 
 [[package]]
@@ -9844,6 +10082,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmss"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "backend 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "ethereum_ssz",
+ "postcard",
+ "rand 0.10.2",
+ "serde",
+]
+
+[[package]]
 name = "yamux"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10008,6 +10258,16 @@ dependencies = [
  "libc",
  "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
  "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=2498896ca4d32a545a98a1b1cf1ca78f7f13f553)",
+]
+
+[[package]]
+name = "zk-alloc"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a#a5909d18647de6aed38640c098d9177fab2bf36a"
+dependencies = [
+ "libc",
+ "parallel 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
+ "system-info 0.1.0 (git+https://github.com/leanEthereum/leanVM.git?rev=a5909d18647de6aed38640c098d9177fab2bf36a)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ jsonwebtoken = { version = "11.0.0", default-features = false, features = ["rust
 kzg = { git = "https://github.com/grandinetech/rust-kzg" }
 lazy_static = "1.5.0"
 lean-multisig = { git = "https://github.com/leanEthereum/leanVM.git", rev = "2498896ca4d32a545a98a1b1cf1ca78f7f13f553" }
+lean-multisig-optimized = { package = "lean-multisig", git = "https://github.com/leanEthereum/leanVM.git", rev = "a5909d18647de6aed38640c098d9177fab2bf36a" }
 lean-multisig-type2 = { package = "lean-multisig", git = "https://github.com/leanEthereum/leanMultisig.git", rev = "e2592df4e30fdddbbf8ae26a333116c68cec7026" }
 leansig = { git = "https://github.com/leanEthereum//leanSig.git", branch = "devnet4" }
 libp2p = { version = "0.56", default-features = false, features = [
@@ -131,6 +132,7 @@ libp2p-mplex = "0.43.1"
 libp2p-swarm = "0.47.1"
 lru = "0.18.1"
 parking_lot = "0.12.5"
+postcard = { version = "1.1.3", features = ["alloc"] }
 prometheus_exporter = { git = "https://github.com/AlexanderThaller/prometheus_exporter", rev = "c49efe614486f998b20eb410ae0caf3e904cf540" }
 rand = "0.10.2"
 rand_chacha = "0.10.0"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ CARGO_TARGET_DIR ?= target
 
 IMAGE ?= ream-local
 TAG ?= dev
+DOCKER_REPOSITORY ?= ghcr.io/reamlabs/ream
+DOCKER_TAGS ?= latest latest-devnet5 devnet5
 
 ##@ Help
 
@@ -156,8 +158,7 @@ docker-build-push:
 
 	docker buildx build --file ./Dockerfile.cross . \
 		--platform linux/amd64,linux/arm64 \
-		--tag ghcr.io/reamlabs/ream:latest \
-		--tag ghcr.io/reamlabs/ream:latest-devnet5 \
+		$(foreach tag,$(DOCKER_TAGS),--tag $(DOCKER_REPOSITORY):$(tag)) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg GIT_BRANCH=$(GIT_BRANCH) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -32,6 +32,28 @@ shadow-integration = [
     "ream-executor/shadow-integration",
     "ream-post-quantum-crypto/shadow-integration",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-chain-beacon/optimized-leanvm",
+    "ream-chain-lean/optimized-leanvm",
+    "ream-checkpoint-sync-beacon/optimized-leanvm",
+    "ream-checkpoint-sync-lean/optimized-leanvm",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-fork-choice-beacon/optimized-leanvm",
+    "ream-fork-choice-lean/optimized-leanvm",
+    "ream-keystore/optimized-leanvm",
+    "ream-network-manager/optimized-leanvm",
+    "ream-network-state-lean/optimized-leanvm",
+    "ream-p2p/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+    "ream-rpc-beacon/optimized-leanvm",
+    "ream-rpc-lean/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-sync-committee-pool/optimized-leanvm",
+    "ream-validator-beacon/optimized-leanvm",
+    "ream-validator-lean/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/common/chain/beacon/Cargo.toml
+++ b/crates/common/chain/beacon/Cargo.toml
@@ -9,6 +9,15 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "ream-fork-choice-beacon/optimized-leanvm",
+    "ream-req-resp/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-sync-committee-pool/optimized-leanvm",
+]
+
 [dependencies]
 alloy-primitives.workspace = true
 anyhow.workspace = true

--- a/crates/common/chain/lean/Cargo.toml
+++ b/crates/common/chain/lean/Cargo.toml
@@ -23,6 +23,17 @@ devnet5 = [
     "ream-sync/devnet5",
     "ream-post-quantum-crypto/devnet5",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-fork-choice-lean/optimized-leanvm",
+    "ream-network-state-lean/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+    "ream-req-resp/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-test-utils/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/common/checkpoint_sync/beacon/Cargo.toml
+++ b/crates/common/checkpoint_sync/beacon/Cargo.toml
@@ -9,6 +9,13 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "ream-fork-choice-beacon/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+]
+
 [dependencies]
 alloy-primitives.workspace = true
 anyhow.workspace = true

--- a/crates/common/checkpoint_sync/lean/Cargo.toml
+++ b/crates/common/checkpoint_sync/lean/Cargo.toml
@@ -12,6 +12,11 @@ version.workspace = true
 [features]
 default = ["devnet5"]
 devnet5 = ["ream-consensus-lean/devnet5"]
+optimized-leanvm = [
+    "devnet5",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/common/consensus/lean/Cargo.toml
+++ b/crates/common/consensus/lean/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [features]
 default = ["devnet5"]
 devnet5 = ["ream-post-quantum-crypto/devnet5"]
+optimized-leanvm = ["devnet5", "ream-post-quantum-crypto/optimized-leanvm"]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/common/consensus/lean/src/utils.rs
+++ b/crates/common/consensus/lean/src/utils.rs
@@ -5,8 +5,8 @@ use crate::validator::Validator;
 pub fn generate_default_validators(number_of_validators: usize) -> Vec<Validator> {
     (0..number_of_validators)
         .map(|index| Validator {
-            attestation_public_key: PublicKey::from(&[0_u8; 52][..]),
-            proposal_public_key: PublicKey::from(&[0_u8; 52][..]),
+            attestation_public_key: PublicKey::default(),
+            proposal_public_key: PublicKey::default(),
             index: index as u64,
         })
         .collect()

--- a/crates/common/fork_choice/beacon/Cargo.toml
+++ b/crates/common/fork_choice/beacon/Cargo.toml
@@ -9,6 +9,14 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-sync-committee-pool/optimized-leanvm",
+]
+
 [dependencies]
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true

--- a/crates/common/fork_choice/lean/Cargo.toml
+++ b/crates/common/fork_choice/lean/Cargo.toml
@@ -19,6 +19,15 @@ devnet5 = [
     "ream-storage/devnet5",
     "ream-test-utils/devnet5",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-network-state-lean/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-test-utils/optimized-leanvm",
+]
 
 [dependencies]
 alloy-consensus.workspace = true

--- a/crates/common/network_spec/Cargo.toml
+++ b/crates/common/network_spec/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [features]
 default = ["devnet5"]
 devnet5 = []
+optimized-leanvm = ["devnet5"]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/common/network_spec/src/networks/lean.rs
+++ b/crates/common/network_spec/src/networks/lean.rs
@@ -53,13 +53,20 @@ fn default_seconds_per_slot() -> u64 {
     4
 }
 
+/// Serialized XMSS public key size: 52 bytes for the leansig scheme, 32 bytes for the
+/// leanVM sub-MTU scheme.
+#[cfg(not(feature = "optimized-leanvm"))]
+pub const PUBLIC_KEY_SIZE: usize = 52;
+#[cfg(feature = "optimized-leanvm")]
+pub const PUBLIC_KEY_SIZE: usize = 32;
+
 /// A single validator's public keys in the genesis configuration.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, Default)]
 pub struct GenesisValidatorEntry {
     #[serde(alias = "attestation_pubkey")]
-    pub attestation_public_key: FixedBytes<52>,
+    pub attestation_public_key: FixedBytes<PUBLIC_KEY_SIZE>,
     #[serde(alias = "proposal_pubkey")]
-    pub proposal_public_key: FixedBytes<52>,
+    pub proposal_public_key: FixedBytes<PUBLIC_KEY_SIZE>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Default)]

--- a/crates/common/sync_committee_pool/Cargo.toml
+++ b/crates/common/sync_committee_pool/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+optimized-leanvm = ["ream-validator-beacon/optimized-leanvm"]
+
 [dependencies]
 alloy-primitives.workspace = true
 parking_lot.workspace = true

--- a/crates/common/validator/beacon/Cargo.toml
+++ b/crates/common/validator/beacon/Cargo.toml
@@ -9,6 +9,12 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "ream-keystore/optimized-leanvm",
+]
+
 [dependencies]
 alloy-primitives.workspace = true
 anyhow.workspace = true

--- a/crates/common/validator/lean/Cargo.toml
+++ b/crates/common/validator/lean/Cargo.toml
@@ -19,6 +19,15 @@ devnet5 = [
     "ream-network-spec/devnet5",
     "ream-post-quantum-crypto/devnet5",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-chain-lean/optimized-leanvm",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-fork-choice-lean/optimized-leanvm",
+    "ream-keystore/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/crypto/keystore/Cargo.toml
+++ b/crates/crypto/keystore/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [features]
 default = ["devnet5"]
 devnet5 = []
+optimized-leanvm = ["devnet5", "ream-post-quantum-crypto/optimized-leanvm"]
 
 [dependencies]
 aes.workspace = true

--- a/crates/crypto/post_quantum/Cargo.toml
+++ b/crates/crypto/post_quantum/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [features]
 devnet5 = ["dep:lean-multisig-type2"]
 shadow-integration = []
+optimized-leanvm = ["devnet5", "dep:lean-multisig-optimized", "dep:postcard"]
 
 [dependencies]
 alloy-primitives.workspace = true
@@ -19,8 +20,10 @@ anyhow.workspace = true
 ethereum_ssz.workspace = true
 ethereum_ssz_derive.workspace = true
 lean-multisig.workspace = true
+lean-multisig-optimized = { workspace = true, optional = true }
 lean-multisig-type2 = { workspace = true, optional = true }
 leansig.workspace = true
+postcard = { workspace = true, optional = true }
 rand_0_10 = { package = "rand", version = "0.10" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/crypto/post_quantum/src/lean_multisig/mod.rs
+++ b/crates/crypto/post_quantum/src/lean_multisig/mod.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "optimized-leanvm"))]
 pub mod aggregate;
 pub mod errors;
-#[cfg(feature = "devnet5")]
+#[cfg(all(feature = "devnet5", not(feature = "optimized-leanvm")))]
+pub mod type_2;
+#[cfg(feature = "optimized-leanvm")]
+#[path = "type_2_leanvm.rs"]
 pub mod type_2;

--- a/crates/crypto/post_quantum/src/lean_multisig/type_2_leanvm.rs
+++ b/crates/crypto/post_quantum/src/lean_multisig/type_2_leanvm.rs
@@ -1,0 +1,159 @@
+use anyhow::{Result, anyhow};
+use lean_multisig_optimized::{
+    MultiMessageAggregateSignature as MultiMessageAggregate,
+    SingleMessageAggregateSignature as SingleMessageAggregate, XmssPublicKey, XmssSignature,
+    aggregate_single_message_signatures, merge_single_message_aggregates, setup_prover,
+    setup_verifier, split_multi_message_aggregate, verify_multi_message_aggregate,
+    verify_single_message_aggregate,
+};
+
+use crate::leansig::{public_key::PublicKey, signature::Signature};
+
+pub const LOG_INV_RATE: usize = 2;
+
+pub fn type_2_setup() {
+    setup_prover();
+}
+
+pub fn type_2_setup_verifier() {
+    setup_verifier();
+}
+
+fn to_lib_public_key(public_key: &PublicKey) -> Result<XmssPublicKey> {
+    public_key.as_lean_sig()
+}
+
+fn to_lib_signature(signature: &Signature) -> Result<XmssSignature> {
+    signature.as_lean_sig()
+}
+
+fn ensure_expected_pubkeys(embedded: &[XmssPublicKey], expected: &[PublicKey]) -> Result<()> {
+    let mut expected = expected
+        .iter()
+        .map(to_lib_public_key)
+        .collect::<Result<Vec<_>>>()?;
+    expected.sort();
+    expected.dedup();
+    if embedded != expected.as_slice() {
+        return Err(anyhow!(
+            "Aggregate proof public keys do not match the expected validator keys"
+        ));
+    }
+    Ok(())
+}
+
+pub fn type_1_from_wire(wire: &[u8], public_keys: &[PublicKey]) -> Result<SingleMessageAggregate> {
+    type_2_setup_verifier();
+    let proof = SingleMessageAggregate::from_bytes(wire).ok_or_else(|| {
+        anyhow!("Failed to decode single-message aggregate multi-signature from wire bytes")
+    })?;
+    ensure_expected_pubkeys(&proof.info.pubkeys, public_keys)?;
+    Ok(proof)
+}
+
+pub fn type_1_to_wire(proof: &SingleMessageAggregate) -> Vec<u8> {
+    proof.to_bytes()
+}
+
+pub fn type_1_aggregate(
+    children: &[SingleMessageAggregate],
+    raw_xmss: &[(PublicKey, Signature)],
+    message: &[u8; 32],
+    slot: u32,
+) -> Result<SingleMessageAggregate> {
+    type_2_setup();
+
+    let raw: Vec<_> = raw_xmss
+        .iter()
+        .map(|(public_key, signature)| {
+            Ok((to_lib_public_key(public_key)?, to_lib_signature(signature)?))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    aggregate_single_message_signatures(children, raw, *message, slot, LOG_INV_RATE)
+        .map_err(|err| anyhow!("single-message aggregate aggregation failed: {err}"))
+}
+
+pub fn type_1_verify(proof: &SingleMessageAggregate) -> Result<()> {
+    type_2_setup_verifier();
+    verify_single_message_aggregate(proof)
+        .map(|_| ())
+        .map_err(|err| anyhow!("single-message aggregate verification failed: {err}"))
+}
+
+pub fn type_2_merge(parts: Vec<SingleMessageAggregate>) -> Result<MultiMessageAggregate> {
+    type_2_setup();
+    merge_single_message_aggregates(parts, LOG_INV_RATE)
+        .map_err(|err| anyhow!("multi-message aggregate merge failed: {err}"))
+}
+
+pub fn type_2_to_wire(proof: &MultiMessageAggregate) -> Vec<u8> {
+    proof.to_bytes()
+}
+
+pub fn type_2_from_wire(
+    wire: &[u8],
+    public_keys_per_component: &[Vec<PublicKey>],
+) -> Result<MultiMessageAggregate> {
+    type_2_setup_verifier();
+    let proof = MultiMessageAggregate::from_bytes(wire).ok_or_else(|| {
+        anyhow!("Failed to decode multi-message aggregate multi-signature from wire bytes")
+    })?;
+    if proof.info.len() != public_keys_per_component.len() {
+        return Err(anyhow!(
+            "Multi-message aggregate has {} components but {} public key sets were expected",
+            proof.info.len(),
+            public_keys_per_component.len()
+        ));
+    }
+    for (component, public_keys) in proof.info.iter().zip(public_keys_per_component.iter()) {
+        ensure_expected_pubkeys(&component.pubkeys, public_keys)?;
+    }
+    Ok(proof)
+}
+
+pub fn type_2_verify(proof: &MultiMessageAggregate) -> Result<()> {
+    type_2_setup_verifier();
+    verify_multi_message_aggregate(proof)
+        .map(|_| ())
+        .map_err(|err| anyhow!("multi-message aggregate verification failed: {err}"))
+}
+
+pub fn type_2_split(proof: MultiMessageAggregate, index: usize) -> Result<SingleMessageAggregate> {
+    type_2_setup();
+    split_multi_message_aggregate(proof, index, LOG_INV_RATE)
+        .map_err(|err| anyhow!("multi-message aggregate split failed: {err}"))
+}
+
+pub fn type_2_verify_block(
+    wire: &[u8],
+    public_keys_per_component: &[Vec<PublicKey>],
+    expected_bindings: &[([u8; 32], u32)],
+) -> Result<()> {
+    let proof = type_2_from_wire(wire, public_keys_per_component)?;
+
+    if proof.info.len() != expected_bindings.len() {
+        return Err(anyhow!(
+            "Block proof has {} components but {} bindings were expected",
+            proof.info.len(),
+            expected_bindings.len()
+        ));
+    }
+
+    for (component, (message, slot)) in proof.info.iter().zip(expected_bindings.iter()) {
+        if &component.core.message != message {
+            return Err(anyhow!(
+                "Block proof component message does not match block body"
+            ));
+        }
+        if component.core.slot != *slot {
+            return Err(anyhow!(
+                "Block proof component slot does not match block body"
+            ));
+        }
+    }
+
+    verify_multi_message_aggregate(&proof)
+        .map(|_| ())
+        .map_err(|err| anyhow!("multi-message aggregate verification failed: {err}"))
+}

--- a/crates/crypto/post_quantum/src/leanvm_sig/errors.rs
+++ b/crates/crypto/post_quantum/src/leanvm_sig/errors.rs
@@ -1,0 +1,23 @@
+#[derive(Debug, thiserror::Error)]
+pub enum LeanSigError {
+    #[error("Signing failed: {0}")]
+    SigningFailed(lean_multisig_optimized::XmssSignatureError),
+
+    #[error("Key generation failed: {0}")]
+    KeyGenFailed(lean_multisig_optimized::XmssKeyGenError),
+
+    #[error("TryFromSliceError error: {0:?}")]
+    TryFromSliceError(core::array::TryFromSliceError),
+
+    #[error("Invalid signature length: {0}")]
+    InvalidSignatureLength(usize),
+
+    #[error("Deserialization error: {0}")]
+    DeserializationError(anyhow::Error),
+}
+
+impl From<core::array::TryFromSliceError> for LeanSigError {
+    fn from(err: core::array::TryFromSliceError) -> Self {
+        LeanSigError::TryFromSliceError(err)
+    }
+}

--- a/crates/crypto/post_quantum/src/leanvm_sig/mod.rs
+++ b/crates/crypto/post_quantum/src/leanvm_sig/mod.rs
@@ -1,0 +1,4 @@
+pub mod errors;
+pub mod private_key;
+pub mod public_key;
+pub mod signature;

--- a/crates/crypto/post_quantum/src/leanvm_sig/private_key.rs
+++ b/crates/crypto/post_quantum/src/leanvm_sig/private_key.rs
@@ -1,0 +1,127 @@
+use std::{fmt, fmt::Debug, ops::Range};
+
+use alloy_primitives::hex::ToHexExt;
+use anyhow::anyhow;
+use lean_multisig_optimized::{XmssSecretKey, xmss_key_gen_from_seed, xmss_sign};
+use rand_0_10::Rng;
+
+use super::{errors::LeanSigError, public_key::PublicKey, signature::Signature};
+
+pub type LeanSigPrivateKey = XmssSecretKey;
+
+pub struct PrivateKey {
+    pub inner: XmssSecretKey,
+}
+
+impl PrivateKey {
+    pub fn new(inner: XmssSecretKey) -> Self {
+        Self { inner }
+    }
+
+    pub fn generate_key_pair_from_seed(
+        seed: [u8; 32],
+        activation_epoch: usize,
+        num_active_epochs: usize,
+    ) -> (PublicKey, Self) {
+        let (public_key, private_key) =
+            xmss_key_gen_from_seed(seed, activation_epoch as u64, num_active_epochs as u64)
+                .expect("XMSS key generation failed: invalid activation range");
+
+        (
+            PublicKey::from_lean_sig(&public_key)
+                .expect("We are generating this internally so it shouldn't fail"),
+            Self::new(private_key),
+        )
+    }
+
+    pub fn generate_key_pair(
+        activation_epoch: usize,
+        num_active_epochs: usize,
+    ) -> (PublicKey, Self) {
+        let mut seed = [0u8; 32];
+        rand_0_10::rng().fill_bytes(&mut seed);
+        Self::generate_key_pair_from_seed(seed, activation_epoch, num_active_epochs)
+    }
+
+    pub fn get_activation_interval(&self) -> Range<u64> {
+        let slots = self.inner.activation_slots();
+        u64::from(*slots.start())..u64::from(*slots.end()) + 1
+    }
+
+    pub fn get_prepared_interval(&self) -> Range<u64> {
+        self.get_activation_interval()
+    }
+
+    pub fn prepare_signature(&mut self) {}
+
+    pub fn prepare_epoch(&self, epoch: u32) -> Result<(), LeanSigError> {
+        self.inner
+            .prepare(epoch)
+            .map_err(LeanSigError::SigningFailed)
+    }
+
+    pub fn sign(&self, message: &[u8; 32], epoch: u32) -> Result<Signature, LeanSigError> {
+        let activation_interval = self.get_activation_interval();
+
+        assert!(
+            activation_interval.contains(&u64::from(epoch)),
+            "Epoch {epoch} is outside the activation interval {activation_interval:?}",
+        );
+
+        let signature =
+            xmss_sign(&self.inner, epoch, message).map_err(LeanSigError::SigningFailed)?;
+
+        Signature::from_lean_sig(&signature)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, LeanSigError> {
+        Ok(Self {
+            inner: postcard::from_bytes(bytes)
+                .map_err(|err| LeanSigError::DeserializationError(anyhow!("{err:?}")))?,
+        })
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(&self.inner).expect("XMSS secret key serialization failed")
+    }
+}
+
+impl Debug for PrivateKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_bytes().encode_hex())
+    }
+}
+
+impl PartialEq for PrivateKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PrivateKey;
+
+    #[test]
+    fn test_sign_and_verify() {
+        let (public_key, private_key) = PrivateKey::generate_key_pair(0, 10);
+
+        let epoch = 5;
+        let message = [0u8; 32];
+
+        let signature = private_key
+            .sign(&message, epoch)
+            .expect("Signing should succeed");
+
+        let verify_result = signature.verify(&public_key, epoch, &message);
+        assert!(verify_result.is_ok(), "Verification should succeed");
+        assert!(verify_result.unwrap(), "Signature should be valid");
+    }
+
+    #[test]
+    fn test_private_key_roundtrip() {
+        let (_, private_key) = PrivateKey::generate_key_pair(0, 10);
+        let recovered = PrivateKey::from_bytes(&private_key.to_bytes()).unwrap();
+        assert_eq!(private_key, recovered);
+    }
+}

--- a/crates/crypto/post_quantum/src/leanvm_sig/public_key.rs
+++ b/crates/crypto/post_quantum/src/leanvm_sig/public_key.rs
@@ -1,0 +1,72 @@
+use alloy_primitives::{
+    FixedBytes,
+    hex::{self, ToHexExt},
+};
+use anyhow::anyhow;
+use lean_multisig_optimized::{PUB_KEY_SSZ_LEN, XmssPublicKey};
+use serde::{Deserialize, Deserializer, Serialize};
+use ssz::{Decode as _, Encode as _};
+use ssz_derive::{Decode, Encode};
+use tree_hash_derive::TreeHash;
+
+use super::errors::LeanSigError;
+
+pub const PUBLIC_KEY_SIZE: usize = PUB_KEY_SSZ_LEN;
+
+#[derive(Debug, PartialEq, Clone, Encode, Decode, TreeHash, Default, Eq, Hash, Copy)]
+pub struct PublicKey {
+    pub inner: FixedBytes<PUBLIC_KEY_SIZE>,
+}
+
+impl From<&[u8]> for PublicKey {
+    fn from(value: &[u8]) -> Self {
+        Self {
+            inner: FixedBytes::from_slice(value),
+        }
+    }
+}
+
+impl PublicKey {
+    pub fn new(inner: FixedBytes<PUBLIC_KEY_SIZE>) -> Self {
+        Self { inner }
+    }
+
+    pub fn from_lean_sig(public_key: &XmssPublicKey) -> Result<Self, LeanSigError> {
+        Ok(Self {
+            inner: FixedBytes::try_from(public_key.as_ssz_bytes().as_slice())?,
+        })
+    }
+
+    pub fn as_lean_sig(&self) -> anyhow::Result<XmssPublicKey> {
+        XmssPublicKey::from_ssz_bytes(self.inner.as_slice())
+            .map_err(|err| anyhow!("Failed to decode XmssPublicKey from SSZ: {err:?}"))
+    }
+}
+
+impl Serialize for PublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("0x{}", self.inner.encode_hex()))
+    }
+}
+
+impl<'de> Deserialize<'de> for PublicKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let result: String = Deserialize::deserialize(deserializer)?;
+        let result = hex::decode(&result).map_err(serde::de::Error::custom)?;
+        if result.len() != PUBLIC_KEY_SIZE {
+            return Err(serde::de::Error::custom(format!(
+                "Invalid public key length: {}",
+                result.len()
+            )));
+        }
+        let public_key = XmssPublicKey::from_ssz_bytes(&result)
+            .map_err(|err| serde::de::Error::custom(format!("{err:?}")))?;
+        Self::from_lean_sig(&public_key).map_err(serde::de::Error::custom)
+    }
+}

--- a/crates/crypto/post_quantum/src/leanvm_sig/signature.rs
+++ b/crates/crypto/post_quantum/src/leanvm_sig/signature.rs
@@ -1,0 +1,90 @@
+use alloy_primitives::FixedBytes;
+use anyhow::anyhow;
+use lean_multisig_optimized::{SIGNATURE_SSZ_LEN, XmssSignature, xmss_verify};
+use serde::{Deserialize, Serialize};
+use ssz::{Decode as _, Encode as _};
+use ssz_derive::{Decode, Encode};
+use tree_hash_derive::TreeHash;
+
+use super::{errors::LeanSigError, public_key::PublicKey};
+
+pub const SIGNATURE_SIZE: usize = SIGNATURE_SSZ_LEN;
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Copy)]
+pub struct Signature {
+    pub inner: FixedBytes<SIGNATURE_SIZE>,
+}
+
+impl From<&[u8]> for Signature {
+    fn from(value: &[u8]) -> Self {
+        Self {
+            inner: FixedBytes::from_slice(value),
+        }
+    }
+}
+
+impl Signature {
+    pub fn new(inner: FixedBytes<SIGNATURE_SIZE>) -> Self {
+        Self { inner }
+    }
+
+    pub fn blank() -> Self {
+        Self::new(FixedBytes::from([0; SIGNATURE_SIZE]))
+    }
+
+    pub fn mock() -> Self {
+        use super::private_key::PrivateKey;
+
+        let (_, private_key) = PrivateKey::generate_key_pair(0, 10);
+        let message = [0u8; 32];
+        private_key
+            .sign(&message, 0)
+            .expect("Mock signature generation failed")
+    }
+
+    pub fn from_lean_sig(signature: &XmssSignature) -> Result<Self, LeanSigError> {
+        Ok(Self {
+            inner: FixedBytes::try_from(signature.as_ssz_bytes().as_slice())?,
+        })
+    }
+
+    pub fn as_lean_sig(&self) -> anyhow::Result<XmssSignature> {
+        XmssSignature::from_ssz_bytes(self.inner.as_slice())
+            .map_err(|err| anyhow!("Failed to decode XmssSignature from SSZ: {err:?}"))
+    }
+
+    pub fn verify(
+        &self,
+        public_key: &PublicKey,
+        epoch: u32,
+        message: &[u8; 32],
+    ) -> anyhow::Result<bool> {
+        Ok(xmss_verify(
+            &public_key.as_lean_sig()?,
+            epoch,
+            message,
+            &self.as_lean_sig()?,
+        )
+        .is_ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::leansig::{private_key::PrivateKey, signature::Signature};
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let (_, private_key) = PrivateKey::generate_key_pair(0, 10);
+        let message = [0u8; 32];
+
+        let signature = private_key
+            .sign(&message, 5)
+            .expect("Signing should succeed");
+
+        let lean_signature = signature.as_lean_sig().unwrap();
+        let signature_returned = Signature::from_lean_sig(&lean_signature).unwrap();
+
+        assert_eq!(signature, signature_returned);
+    }
+}

--- a/crates/crypto/post_quantum/src/lib.rs
+++ b/crates/crypto/post_quantum/src/lib.rs
@@ -1,4 +1,8 @@
 pub mod lean_multisig;
+#[cfg(not(feature = "optimized-leanvm"))]
+pub mod leansig;
+#[cfg(feature = "optimized-leanvm")]
+#[path = "leanvm_sig/mod.rs"]
 pub mod leansig;
 #[cfg(feature = "shadow-integration")]
 pub mod shadow;

--- a/crates/networking/manager/Cargo.toml
+++ b/crates/networking/manager/Cargo.toml
@@ -12,6 +12,18 @@ version.workspace = true
 [features]
 default = []
 devnet5 = ["ream-p2p/devnet5", "ream-storage/devnet5"]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-chain-beacon/optimized-leanvm",
+    "ream-fork-choice-beacon/optimized-leanvm",
+    "ream-p2p/optimized-leanvm",
+    "ream-req-resp/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-sync-committee-pool/optimized-leanvm",
+    "ream-syncer/optimized-leanvm",
+    "ream-validator-beacon/optimized-leanvm",
+]
 disable_ancestor_validation = []
 
 [dependencies]

--- a/crates/networking/network_state/lean/Cargo.toml
+++ b/crates/networking/network_state/lean/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [features]
 default = ["devnet5"]
 devnet5 = ["ream-consensus-lean/devnet5"]
+optimized-leanvm = ["devnet5", "ream-consensus-lean/optimized-leanvm"]
 
 [dependencies]
 libp2p.workspace = true

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -17,6 +17,16 @@ devnet5 = [
     "ream-network-state-lean/devnet5",
     "ream-storage/devnet5",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-chain-lean/optimized-leanvm",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-network-state-lean/optimized-leanvm",
+    "ream-req-resp/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-validator-beacon/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/networking/req_resp/Cargo.toml
+++ b/crates/networking/req_resp/Cargo.toml
@@ -12,6 +12,11 @@ version.workspace = true
 [features]
 default = ["devnet5"]
 devnet5 = ["ream-consensus-lean/devnet5"]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-consensus-lean/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/networking/syncer/Cargo.toml
+++ b/crates/networking/syncer/Cargo.toml
@@ -12,6 +12,14 @@ version.workspace = true
 [features]
 default = []
 devnet5 = ["ream-storage/devnet5", "ream-p2p/devnet5"]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-chain-beacon/optimized-leanvm",
+    "ream-p2p/optimized-leanvm",
+    "ream-req-resp/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/crates/rpc/beacon/Cargo.toml
+++ b/crates/rpc/beacon/Cargo.toml
@@ -12,6 +12,18 @@ version.workspace = true
 [features]
 default = []
 devnet5 = ["ream-network-manager/devnet5", "ream-storage/devnet5", "ream-p2p/devnet5"]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-chain-beacon/optimized-leanvm",
+    "ream-fork-choice-beacon/optimized-leanvm",
+    "ream-network-manager/optimized-leanvm",
+    "ream-p2p/optimized-leanvm",
+    "ream-req-resp/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-sync-committee-pool/optimized-leanvm",
+    "ream-validator-beacon/optimized-leanvm",
+]
 
 [dependencies]
 actix-web.workspace = true

--- a/crates/rpc/lean/Cargo.toml
+++ b/crates/rpc/lean/Cargo.toml
@@ -19,6 +19,17 @@ devnet5 = [
     "ream-storage/devnet5",
     "ream-test-utils/devnet5",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "lean-spec-tests/optimized-leanvm",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-fork-choice-lean/optimized-leanvm",
+    "ream-network-state-lean/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-test-utils/optimized-leanvm",
+]
 
 [dependencies]
 actix-web.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -12,6 +12,11 @@ version.workspace = true
 [features]
 default = ["devnet5"]
 devnet5 = ["ream-consensus-lean/devnet5"]
+optimized-leanvm = [
+    "devnet5",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -16,6 +16,13 @@ devnet5 = [
     "ream-storage/devnet5",
     "ream-consensus-misc/devnet5",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-fork-choice-beacon/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+]
 ef-tests = []
 
 [dependencies]

--- a/testing/gossip-validation/Cargo.toml
+++ b/testing/gossip-validation/Cargo.toml
@@ -12,6 +12,16 @@ version.workspace = true
 [features]
 default = ["devnet5"]
 devnet5 = ["ream-consensus-lean/devnet5", "ream-p2p/devnet5", "ream-storage/devnet5"]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-chain-beacon/optimized-leanvm",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-network-manager/optimized-leanvm",
+    "ream-p2p/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+    "ream-sync-committee-pool/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true
@@ -38,4 +48,3 @@ ream-sync-committee-pool.workspace = true
 
 [lints]
 workspace = true
-

--- a/testing/lean-spec-tests/Cargo.toml
+++ b/testing/lean-spec-tests/Cargo.toml
@@ -18,6 +18,14 @@ devnet5 = [
     "ream-fork-choice-lean/devnet5",
     "ream-storage/devnet5",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-fork-choice-lean/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+]
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/testing/test_utils/Cargo.toml
+++ b/testing/test_utils/Cargo.toml
@@ -16,6 +16,14 @@ devnet5 = [
     "ream-fork-choice-lean/devnet5",
     "ream-storage/devnet5",
 ]
+optimized-leanvm = [
+    "ream-network-spec/optimized-leanvm",
+    "devnet5",
+    "ream-consensus-lean/optimized-leanvm",
+    "ream-fork-choice-lean/optimized-leanvm",
+    "ream-post-quantum-crypto/optimized-leanvm",
+    "ream-storage/optimized-leanvm",
+]
 
 [dependencies]
 ssz_types.workspace = true


### PR DESCRIPTION
### What was wrong?

The devnet's Ethlambda are running are currently using leanvm 0.9, we still want to support the last version for hive


### How was it fixed?

use feature flags