### PR TITLE
fix: regenerate Cargo.lock for data_availability crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6667,7 +6667,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6678,7 +6678,7 @@ dependencies = [
  "ream-data-availability",
  "ream-executor",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]


### PR DESCRIPTION
## Problem

Since #1485 merged, any `--locked` build of master fails — including the default `docker build` (the Dockerfile passes `--locked` by default), which is breaking the ethpandaops image builds for `ReamLabs/ream#master`:

```
#22 RUN cargo build --profile release --features "" --locked --bin ream
error: cannot update the lock file /app/Cargo.lock because --locked was passed to prevent this
```

## Cause

`ream-data-availability` and `ream-data-availability-node` (new in #1485) reference `thiserror 2.0.18` in `Cargo.lock`, but the workspace was bumped to `thiserror 2.0.19` in #1537 / #1540 and the `2.0.18` package entry no longer exists in the lockfile. Cargo has to re-resolve, so `--locked` refuses. Upstream CI didn't catch it because the `build` job doesn't use `--locked`.

## Fix

Output of `cargo update -w` — a 2-line change pointing both crates at the already-locked `2.0.19`. No dependency versions change.

Verified: `cargo metadata --locked` now succeeds on this branch (fails on master).