### PR TITLE
chore: raise minimum Rust version to 1.98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ keywords = ["ethereum", "beam-chain", "blockchain", "consensus", "protocol", "re
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ReamLabs/ream"
-rust-version = "1.90.0"
+rust-version = "1.98.0"
 version = "0.1.0"
 
 [workspace.lints.clippy]

--- a/crates/rpc/beacon/src/handlers/state.rs
+++ b/crates/rpc/beacon/src/handlers/state.rs
@@ -250,7 +250,9 @@ pub async fn get_sync_committees(
         .collect::<Vec<_>>();
 
     let validator_aggregates = validators
-        .chunks_exact((SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT) as usize)
+        .as_chunks::<{ (SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT) as usize }>()
+        .0
+        .iter()
         .map(|chunk| QuotedU64Vec(chunk.to_vec()))
         .collect::<Vec<QuotedU64Vec>>();
 


### PR DESCRIPTION
### What was wrong?

our rust version is 1 year old


### How was it fixed?

bumping it