### PR TITLE
docs: regenerate book CLI docs for `da_node`

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -8,6 +8,7 @@
   - [`ream`](./cli/ream.md)
     - [`ream lean_node`](./cli/ream/lean_node.md)
     - [`ream beacon_node`](./cli/ream/beacon_node.md)
+    - [`ream da_node`](./cli/ream/da_node.md)
     - [`ream validator_node`](./cli/ream/validator_node.md)
     - [`ream account_manager`](./cli/ream/account_manager.md)
     - [`ream voluntary_exit`](./cli/ream/voluntary_exit.md)

--- a/book/cli/SUMMARY.md
+++ b/book/cli/SUMMARY.md
@@ -1,6 +1,7 @@
 - [`ream`](./ream.md)
   - [`ream lean_node`](./ream/lean_node.md)
   - [`ream beacon_node`](./ream/beacon_node.md)
+  - [`ream da_node`](./ream/da_node.md)
   - [`ream validator_node`](./ream/validator_node.md)
   - [`ream account_manager`](./ream/account_manager.md)
   - [`ream voluntary_exit`](./ream/voluntary_exit.md)

--- a/book/cli/ream.md
+++ b/book/cli/ream.md
@@ -11,6 +11,7 @@ Usage: ream [OPTIONS] <COMMAND>
 Commands:
   lean_node                    Start the lean node
   beacon_node                  Start the beacon node
+  da_node                      Start the data node
   validator_node               Start the validator node
   account_manager              Manage validator accounts
   voluntary_exit               Perform voluntary exit for a validator

--- a/book/cli/ream/da_node.md
+++ b/book/cli/ream/da_node.md
@@ -1,0 +1,17 @@
+# ream da_node
+
+Start the data node
+
+```bash
+$ ream da_node --help
+```
+```txt
+Usage: ream da_node [OPTIONS]
+
+Options:
+      --network <NETWORK>            Choose mainnet, sepolia, hoodi, dev or provide a path to a YAML config file [default: mainnet]
+      --http-address <HTTP_ADDRESS>  [default: 127.0.0.1]
+      --http-port <HTTP_PORT>        [default: 5062]
+      --http-allow-origin
+  -h, --help                         Print help
+```


### PR DESCRIPTION
## Summary

The `check-cli-docs` job is failing on `master`. The `da_node` subcommand was added without regenerating the generated CLI documentation: