### PR TITLE
feat(DA): ssz payload and batch process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7246,12 +7246,15 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "alloy-primitives",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "ream-api-types-common",
  "ream-data-availability",
  "ream-data-availability-node",
  "ream-rpc-common",
  "serde",
  "serde_json",
+ "ssz_types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6357,6 +6357,7 @@ dependencies = [
  "clap",
  "discv5",
  "ethereum_ssz",
+ "ethereum_ssz_derive",
  "hashbrown 0.17.1",
  "leansig",
  "libp2p-identity",

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -67,6 +67,7 @@ bip39.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 discv5.workspace = true
 ethereum_ssz.workspace = true
+ethereum_ssz_derive.workspace = true
 hashbrown.workspace = true
 leansig.workspace = true
 libp2p-identity.workspace = true

--- a/bin/ream/src/data_availability_tool/README.md
+++ b/bin/ream/src/data_availability_tool/README.md
@@ -16,9 +16,14 @@ ream-data-availability-tool health
 ream-data-availability-tool availability <0x-block-root>
 
 # The main event: fetch a block's blobs from a live beacon node, derive its
-# 128 data column sidecars locally (real KZG cells + proofs), submit them all,
-# and wait until the data node has verified and stored every one.
+# 128 data column sidecars locally (real KZG cells + proofs), submit them all
+# as ONE SSZ batch request, and wait until the data node has verified and
+# stored every one.
 ream-data-availability-tool feed --beacon-url <beacon-api-url> [block_id]
+
+# The legacy path — 128 JSON requests, one per column — kept for comparing
+# the two submission modes end to end (both print wall-clock timings).
+ream-data-availability-tool feed --beacon-url <beacon-api-url> [block_id] --per-column
 
 # The same pipeline fully offline: synthesize a KZG-valid block from all-zero
 # blobs (no beacon node anywhere) and submit it…
@@ -33,7 +38,10 @@ curl -X POST http://127.0.0.1:5062/data/v0/ingest \
 `--da-url` overrides the data node address (default `http://127.0.0.1:5062`).
 `block_id` is a slot number, `head`, `finalized`, or a `0x` block root
 (default `head`). `--columns 0,5,17` submits a subset; `--wait` bounds the
-verification wait in seconds.
+verification wait in seconds. `--per-column` switches `feed`/`generate` from
+the default single SSZ batch (`POST /ingest/block/{root}`) back to one JSON
+request per column (`POST /ingest`) — on the node side that also means 128
+separate KZG checks instead of one cross-column batched check.
 
 `generate` builds a synthetic block: real KZG cells and proofs over all-zero blobs,
 and a self-built commitments inclusion proof — valid because the data node
@@ -70,8 +78,8 @@ cargo build -p ream   # builds both the `ream` node and `ream-data-availability-
     --beacon-url https://ethereum-beacon-api.publicnode.com finalized
 # fetched 7 blob(s) for block finalized, slot 14706334
 # derived 128 column sidecars (block root 0xe4bb...a2d5)
-# submitted 128 column(s) to the data node
-# all submitted columns verified and held:
+# submitted 128 column(s) in one SSZ batch request — 89.31ms
+# all submitted columns verified and held — 412.79ms end to end (±100ms poll granularity):
 # { "complete": true, "held_count": 128, "missing": [] }
 
 # 3. ask again any time

--- a/bin/ream/src/data_availability_tool/data_availability.rs
+++ b/bin/ream/src/data_availability_tool/data_availability.rs
@@ -16,9 +16,6 @@ const OVERLOAD_RETRIES: u32 = 50;
 const OVERLOAD_BACKOFF_MS: u64 = 200;
 
 /// One `(column index, payload)` entry of the SSZ batch-ingest body.
-///
-/// Mirror of `WireIndexedPayload` in `ream-rpc-data-availability` — keep the two in sync (a
-/// shared wire crate is the production answer once the surface settles).
 #[derive(SszEncode, SszDecode)]
 struct WireIndexedPayload {
     index: u64,
@@ -94,9 +91,7 @@ impl DataAvailabilityClient {
     }
 
     /// `POST /data/v0/ingest/block/{block_root}?slot={slot}` — submit a whole
-    /// block's columns as one SSZ batch: raw payload bytes, no hex, no JSON,
-    /// one HTTP round-trip. Backs off and retries while the data node reports
-    /// overload; the batch is queued or refused as one unit.
+    /// block's columns as one SSZ batch: raw payload bytes.
     pub async fn ingest_block(
         &self,
         block_root: B256,

--- a/bin/ream/src/data_availability_tool/data_availability.rs
+++ b/bin/ream/src/data_availability_tool/data_availability.rs
@@ -2,15 +2,31 @@
 //! surface the beacon-side feeder will speak.
 
 use alloy_primitives::B256;
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use reqwest::StatusCode;
 use serde_json::{Value, json};
+use ssz::Encode;
+use ssz_derive::{Decode as SszDecode, Encode as SszEncode};
+use ssz_types::{VariableList, typenum};
 
-/// How long to keep retrying a `503 Service Unavailable` from `/ingest` (the
-/// data node sheds load when its verification queue is full; that is a
-/// retry-shortly signal, not a failure).
+/// How long to keep retrying a `503 Service Unavailable` from the ingest
+/// endpoints (the data node sheds load when its verification queue is full; that
+/// is a retry-shortly signal, not a failure).
 const OVERLOAD_RETRIES: u32 = 50;
 const OVERLOAD_BACKOFF_MS: u64 = 200;
+
+/// One `(column index, payload)` entry of the SSZ batch-ingest body.
+///
+/// Mirror of `WireIndexedPayload` in `ream-rpc-data-availability` — keep the two in sync (a
+/// shared wire crate is the production answer once the surface settles).
+#[derive(SszEncode, SszDecode)]
+struct WireIndexedPayload {
+    index: u64,
+    payload: VariableList<u8, typenum::U16777216>,
+}
+
+/// SSZ body of `POST /data/v0/ingest/block/{block_root}`.
+type WireBlockBatch = VariableList<WireIndexedPayload, typenum::U128>;
 
 pub struct DataAvailabilityClient {
     http: reqwest::Client,
@@ -71,6 +87,58 @@ impl DataAvailabilityClient {
                 status => {
                     let body = response.text().await.unwrap_or_default();
                     bail!("data node rejected column {index}: {status}: {body}");
+                }
+            }
+        }
+        bail!("data node still overloaded after {OVERLOAD_RETRIES} retries");
+    }
+
+    /// `POST /data/v0/ingest/block/{block_root}?slot={slot}` — submit a whole
+    /// block's columns as one SSZ batch: raw payload bytes, no hex, no JSON,
+    /// one HTTP round-trip. Backs off and retries while the data node reports
+    /// overload; the batch is queued or refused as one unit.
+    pub async fn ingest_block(
+        &self,
+        block_root: B256,
+        slot: u64,
+        columns: &[(u64, Vec<u8>)],
+    ) -> Result<()> {
+        let entries: Vec<WireIndexedPayload> = columns
+            .iter()
+            .map(|(index, payload)| {
+                Ok(WireIndexedPayload {
+                    index: *index,
+                    payload: VariableList::new(payload.clone())
+                        .map_err(|err| anyhow!("column payload too large: {err:?}"))?,
+                })
+            })
+            .collect::<Result<_>>()?;
+        let batch: WireBlockBatch = VariableList::new(entries)
+            .map_err(|err| anyhow!("too many columns for one block: {err:?}"))?;
+        let body = batch.as_ssz_bytes();
+
+        let url = format!(
+            "{}/data/v0/ingest/block/{block_root}?slot={slot}",
+            self.base
+        );
+        for _ in 0..OVERLOAD_RETRIES {
+            let response = self
+                .http
+                .post(&url)
+                .header("content-type", "application/octet-stream")
+                .body(body.clone())
+                .send()
+                .await
+                .with_context(|| format!("POST {url}"))?;
+
+            match response.status() {
+                StatusCode::ACCEPTED => return Ok(()),
+                StatusCode::SERVICE_UNAVAILABLE => {
+                    tokio::time::sleep(std::time::Duration::from_millis(OVERLOAD_BACKOFF_MS)).await;
+                }
+                status => {
+                    let body = response.text().await.unwrap_or_default();
+                    bail!("data node rejected the batch: {status}: {body}");
                 }
             }
         }

--- a/bin/ream/src/data_availability_tool/main.rs
+++ b/bin/ream/src/data_availability_tool/main.rs
@@ -2,8 +2,8 @@
 //! Usage:
 //!   ream-data-availability-tool health
 //!   ream-data-availability-tool availability <block_root>
-//!   ream-data-availability-tool feed --beacon-url <url> [block_id] [--columns 0,1,2] [--wait 30]
-//!   ream-data-availability-tool generate [--slot 1] [--blobs 1] [--out dir]
+//!   ream-data-availability-tool feed --beacon-url <url> [block_id] [--columns 0,1,2] [--wait 30] [--per-column]
+//!   ream-data-availability-tool generate [--slot 1] [--blobs 1] [--out dir] [--per-column]
 
 mod beacon;
 mod data_availability;
@@ -59,6 +59,11 @@ enum Command {
         /// Seconds to wait for the data node to verify the submitted columns.
         #[arg(long, default_value_t = 30)]
         wait: u64,
+        /// Submit one JSON request per column through `/ingest` instead of one
+        /// SSZ batch through `/ingest/block` — the legacy path, kept for
+        /// comparing the two end to end.
+        #[arg(long)]
+        per_column: bool,
     },
     /// Synthesize a block's worth of KZG-valid sidecars offline — no beacon
     /// node needed — and submit them, or write them as ingest-ready vectors.
@@ -80,6 +85,11 @@ enum Command {
         /// Seconds to wait for the data node to verify the submitted columns.
         #[arg(long, default_value_t = 30)]
         wait: u64,
+        /// Submit one JSON request per column through `/ingest` instead of one
+        /// SSZ batch through `/ingest/block` — the legacy path, kept for
+        /// comparing the two end to end.
+        #[arg(long)]
+        per_column: bool,
     },
 }
 
@@ -102,6 +112,7 @@ async fn main() -> Result<()> {
             block_id,
             columns,
             wait,
+            per_column,
         } => {
             let blob_sidecars = beacon::fetch_blob_sidecars(&beacon_url, &block_id)
                 .await
@@ -125,7 +136,7 @@ async fn main() -> Result<()> {
             );
 
             let selected = select_columns(sidecars, columns.as_deref())?;
-            submit_and_wait(&client, block_root, slot, &selected, wait).await?;
+            submit_and_wait(&client, block_root, slot, &selected, wait, per_column).await?;
         }
         Command::Generate {
             slot,
@@ -133,6 +144,7 @@ async fn main() -> Result<()> {
             out,
             columns,
             wait,
+            per_column,
         } => {
             let (block_root, slot, sidecars) =
                 tokio::task::spawn_blocking(move || build_synthetic_sidecars(slot, blobs))
@@ -146,7 +158,9 @@ async fn main() -> Result<()> {
             let selected = select_columns(sidecars, columns.as_deref())?;
             match out {
                 Some(dir) => write_vectors(&dir, block_root, slot, &selected)?,
-                None => submit_and_wait(&client, block_root, slot, &selected, wait).await?,
+                None => {
+                    submit_and_wait(&client, block_root, slot, &selected, wait, per_column).await?
+                }
             }
         }
     }
@@ -180,24 +194,50 @@ fn payload_hex(sidecar: &DataColumnSidecar) -> String {
     )
 }
 
-/// Submit the sidecars, then poll availability until every submitted index is
-/// held (verification runs asynchronously behind the ingest queue).
+/// Submit the sidecars — one SSZ block batch by default, or one JSON request
+/// per column with `--per-column` — then poll availability until every
+/// submitted index is held (verification runs asynchronously behind the
+/// ingest queue). Prints wall-clock timings so the two submission paths can
+/// be compared end to end.
 async fn submit_and_wait(
     client: &DataAvailabilityClient,
     block_root: B256,
     slot: u64,
     sidecars: &[DataColumnSidecar],
     wait_secs: u64,
+    per_column: bool,
 ) -> Result<()> {
-    let mut submitted = Vec::with_capacity(sidecars.len());
-    for sidecar in sidecars {
+    let submitted: Vec<u64> = sidecars.iter().map(|sidecar| sidecar.index).collect();
+    let started = std::time::Instant::now();
+
+    if per_column {
+        for sidecar in sidecars {
+            client
+                .ingest(block_root, sidecar.index, slot, &payload_hex(sidecar))
+                .await
+                .with_context(|| format!("submitting column {}", sidecar.index))?;
+        }
+        println!(
+            "submitted {} column(s) in {} JSON request(s) — {:.2?}",
+            submitted.len(),
+            submitted.len(),
+            started.elapsed()
+        );
+    } else {
+        let columns: Vec<(u64, Vec<u8>)> = sidecars
+            .iter()
+            .map(|sidecar| (sidecar.index, sidecar.as_ssz_bytes()))
+            .collect();
         client
-            .ingest(block_root, sidecar.index, slot, &payload_hex(sidecar))
+            .ingest_block(block_root, slot, &columns)
             .await
-            .with_context(|| format!("submitting column {}", sidecar.index))?;
-        submitted.push(sidecar.index);
+            .context("submitting the block batch")?;
+        println!(
+            "submitted {} column(s) in one SSZ batch request — {:.2?}",
+            submitted.len(),
+            started.elapsed()
+        );
     }
-    println!("submitted {} column(s) to the data node", submitted.len());
 
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(wait_secs);
     let availability = loop {
@@ -219,10 +259,13 @@ async fn submit_and_wait(
                     .count()
             );
         }
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     };
 
-    println!("all submitted columns verified and held:");
+    println!(
+        "all submitted columns verified and held — {:.2?} end to end (±100ms poll granularity):",
+        started.elapsed()
+    );
     println!("{}", serde_json::to_string_pretty(&availability)?);
     Ok(())
 }

--- a/bin/ream/src/data_availability_tool/main.rs
+++ b/bin/ream/src/data_availability_tool/main.rs
@@ -2,8 +2,10 @@
 //! Usage:
 //!   ream-data-availability-tool health
 //!   ream-data-availability-tool availability <block_root>
-//!   ream-data-availability-tool feed --beacon-url <url> [block_id] [--columns 0,1,2] [--wait 30] [--per-column]
-//!   ream-data-availability-tool generate [--slot 1] [--blobs 1] [--out dir] [--per-column]
+//!   ream-data-availability-tool feed --beacon-url <url> [block_id] [--columns 0,1,2]
+//!       [--wait 30] [--per-column]
+//!   ream-data-availability-tool generate [--slot 1] [--blobs 1] [--out dir]
+//!       [--per-column]
 
 mod beacon;
 mod data_availability;

--- a/bin/ream/src/data_availability_tool/main.rs
+++ b/bin/ream/src/data_availability_tool/main.rs
@@ -59,9 +59,7 @@ enum Command {
         /// Seconds to wait for the data node to verify the submitted columns.
         #[arg(long, default_value_t = 30)]
         wait: u64,
-        /// Submit one JSON request per column through `/ingest` instead of one
-        /// SSZ batch through `/ingest/block` — the legacy path, kept for
-        /// comparing the two end to end.
+        /// Submit one JSON request per column through `/ingest`
         #[arg(long)]
         per_column: bool,
     },
@@ -85,9 +83,7 @@ enum Command {
         /// Seconds to wait for the data node to verify the submitted columns.
         #[arg(long, default_value_t = 30)]
         wait: u64,
-        /// Submit one JSON request per column through `/ingest` instead of one
-        /// SSZ batch through `/ingest/block` — the legacy path, kept for
-        /// comparing the two end to end.
+        /// Submit one JSON request per column through `/ingest`
         #[arg(long)]
         per_column: bool,
     },
@@ -195,10 +191,7 @@ fn payload_hex(sidecar: &DataColumnSidecar) -> String {
 }
 
 /// Submit the sidecars — one SSZ block batch by default, or one JSON request
-/// per column with `--per-column` — then poll availability until every
-/// submitted index is held (verification runs asynchronously behind the
-/// ingest queue). Prints wall-clock timings so the two submission paths can
-/// be compared end to end.
+/// per column with `--per-column`
 async fn submit_and_wait(
     client: &DataAvailabilityClient,
     block_root: B256,

--- a/crates/common/api_types/common/src/error.rs
+++ b/crates/common/api_types/common/src/error.rs
@@ -29,6 +29,9 @@ pub enum ApiError {
 
     #[error("Service Unavailable: {0}")]
     ServiceUnavailable(String),
+
+    #[error("Unsupported Media Type: {0}")]
+    UnsupportedMediaType(String),
 }
 
 impl ResponseError for ApiError {
@@ -47,6 +50,7 @@ impl ResponseError for ApiError {
             ApiError::TooManyValidatorsIds => StatusCode::URI_TOO_LONG,
             ApiError::UnderSyncing => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+            ApiError::UnsupportedMediaType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
         }
     }
 }

--- a/crates/common/data_availability/src/column.rs
+++ b/crates/common/data_availability/src/column.rs
@@ -1,6 +1,7 @@
+use alloy_primitives::B256;
 use serde::{Deserialize, Serialize};
 
-use crate::id::ColumnId;
+use crate::{error::ValidationError, id::ColumnId};
 
 /// Consensus-derived context attached to a candidate column.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -45,5 +46,167 @@ impl VerifiedColumn {
 
     pub fn payload(&self) -> &[u8] {
         &self.payload
+    }
+}
+
+/// A whole block's worth of candidate columns, submitted as one unit.
+///
+/// The block root and context are stored once, so a batch mixing columns from
+/// different blocks is unrepresentable. Construction validates structure only
+/// — non-empty, in-range, duplicate-free indices — and never reads payload
+/// bytes; content verification is the verifier's job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CandidateBlock {
+    block_root: B256,
+    context: ColumnContext,
+    columns: Vec<(u64, Vec<u8>)>,
+}
+
+impl CandidateBlock {
+    /// Validate the batch structure: rejects an empty batch, out-of-range
+    /// column indices, and duplicate column indices. A valid batch is
+    /// therefore also bounded by the column count of one block.
+    pub fn new(
+        block_root: B256,
+        context: ColumnContext,
+        columns: Vec<(u64, Vec<u8>)>,
+    ) -> Result<Self, ValidationError> {
+        if columns.is_empty() {
+            return Err(ValidationError::EmptyBatch);
+        }
+
+        let mut seen = 0u128;
+        for (index, _) in &columns {
+            // Range check first, delegated to the id type — the single owner
+            // of that invariant.
+            ColumnId::new(block_root, *index)?;
+            let bit = 1u128 << *index;
+            if seen & bit != 0 {
+                return Err(ValidationError::DuplicateColumnIndex {
+                    column_index: *index,
+                });
+            }
+            seen |= bit;
+        }
+
+        Ok(Self {
+            block_root,
+            context,
+            columns,
+        })
+    }
+
+    pub fn block_root(&self) -> B256 {
+        self.block_root
+    }
+
+    pub fn context(&self) -> ColumnContext {
+        self.context
+    }
+
+    pub fn columns(&self) -> &[(u64, Vec<u8>)] {
+        &self.columns
+    }
+
+    pub fn columns_len(&self) -> usize {
+        self.columns.len()
+    }
+
+    /// Explode into per-column candidates, in submission order.
+    ///
+    /// Id construction cannot fail here: every index was validated by
+    /// [`CandidateBlock::new`].
+    pub fn into_columns(self) -> impl Iterator<Item = CandidateColumn> {
+        let block_root = self.block_root;
+        let context = self.context;
+        self.columns.into_iter().map(move |(index, payload)| {
+            let id = ColumnId::new(block_root, index)
+                .expect("batch indices are validated at construction");
+            CandidateColumn {
+                id,
+                context,
+                payload,
+            }
+        })
+    }
+
+    /// Decompose into `(block_root, context, columns)`, the inverse of
+    /// [`CandidateBlock::new`] — for callers that filter the batch (e.g. drop
+    /// already-held columns) and rebuild it.
+    pub fn into_parts(self) -> (B256, ColumnContext, Vec<(u64, Vec<u8>)>) {
+        (self.block_root, self.context, self.columns)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+
+    use super::{CandidateBlock, ColumnContext};
+    use crate::{error::ValidationError, id::NUMBER_OF_COLUMNS};
+
+    fn payload(byte: u8) -> Vec<u8> {
+        vec![byte]
+    }
+
+    #[test]
+    fn candidate_block_rejects_an_empty_batch() {
+        assert_eq!(
+            CandidateBlock::new(B256::ZERO, ColumnContext::default(), vec![]),
+            Err(ValidationError::EmptyBatch),
+        );
+    }
+
+    #[test]
+    fn candidate_block_rejects_an_out_of_range_index() {
+        let columns = vec![(0, payload(0)), (NUMBER_OF_COLUMNS, payload(1))];
+        assert!(matches!(
+            CandidateBlock::new(B256::ZERO, ColumnContext::default(), columns),
+            Err(ValidationError::InvalidColumnIndex { .. }),
+        ));
+    }
+
+    #[test]
+    fn candidate_block_rejects_a_duplicate_index() {
+        let columns = vec![(3, payload(0)), (5, payload(1)), (3, payload(2))];
+        assert_eq!(
+            CandidateBlock::new(B256::ZERO, ColumnContext::default(), columns),
+            Err(ValidationError::DuplicateColumnIndex { column_index: 3 }),
+        );
+    }
+
+    #[test]
+    fn candidate_block_accepts_a_full_block_and_explodes_in_order() {
+        let block_root = B256::repeat_byte(7);
+        let context = ColumnContext { slot: 42 };
+        let columns: Vec<_> = (0..NUMBER_OF_COLUMNS)
+            .map(|index| (index, payload(index as u8)))
+            .collect();
+
+        let block = CandidateBlock::new(block_root, context, columns).expect("a valid batch");
+        assert_eq!(block.columns_len(), NUMBER_OF_COLUMNS as usize);
+        assert_eq!(block.block_root(), block_root);
+        assert_eq!(block.context(), context);
+
+        // Explodes into per-column candidates carrying the shared root/context,
+        // in submission order.
+        for (expected_index, candidate) in block.into_columns().enumerate() {
+            assert_eq!(candidate.id.index(), expected_index as u64);
+            assert_eq!(candidate.id.block_root(), block_root);
+            assert_eq!(candidate.context, context);
+            assert_eq!(candidate.payload, &[expected_index as u8]);
+        }
+    }
+
+    #[test]
+    fn candidate_block_round_trips_through_parts() {
+        let columns = vec![(1, payload(1)), (9, payload(9))];
+        let block = CandidateBlock::new(B256::ZERO, ColumnContext { slot: 5 }, columns.clone())
+            .expect("a valid batch");
+
+        let (root, context, parts) = block.into_parts();
+        assert_eq!(root, B256::ZERO);
+        assert_eq!(context.slot, 5);
+        assert_eq!(parts, columns);
     }
 }

--- a/crates/common/data_availability/src/column.rs
+++ b/crates/common/data_availability/src/column.rs
@@ -50,11 +50,6 @@ impl VerifiedColumn {
 }
 
 /// A whole block's worth of candidate columns, submitted as one unit.
-///
-/// The block root and context are stored once, so a batch mixing columns from
-/// different blocks is unrepresentable. Construction validates structure only
-/// — non-empty, in-range, duplicate-free indices — and never reads payload
-/// bytes; content verification is the verifier's job.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CandidateBlock {
     block_root: B256,
@@ -64,8 +59,7 @@ pub struct CandidateBlock {
 
 impl CandidateBlock {
     /// Validate the batch structure: rejects an empty batch, out-of-range
-    /// column indices, and duplicate column indices. A valid batch is
-    /// therefore also bounded by the column count of one block.
+    /// column indices, and duplicate column indices.
     pub fn new(
         block_root: B256,
         context: ColumnContext,
@@ -113,9 +107,6 @@ impl CandidateBlock {
     }
 
     /// Explode into per-column candidates, in submission order.
-    ///
-    /// Id construction cannot fail here: every index was validated by
-    /// [`CandidateBlock::new`].
     pub fn into_columns(self) -> impl Iterator<Item = CandidateColumn> {
         let block_root = self.block_root;
         let context = self.context;
@@ -130,9 +121,7 @@ impl CandidateBlock {
         })
     }
 
-    /// Decompose into `(block_root, context, columns)`, the inverse of
-    /// [`CandidateBlock::new`] — for callers that filter the batch (e.g. drop
-    /// already-held columns) and rebuild it.
+    /// Decompose into `(block_root, context, columns)`
     pub fn into_parts(self) -> (B256, ColumnContext, Vec<(u64, Vec<u8>)>) {
         (self.block_root, self.context, self.columns)
     }

--- a/crates/common/data_availability/src/error.rs
+++ b/crates/common/data_availability/src/error.rs
@@ -42,6 +42,12 @@ pub enum ValidationError {
 
     #[error("verifier error: {0}")]
     VerifierFailure(String),
+
+    #[error("block batch contains no columns")]
+    EmptyBatch,
+
+    #[error("duplicate column index {column_index} in block batch")]
+    DuplicateColumnIndex { column_index: u64 },
 }
 
 #[derive(Debug, Error)]

--- a/crates/common/data_availability/src/verifier.rs
+++ b/crates/common/data_availability/src/verifier.rs
@@ -12,11 +12,6 @@ pub trait ColumnVerifier: Send + Sync {
     /// block. Per-column verdicts (rather than all-or-nothing) fit mixed-trust
     /// sources like backfill, where one invalid column says nothing about its
     /// 127 siblings.
-    ///
-    /// The default implementation simply funnels each column through
-    /// [`ColumnVerifier::verify`]; scheme adapters should override it when they can
-    /// amortize cryptography across the block (e.g. one batched KZG pairing
-    /// check instead of one per column).
     fn verify_block(
         &self,
         block: CandidateBlock,

--- a/crates/common/data_availability/src/verifier.rs
+++ b/crates/common/data_availability/src/verifier.rs
@@ -5,13 +5,6 @@ use crate::{
 
 pub trait ColumnVerifier: Send + Sync {
     fn verify(&self, candidate: CandidateColumn) -> Result<VerifiedColumn, ValidationError>;
-    /// Verify a whole block's candidate batch.
-    ///
-    /// Returns one verdict per submitted column — tagged with its column index,
-    /// in submission order — so a bad column never blocks the rest of the
-    /// block. Per-column verdicts (rather than all-or-nothing) fit mixed-trust
-    /// sources like backfill, where one invalid column says nothing about its
-    /// 127 siblings.
     fn verify_block(
         &self,
         block: CandidateBlock,

--- a/crates/common/data_availability/src/verifier.rs
+++ b/crates/common/data_availability/src/verifier.rs
@@ -1,8 +1,84 @@
 use crate::{
-    column::{CandidateColumn, VerifiedColumn},
+    column::{CandidateBlock, CandidateColumn, VerifiedColumn},
     error::ValidationError,
 };
 
 pub trait ColumnVerifier: Send + Sync {
     fn verify(&self, candidate: CandidateColumn) -> Result<VerifiedColumn, ValidationError>;
+    /// Verify a whole block's candidate batch.
+    ///
+    /// Returns one verdict per submitted column — tagged with its column index,
+    /// in submission order — so a bad column never blocks the rest of the
+    /// block. Per-column verdicts (rather than all-or-nothing) fit mixed-trust
+    /// sources like backfill, where one invalid column says nothing about its
+    /// 127 siblings.
+    ///
+    /// The default implementation simply funnels each column through
+    /// [`ColumnVerifier::verify`]; scheme adapters should override it when they can
+    /// amortize cryptography across the block (e.g. one batched KZG pairing
+    /// check instead of one per column).
+    fn verify_block(
+        &self,
+        block: CandidateBlock,
+    ) -> Vec<(u64, Result<VerifiedColumn, ValidationError>)> {
+        block
+            .into_columns()
+            .map(|candidate| (candidate.id.index(), self.verify(candidate)))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+
+    use super::ColumnVerifier;
+    use crate::{
+        column::{CandidateBlock, CandidateColumn, ColumnContext, VerifiedColumn},
+        error::ValidationError,
+    };
+
+    /// A stub that accepts even column indices and rejects odd ones, so a
+    /// batch exercises both verdict kinds in one pass.
+    struct RejectOddIndices;
+
+    impl ColumnVerifier for RejectOddIndices {
+        fn verify(&self, candidate: CandidateColumn) -> Result<VerifiedColumn, ValidationError> {
+            if candidate.id.index() % 2 == 1 {
+                return Err(ValidationError::InvalidProof);
+            }
+            Ok(VerifiedColumn::new_unchecked(
+                candidate.id,
+                candidate.context,
+                candidate.payload,
+            ))
+        }
+    }
+
+    #[test]
+    fn default_verify_block_yields_one_tagged_verdict_per_column() {
+        let block = CandidateBlock::new(
+            B256::repeat_byte(1),
+            ColumnContext { slot: 9 },
+            (0..4).map(|index| (index, vec![])).collect(),
+        )
+        .expect("a valid batch");
+
+        let verdicts = RejectOddIndices.verify_block(block);
+
+        // One verdict per column, tagged, in submission order; a rejected
+        // column does not disturb its neighbours.
+        assert_eq!(verdicts.len(), 4);
+        for (position, (index, verdict)) in verdicts.iter().enumerate() {
+            assert_eq!(*index, position as u64);
+            match index % 2 {
+                0 => {
+                    let verified = verdict.as_ref().expect("even indices are accepted");
+                    assert_eq!(verified.id().index(), *index);
+                    assert_eq!(verified.context().slot, 9);
+                }
+                _ => assert_eq!(verdict, &Err(ValidationError::InvalidProof)),
+            }
+        }
+    }
 }

--- a/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
+++ b/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
@@ -8,7 +8,10 @@ use ream_data_availability::{
     id::ColumnId,
     verifier::ColumnVerifier,
 };
-use ream_polynomial_commitments::{handlers::verify_data_column_sidecar_kzg_proofs, trusted_setup};
+use ream_polynomial_commitments::{
+    handlers::{verify_data_column_sidecar_kzg_proofs, verify_data_column_sidecars_batch},
+    trusted_setup,
+};
 use ssz::Decode;
 use tree_hash::TreeHash;
 
@@ -89,10 +92,9 @@ impl KzgVerifier {
         }
         Ok(())
     }
-}
 
-impl ColumnVerifier for KzgVerifier {
-    fn verify(&self, candidate: CandidateColumn) -> Result<VerifiedColumn, ValidationError> {
+    /// Every check before the kzg verification
+    fn precheck(&self, candidate: &CandidateColumn) -> Result<DataColumnSidecar, ValidationError> {
         let sidecar = self.decode(&candidate.payload)?;
 
         // The id is derived from the payload's own signed header, so a
@@ -126,6 +128,14 @@ impl ColumnVerifier for KzgVerifier {
             return Err(ValidationError::InvalidInclusionProof);
         }
 
+        Ok(sidecar)
+    }
+}
+
+impl ColumnVerifier for KzgVerifier {
+    fn verify(&self, candidate: CandidateColumn) -> Result<VerifiedColumn, ValidationError> {
+        let sidecar = self.precheck(&candidate)?;
+
         match verify_data_column_sidecar_kzg_proofs(&sidecar) {
             Ok(true) => {}
             Ok(false) => return Err(ValidationError::InvalidProof),
@@ -139,14 +149,58 @@ impl ColumnVerifier for KzgVerifier {
         ))
     }
 
+    /// Batched verification of a whole block's columns.
     fn verify_block(
         &self,
         block: CandidateBlock,
     ) -> Vec<(u64, Result<VerifiedColumn, ValidationError>)> {
-        block
-            .into_columns()
-            .map(|candidate| (candidate.id.index(), self.verify(candidate)))
-            .collect()
+        // Step 1: prechecks, one verdict slot per column in submission order.
+        let mut verdicts: Vec<(u64, Result<VerifiedColumn, ValidationError>)> = Vec::new();
+        let mut survivors: Vec<(usize, DataColumnSidecar, CandidateColumn)> = Vec::new();
+        for candidate in block.into_columns() {
+            let index = candidate.id.index();
+            match self.precheck(&candidate) {
+                Ok(sidecar) => {
+                    survivors.push((verdicts.len(), sidecar, candidate));
+                    // To keep the order of index, these values will be overwritten in the step 2
+                    verdicts.push((index, Err(ValidationError::InvalidProof)));
+                }
+                Err(err) => verdicts.push((index, Err(err))),
+            }
+        }
+        if survivors.is_empty() {
+            return verdicts;
+        }
+
+        // Step 2: one cross-column KZG batch over every survivor.
+        let batch_verdict =
+            verify_data_column_sidecars_batch(survivors.iter().map(|(_, sidecar, _)| sidecar));
+        match batch_verdict {
+            Ok(true) => {
+                for (position, _, candidate) in survivors {
+                    verdicts[position].1 = Ok(VerifiedColumn::new_unchecked(
+                        candidate.id,
+                        candidate.context,
+                        candidate.payload,
+                    ));
+                }
+            }
+            // Fallback: if batch verifcation fails, re-check per column
+            Ok(false) | Err(_) => {
+                for (position, sidecar, candidate) in survivors {
+                    verdicts[position].1 = match verify_data_column_sidecar_kzg_proofs(&sidecar) {
+                        Ok(true) => Ok(VerifiedColumn::new_unchecked(
+                            candidate.id,
+                            candidate.context,
+                            candidate.payload,
+                        )),
+                        Ok(false) => Err(ValidationError::InvalidProof),
+                        Err(err) => Err(ValidationError::VerifierFailure(format!("{err:?}"))),
+                    };
+                }
+            }
+        }
+        verdicts
     }
 }
 
@@ -168,7 +222,7 @@ mod tests {
         polynomial_commitments::{kzg_commitment::KZGCommitment, kzg_proof::KZGProof},
     };
     use ream_data_availability::{
-        column::{CandidateColumn, ColumnContext},
+        column::{CandidateBlock, CandidateColumn, ColumnContext},
         error::ValidationError,
         id::ColumnId,
         verifier::ColumnVerifier,
@@ -220,8 +274,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn accepts_a_valid_sidecar() {
+    /// A full set of 128 KZG-valid sidecars over one all-zero blob
+    fn real_sidecars() -> Vec<DataColumnSidecar> {
         let blob = Blob {
             inner: FixedVector::default(),
         };
@@ -229,7 +283,6 @@ mod tests {
         let (cells, proofs) =
             compute_cells_and_kzg_proofs(&blob, &das_context).expect("compute cells and proofs");
 
-        // The zero polynomial's commitment is the G1 point at infinity.
         let mut commitment_bytes = [0u8; 48];
         commitment_bytes[0] = 0xc0;
         let kzg_commitments = VariableList::new(vec![KZGCommitment(commitment_bytes)])
@@ -262,13 +315,33 @@ mod tests {
             signature: Default::default(),
         };
 
-        let sidecars = get_data_column_sidecars(
+        get_data_column_sidecars(
             signed_block_header,
             kzg_commitments,
             inclusion_proof,
             vec![(cells, proofs)],
         )
-        .expect("assemble column sidecars");
+        .expect("assemble column sidecars")
+    }
+
+    /// A candidate batch built the way the RPC does it: shared root and slot
+    /// from the header, one `(index, payload)` entry per sidecar.
+    fn block_of(sidecars: &[DataColumnSidecar]) -> CandidateBlock {
+        let header = &sidecars[0].signed_block_header.message;
+        CandidateBlock::new(
+            header.tree_hash_root(),
+            ColumnContext { slot: header.slot },
+            sidecars
+                .iter()
+                .map(|sidecar| (sidecar.index, payload_of(sidecar)))
+                .collect(),
+        )
+        .expect("a valid batch")
+    }
+
+    #[test]
+    fn accepts_a_valid_sidecar() {
+        let sidecars = real_sidecars();
 
         let sidecar = &sidecars[7];
         let verified = verifier()
@@ -277,6 +350,51 @@ mod tests {
 
         assert_eq!(verified.id().index(), sidecar.index);
         assert_eq!(verified.payload(), sidecar.as_ssz_bytes());
+    }
+
+    #[test]
+    fn verify_block_accepts_a_real_batch() {
+        let sidecars = real_sidecars();
+
+        // Several real columns as one batch: every verdict comes back Ok
+        // through the single cross-column KZG check.
+        let verdicts = verifier().verify_block(block_of(&sidecars[0..4]));
+
+        assert_eq!(verdicts.len(), 4);
+        for (position, (index, verdict)) in verdicts.iter().enumerate() {
+            assert_eq!(*index, position as u64);
+            let verified = verdict.as_ref().expect("a KZG-valid column is accepted");
+            assert_eq!(verified.id().index(), *index);
+        }
+    }
+
+    #[test]
+    fn verify_block_corrupt_one_proof() {
+        let sidecars = real_sidecars();
+
+        // Corrupt one column's proof: the batched check fails as a whole, and
+        // the per-column fallback must pin the failure on exactly that column.
+        let mut batch = sidecars[0..4].to_vec();
+        let mut bad_proof = batch[2].kzg_proofs[0];
+        bad_proof.0[10] ^= 0xff;
+        batch[2].kzg_proofs = VariableList::new(vec![bad_proof]).expect("proofs within bounds");
+
+        let verdicts = verifier().verify_block(block_of(&batch));
+
+        assert_eq!(verdicts.len(), 4);
+        for (index, verdict) in &verdicts {
+            match index {
+                2 => assert!(
+                    matches!(
+                        verdict,
+                        Err(ValidationError::InvalidProof)
+                            | Err(ValidationError::VerifierFailure(_))
+                    ),
+                    "the corrupted column is rejected"
+                ),
+                _ => assert!(verdict.is_ok(), "innocent column {index} still passes"),
+            }
+        }
     }
 
     #[test]

--- a/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
+++ b/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use ream_consensus_beacon::data_column_sidecar::DataColumnSidecar;
 use ream_consensus_misc::{blob_parameters::BlobParameters, misc::compute_epoch_at_slot};
 use ream_data_availability::{
-    column::{CandidateColumn, VerifiedColumn},
+    column::{CandidateBlock, CandidateColumn, VerifiedColumn},
     error::ValidationError,
     id::ColumnId,
     verifier::ColumnVerifier,
@@ -137,6 +137,16 @@ impl ColumnVerifier for KzgVerifier {
             candidate.context,
             candidate.payload,
         ))
+    }
+
+    fn verify_block(
+        &self,
+        block: CandidateBlock,
+    ) -> Vec<(u64, Result<VerifiedColumn, ValidationError>)> {
+        block
+            .into_columns()
+            .map(|candidate| (candidate.id.index(), self.verify(candidate)))
+            .collect()
     }
 }
 

--- a/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
+++ b/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
@@ -324,8 +324,6 @@ mod tests {
         .expect("assemble column sidecars")
     }
 
-    /// A candidate batch built the way the RPC does it: shared root and slot
-    /// from the header, one `(index, payload)` entry per sidecar.
     fn block_of(sidecars: &[DataColumnSidecar]) -> CandidateBlock {
         let header = &sidecars[0].signed_block_header.message;
         CandidateBlock::new(

--- a/crates/common/data_availability_node/src/ingest.rs
+++ b/crates/common/data_availability_node/src/ingest.rs
@@ -51,9 +51,6 @@ impl IngestHandle {
     }
 
     /// Submit a whole block's batch, awaiting while the queue is full.
-    ///
-    /// Like [`Self::submit`], applies backpressure instead of dropping work.
-    /// The batch takes a single queue slot, so a block is never half-enqueued.
     pub async fn submit_block(&self, candidate: CandidateBlock) -> Result<(), IngestionError> {
         self.sender
             .send(IngestWorkItem::CandidateBlock(candidate))
@@ -62,11 +59,6 @@ impl IngestHandle {
     }
 
     /// Submit a whole block's batch without waiting.
-    ///
-    /// Like [`Self::try_submit`], returns [`IngestionError::Overloaded`] when
-    /// the queue is full — the whole batch is shed and the caller (e.g. an RPC
-    /// handler answering 503) retries the block as one unit, never tracking
-    /// partial admission.
     pub fn try_submit_block(&self, candidate: CandidateBlock) -> Result<(), IngestionError> {
         self.sender
             .try_send(IngestWorkItem::CandidateBlock(candidate))

--- a/crates/common/data_availability_node/src/ingest.rs
+++ b/crates/common/data_availability_node/src/ingest.rs
@@ -55,7 +55,10 @@ impl IngestHandle {
         self.sender
             .send(IngestWorkItem::CandidateBlock(candidate))
             .await
-            .map_err(|_| IngestionError::Closed)
+            .map_err(|err| {
+                debug!("block submission failed, receiver dropped: {err}");
+                IngestionError::Closed
+            })
     }
 
     /// Submit a whole block's batch without waiting.

--- a/crates/common/data_availability_node/src/ingest.rs
+++ b/crates/common/data_availability_node/src/ingest.rs
@@ -1,4 +1,4 @@
-use ream_data_availability::column::CandidateColumn;
+use ream_data_availability::column::{CandidateBlock, CandidateColumn};
 use tokio::sync::mpsc;
 use tracing::debug;
 
@@ -8,6 +8,9 @@ use crate::error::IngestionError;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IngestWorkItem {
     Candidate(CandidateColumn),
+    /// A whole block's worth of candidate columns. One block occupies one
+    /// queue slot, so admission is all-or-nothing, never split.
+    CandidateBlock(CandidateBlock),
     /// A beacon-issued retention boundary.
     Retention(RetentionHint),
 }
@@ -41,6 +44,32 @@ impl IngestHandle {
     pub fn try_submit(&self, candidate: CandidateColumn) -> Result<(), IngestionError> {
         self.sender
             .try_send(IngestWorkItem::Candidate(candidate))
+            .map_err(|err| match err {
+                mpsc::error::TrySendError::Full(_) => IngestionError::Overloaded,
+                mpsc::error::TrySendError::Closed(_) => IngestionError::Closed,
+            })
+    }
+
+    /// Submit a whole block's batch, awaiting while the queue is full.
+    ///
+    /// Like [`Self::submit`], applies backpressure instead of dropping work.
+    /// The batch takes a single queue slot, so a block is never half-enqueued.
+    pub async fn submit_block(&self, candidate: CandidateBlock) -> Result<(), IngestionError> {
+        self.sender
+            .send(IngestWorkItem::CandidateBlock(candidate))
+            .await
+            .map_err(|_| IngestionError::Closed)
+    }
+
+    /// Submit a whole block's batch without waiting.
+    ///
+    /// Like [`Self::try_submit`], returns [`IngestionError::Overloaded`] when
+    /// the queue is full — the whole batch is shed and the caller (e.g. an RPC
+    /// handler answering 503) retries the block as one unit, never tracking
+    /// partial admission.
+    pub fn try_submit_block(&self, candidate: CandidateBlock) -> Result<(), IngestionError> {
+        self.sender
+            .try_send(IngestWorkItem::CandidateBlock(candidate))
             .map_err(|err| match err {
                 mpsc::error::TrySendError::Full(_) => IngestionError::Overloaded,
                 mpsc::error::TrySendError::Closed(_) => IngestionError::Closed,

--- a/crates/common/data_availability_node/src/service.rs
+++ b/crates/common/data_availability_node/src/service.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use ream_data_availability::{
-    column::CandidateColumn,
+    column::{CandidateBlock, CandidateColumn},
     store::{ColumnWriteStore, InsertOutcome},
     verifier::ColumnVerifier,
 };
 use ream_executor::ReamExecutor;
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::ingest::{IngestWorkItem, RetentionHint};
 
@@ -42,6 +42,9 @@ impl DataAvailabilityVerificationService {
         while let Some(item) = self.receiver.recv().await {
             match item {
                 IngestWorkItem::Candidate(candidate) => self.process_candidate(candidate).await,
+                IngestWorkItem::CandidateBlock(candidate) => {
+                    self.process_candidate_block(candidate).await
+                }
                 IngestWorkItem::Retention(hint) => self.process_retention(hint).await,
             }
         }
@@ -142,6 +145,113 @@ impl DataAvailabilityVerificationService {
             }
         }
     }
+
+    /// Verify a whole block's candidate batch and persist every column that passes.
+    async fn process_candidate_block(&self, candidate: CandidateBlock) {
+        let block_root = candidate.block_root();
+        let submitted = candidate.columns_len();
+
+        // One bitmap lookup covers the pre-check for the whole batch. As in
+        // the single-column path, a failed pre-check falls through to
+        // verification rather than dropping the batch.
+        let candidate = match self.store.availability(block_root) {
+            Ok(availability) => {
+                let (root, context, mut columns) = candidate.into_parts();
+                columns.retain(|(index, _)| {
+                    let held = availability.holds(*index);
+                    if held {
+                        trace!(
+                            "skipping already-held column: block root {block_root}, column {index}"
+                        );
+                    }
+                    !held
+                });
+                // Re-sending a stored block (e.g. a retry after a 503) is a
+                // normal path, not a fault.
+                if columns.is_empty() {
+                    debug!("skipping fully-held block batch: block root {block_root}");
+                    return;
+                }
+                // Re-assembly cannot fail
+                match CandidateBlock::new(root, context, columns) {
+                    Ok(block) => block,
+                    Err(err) => {
+                        error!("failed to rebuild filtered batch: {err}");
+                        return;
+                    }
+                }
+            }
+            Err(err) => {
+                debug!("presence pre-check failed, verifying the whole batch: {err}");
+                candidate
+            }
+        };
+
+        // One verifier call for the block; adapters may batch the cryptography.
+        let verifier = self.verifier.clone();
+        let verdicts = match self
+            .executor
+            .spawn_blocking(move || verifier.verify_block(candidate))
+            .await
+        {
+            Ok(verdicts) => verdicts,
+            Err(err) => {
+                error!("verification worker panicked or was cancelled: {err}");
+                return;
+            }
+        };
+
+        // Sort the verdicts, and rejects are only counted and logged.
+        let mut rejected = 0usize;
+        let verified: Vec<_> = verdicts
+            .into_iter()
+            .filter_map(|(index, verdict)| match verdict {
+                Ok(column) => Some(column),
+                Err(err) => {
+                    rejected += 1;
+                    debug!(
+                        "rejected candidate column: block root {block_root}, column {index}: {err}"
+                    );
+                    None
+                }
+            })
+            .collect();
+
+        // Persist all survivors in one storage hop
+        let store = self.store.clone();
+        let stored = match self
+            .executor
+            .spawn_blocking(move || {
+                let mut stored = 0usize;
+                for column in verified {
+                    match store.put(column) {
+                        Ok(InsertOutcome::Inserted) => stored += 1,
+                        Ok(InsertOutcome::Duplicated) => {
+                            warn!("duplicated column in batch: block root {block_root}")
+                        }
+                        Err(err) => error!("failed to persist verified column: {err}"),
+                    }
+                }
+                stored
+            })
+            .await
+        {
+            Ok(stored) => stored,
+            Err(err) => {
+                error!("storage worker panicked or was cancelled: {err}");
+                return;
+            }
+        };
+
+        // One summary line per batch instead of one per column.
+        if rejected > 0 {
+            warn!(
+                "block batch {block_root}: {stored} stored, {rejected} rejected, {submitted} submitted"
+            );
+        } else {
+            debug!("block batch {block_root}: {stored} stored of {submitted} submitted");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -150,16 +260,16 @@ mod tests {
         path::PathBuf,
         sync::{
             Arc,
-            atomic::{AtomicU64, Ordering},
+            atomic::{AtomicU64, AtomicUsize, Ordering},
         },
     };
 
     use alloy_primitives::B256;
     use ream_data_availability::{
-        column::{CandidateColumn, ColumnContext, VerifiedColumn},
+        column::{CandidateBlock, CandidateColumn, ColumnContext, VerifiedColumn},
         error::ValidationError,
         id::ColumnId,
-        store::ColumnReadStore,
+        store::{ColumnReadStore, ColumnWriteStore},
         verifier::ColumnVerifier,
     };
     use ream_executor::ReamExecutor;
@@ -281,6 +391,177 @@ mod tests {
             assert_eq!(store.get(&old_a.id).expect("get"), None);
             assert_eq!(store.get(&old_b.id).expect("get"), None);
             assert!(store.get(&recent.id).expect("get").is_some());
+        });
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A verifier that counts its calls and rejects a chosen set of column
+    /// indices — lets batch tests observe both the pre-filter (skipped columns
+    /// are never verified) and per-column verdicts.
+    struct CountingVerifier {
+        calls: AtomicUsize,
+        reject: Vec<u64>,
+    }
+
+    impl CountingVerifier {
+        fn accepting_all() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                reject: vec![],
+            }
+        }
+
+        fn rejecting(reject: Vec<u64>) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                reject,
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    impl ColumnVerifier for CountingVerifier {
+        fn verify(&self, candidate: CandidateColumn) -> Result<VerifiedColumn, ValidationError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            if self.reject.contains(&candidate.id.index()) {
+                return Err(ValidationError::InvalidProof);
+            }
+            Ok(VerifiedColumn::new_unchecked(
+                candidate.id,
+                candidate.context,
+                candidate.payload,
+            ))
+        }
+    }
+
+    fn sample_block(block_root: B256, slot: u64, indices: &[u64]) -> CandidateBlock {
+        CandidateBlock::new(
+            block_root,
+            ColumnContext { slot },
+            indices
+                .iter()
+                .map(|index| (*index, vec![*index as u8]))
+                .collect(),
+        )
+        .expect("a valid batch")
+    }
+
+    /// A block batch submitted through the handle is verified and every column
+    /// lands in the store — the whole `submit_block -> queue -> verify_block ->
+    /// put` path in one go.
+    #[test]
+    fn submitted_block_batch_is_verified_and_stored() {
+        let executor = ReamExecutor::new().expect("create executor");
+        let root = temp_root();
+        let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
+        let verifier = Arc::new(CountingVerifier::accepting_all());
+        let (handle, rx) = ingest_channel(8);
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier.clone(),
+            store.clone(),
+            executor.clone(),
+        );
+
+        let block_root = B256::repeat_byte(5);
+        let block = sample_block(block_root, 40, &[0, 7, 127]);
+
+        executor.runtime().block_on(async move {
+            let service_task = tokio::spawn(service.run());
+            handle.submit_block(block).await.expect("submit block");
+            drop(handle);
+            service_task.await.expect("service task joined");
+
+            for index in [0, 7, 127] {
+                let id = ColumnId::new(block_root, index).expect("valid index");
+                let stored = store.get(&id).expect("get").expect("column present");
+                assert_eq!(stored.payload(), &[index as u8]);
+                assert_eq!(stored.context().slot, 40);
+            }
+            assert_eq!(verifier.calls(), 3, "each submitted column verified once");
+        });
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Already-held columns are filtered out by one availability lookup before
+    /// verification — the verifier never sees them.
+    #[test]
+    fn block_batch_skips_already_held_columns() {
+        let executor = ReamExecutor::new().expect("create executor");
+        let root = temp_root();
+        let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
+        let verifier = Arc::new(CountingVerifier::accepting_all());
+        let (handle, rx) = ingest_channel(8);
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier.clone(),
+            store.clone(),
+            executor.clone(),
+        );
+
+        let block_root = B256::repeat_byte(6);
+        // Column 1 is already in the store before the batch arrives.
+        store
+            .put(VerifiedColumn::new_unchecked(
+                ColumnId::new(block_root, 1).expect("valid index"),
+                ColumnContext { slot: 40 },
+                vec![1],
+            ))
+            .expect("seed store");
+
+        let block = sample_block(block_root, 40, &[0, 1, 2]);
+
+        executor.runtime().block_on(async move {
+            let service_task = tokio::spawn(service.run());
+            handle.submit_block(block).await.expect("submit block");
+            drop(handle);
+            service_task.await.expect("service task joined");
+
+            // All three columns are held...
+            for index in [0, 1, 2] {
+                let id = ColumnId::new(block_root, index).expect("valid index");
+                assert!(store.get(&id).expect("get").is_some());
+            }
+            // ...but the held one was never re-verified.
+            assert_eq!(verifier.calls(), 2, "held column skipped verification");
+        });
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Per-column verdicts: rejected columns are dropped, their siblings are
+    /// stored — one bad column never poisons the batch.
+    #[test]
+    fn block_batch_stores_survivors_when_some_columns_are_rejected() {
+        let executor = ReamExecutor::new().expect("create executor");
+        let root = temp_root();
+        let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
+        let verifier = Arc::new(CountingVerifier::rejecting(vec![3]));
+        let (handle, rx) = ingest_channel(8);
+        let service =
+            DataAvailabilityVerificationService::new(rx, verifier, store.clone(), executor.clone());
+
+        let block_root = B256::repeat_byte(8);
+        let block = sample_block(block_root, 40, &[2, 3, 4]);
+
+        executor.runtime().block_on(async move {
+            let service_task = tokio::spawn(service.run());
+            handle.submit_block(block).await.expect("submit block");
+            drop(handle);
+            service_task.await.expect("service task joined");
+
+            // The rejected column is absent; its siblings are stored.
+            for index in [2u64, 4] {
+                let id = ColumnId::new(block_root, index).expect("valid index");
+                assert!(store.get(&id).expect("get").is_some(), "sibling stored");
+            }
+            let rejected = ColumnId::new(block_root, 3).expect("valid index");
+            assert_eq!(store.get(&rejected).expect("get"), None);
         });
 
         std::fs::remove_dir_all(&root).ok();

--- a/crates/common/data_availability_node/src/service.rs
+++ b/crates/common/data_availability_node/src/service.rs
@@ -396,9 +396,7 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// A verifier that counts its calls and rejects a chosen set of column
-    /// indices — lets batch tests observe both the pre-filter (skipped columns
-    /// are never verified) and per-column verdicts.
+    /// A verifier that counts its calls and rejects a chosen set of column indices
     struct CountingVerifier {
         calls: AtomicUsize,
         reject: Vec<u64>,
@@ -450,9 +448,6 @@ mod tests {
         .expect("a valid batch")
     }
 
-    /// A block batch submitted through the handle is verified and every column
-    /// lands in the store — the whole `submit_block -> queue -> verify_block ->
-    /// put` path in one go.
     #[test]
     fn submitted_block_batch_is_verified_and_stored() {
         let executor = ReamExecutor::new().expect("create executor");
@@ -488,8 +483,6 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// Already-held columns are filtered out by one availability lookup before
-    /// verification — the verifier never sees them.
     #[test]
     fn block_batch_skips_already_held_columns() {
         let executor = ReamExecutor::new().expect("create executor");
@@ -534,8 +527,6 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// Per-column verdicts: rejected columns are dropped, their siblings are
-    /// stored — one bad column never poisons the batch.
     #[test]
     fn block_batch_stores_survivors_when_some_columns_are_rejected() {
         let executor = ReamExecutor::new().expect("create executor");

--- a/crates/common/polynomial_commitments/src/handlers.rs
+++ b/crates/common/polynomial_commitments/src/handlers.rs
@@ -47,12 +47,52 @@ pub fn verify_blob_kzg_proof_batch(
 
 /// Verify that a set of cells belong to their corresponding commitments.
 ///
-/// Spec: https://ethereum.github.io/consensus-specs/specs/fulu/polynomial-commitments-sampling/#verify_cell_kzg_proof_batch_impl
+/// Spec: https://ethereum.github.io/consensus-specs/fulu/polynomial-commitments-sampling/#verify_cell_kzg_proof_batch
 pub fn verify_cell_kzg_proof_batch(
     commitments_bytes: &VariableList<KZGCommitment, MaxBlobCommitmentsPerBlock>,
     cell_indices: &[u64],
     cells: &VariableList<Cell, MaxBlobCommitmentsPerBlock>,
     proofs_bytes: &VariableList<KZGProof, MaxBlobCommitmentsPerBlock>,
+) -> anyhow::Result<bool> {
+    verify_cell_kzg_proof_batch_refs(
+        &commitments_bytes.iter().collect::<Vec<_>>(),
+        cell_indices,
+        &cells.iter().collect::<Vec<_>>(),
+        &proofs_bytes.iter().collect::<Vec<_>>(),
+    )
+}
+
+/// Verify the KZG proofs of many data column sidecars in one batched check.
+///
+/// Concatenates every sidecar's `(commitment, cell index, cell, proof)` tuples
+/// into a single batched verification, amortizing the pairing cost across a
+/// whole block instead of paying it once per column.
+pub fn verify_data_column_sidecars_batch<'a>(
+    sidecars: impl IntoIterator<Item = &'a DataColumnSidecar>,
+) -> anyhow::Result<bool> {
+    let mut commitments: Vec<&KZGCommitment> = Vec::new();
+    let mut cell_indices: Vec<u64> = Vec::new();
+    let mut cells: Vec<&Cell> = Vec::new();
+    let mut proofs: Vec<&KZGProof> = Vec::new();
+    for sidecar in sidecars {
+        // As in the per-sidecar check, the column index is the cell index for
+        // every one of the sidecar's rows.
+        commitments.extend(sidecar.kzg_commitments.iter());
+        cell_indices.extend(std::iter::repeat_n(sidecar.index, sidecar.column.len()));
+        cells.extend(sidecar.column.iter());
+        proofs.extend(sidecar.kzg_proofs.iter());
+    }
+    verify_cell_kzg_proof_batch_refs(&commitments, &cell_indices, &cells, &proofs)
+}
+
+/// The reference-based core of the batched cell verification, shared by the
+/// bounded-list wrapper above and the cross-sidecar batch: callers assemble
+/// arbitrarily many tuples without cloning any cell bytes.
+fn verify_cell_kzg_proof_batch_refs(
+    commitments_bytes: &[&KZGCommitment],
+    cell_indices: &[u64],
+    cells: &[&Cell],
+    proofs_bytes: &[&KZGProof],
 ) -> anyhow::Result<bool> {
     if commitments_bytes.len() != cells.len()
         || cells.len() != proofs_bytes.len()
@@ -124,7 +164,7 @@ pub fn verify_cell_kzg_proof_batch(
 
 /// Verify if the KZG proofs are correct for a data column sidecar.
 ///
-/// Spec: https://ethereum.github.io/consensus-specs/specs/fulu/p2p-interface/#verify_data_column_sidecar_kzg_proofs
+/// Spec: https://ethereum.github.io/consensus-specs/fulu/p2p-interface/#new-verify_data_column_sidecar_kzg_proofs
 pub fn verify_data_column_sidecar_kzg_proofs(sidecar: &DataColumnSidecar) -> anyhow::Result<bool> {
     // The column index also represents the cell index
     let cell_indices = vec![sidecar.index; sidecar.column.len()];

--- a/crates/common/polynomial_commitments/src/handlers.rs
+++ b/crates/common/polynomial_commitments/src/handlers.rs
@@ -63,10 +63,6 @@ pub fn verify_cell_kzg_proof_batch(
 }
 
 /// Verify the KZG proofs of many data column sidecars in one batched check.
-///
-/// Concatenates every sidecar's `(commitment, cell index, cell, proof)` tuples
-/// into a single batched verification, amortizing the pairing cost across a
-/// whole block instead of paying it once per column.
 pub fn verify_data_column_sidecars_batch<'a>(
     sidecars: impl IntoIterator<Item = &'a DataColumnSidecar>,
 ) -> anyhow::Result<bool> {
@@ -85,9 +81,7 @@ pub fn verify_data_column_sidecars_batch<'a>(
     verify_cell_kzg_proof_batch_refs(&commitments, &cell_indices, &cells, &proofs)
 }
 
-/// The reference-based core of the batched cell verification, shared by the
-/// bounded-list wrapper above and the cross-sidecar batch: callers assemble
-/// arbitrarily many tuples without cloning any cell bytes.
+/// The reference-based core of the batched cell verification
 fn verify_cell_kzg_proof_batch_refs(
     commitments_bytes: &[&KZGCommitment],
     cell_indices: &[u64],

--- a/crates/rpc/data_availability/Cargo.toml
+++ b/crates/rpc/data_availability/Cargo.toml
@@ -15,11 +15,14 @@ default = []
 [dependencies]
 actix-web.workspace = true
 alloy-primitives.workspace = true
+ethereum_ssz.workspace = true
+ethereum_ssz_derive.workspace = true
 ream-api-types-common.workspace = true
 ream-data-availability.workspace = true
 ream-data-availability-node.workspace = true
 ream-rpc-common.workspace = true
 serde.workspace = true
+ssz_types.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/rpc/data_availability/src/handlers/column.rs
+++ b/crates/rpc/data_availability/src/handlers/column.rs
@@ -2,41 +2,37 @@ use std::sync::Arc;
 
 use actix_web::{
     HttpResponse, Responder, get,
+    http::header::ContentType,
     web::{Data, Path},
 };
-use alloy_primitives::B256;
 use ream_api_types_common::{error::ApiError, id::ID};
-use ream_data_availability::{column::VerifiedColumn, id::ColumnId, store::ColumnReadStore};
-use serde::Serialize;
+use ream_data_availability::{id::ColumnId, store::ColumnReadStore};
+use ssz::Encode;
+use ssz_types::VariableList;
 
-use crate::handlers::block_root_from_id;
+use crate::handlers::{
+    block_root_from_id,
+    ingest::{WireBlockBatch, WireIndexedPayload},
+};
 
-/// JSON view of a stored column; the payload travels as a `0x`-hex string.
+/// Wrap a stored payload as a batch entry.
 ///
-/// TODO: hex-JSON is the dev/debug interface, not the final wire format — the
-/// local beacon wants the bytes verbatim.
-#[derive(Serialize)]
-pub struct ColumnResponse {
-    block_root: B256,
-    index: u64,
-    slot: u64,
-    payload: String,
+/// The bound can only be exceeded by a payload that never passed ingest, so a
+/// failure here means the store handed back something impossible.
+fn wire_entry(index: u64, payload: &[u8]) -> Result<WireIndexedPayload, ApiError> {
+    Ok(WireIndexedPayload {
+        index,
+        payload: VariableList::new(payload.to_vec()).map_err(|err| {
+            ApiError::InternalError(format!(
+                "stored column {index} exceeds the payload bound: {err:?}"
+            ))
+        })?,
+    })
 }
 
-impl From<VerifiedColumn> for ColumnResponse {
-    fn from(column: VerifiedColumn) -> Self {
-        let id = column.id();
-        Self {
-            block_root: id.block_root(),
-            index: id.index(),
-            slot: column.context().slot,
-            payload: alloy_primitives::hex::encode_prefixed(column.payload()),
-        }
-    }
-}
-
-/// `GET /data/v0/columns/{block_root}/{index}` — serve a single stored column;
-/// 400 for an out-of-range index, 404 when not held.
+/// `GET /data/v0/columns/{block_root}/{index}` — serve a single stored column.
+/// 400 for an out-of-range index,
+/// 404 when not held.
 #[get("/columns/{block_root}/{index}")]
 pub async fn get_column(
     store: Data<Arc<dyn ColumnReadStore>>,
@@ -52,11 +48,14 @@ pub async fn get_column(
         .map_err(|err| ApiError::InternalError(format!("column lookup failed: {err}")))?
         .ok_or_else(|| ApiError::NotFound(format!("column {index} for {block_root:?} not held")))?;
 
-    Ok(HttpResponse::Ok().json(ColumnResponse::from(column)))
+    Ok(HttpResponse::Ok()
+        .content_type(ContentType::octet_stream())
+        .body(column.payload().to_vec()))
 }
 
 /// `GET /data/v0/columns/{block_root}` — serve every column this node holds for
-/// a block; an unknown block yields an empty array, not a 404.
+/// a block.
+/// An unknown block yields an empty list, not a 404.
 #[get("/columns/{block_root}")]
 pub async fn get_columns(
     store: Data<Arc<dyn ColumnReadStore>>,
@@ -76,9 +75,17 @@ pub async fn get_columns(
             .get(&id)
             .map_err(|err| ApiError::InternalError(format!("column lookup failed: {err}")))?
         {
-            columns.push(ColumnResponse::from(column));
+            columns.push(wire_entry(index, column.payload())?);
         }
     }
 
-    Ok(HttpResponse::Ok().json(columns))
+    // The list bound mirrors `NUMBER_OF_COLUMNS`, which also bounds the held
+    // indices, so this only fails on a store that broke its own invariant.
+    let batch: WireBlockBatch = VariableList::new(columns).map_err(|err| {
+        ApiError::InternalError(format!("held columns exceed the batch bound: {err:?}"))
+    })?;
+
+    Ok(HttpResponse::Ok()
+        .content_type(ContentType::octet_stream())
+        .body(batch.as_ssz_bytes()))
 }

--- a/crates/rpc/data_availability/src/handlers/ingest.rs
+++ b/crates/rpc/data_availability/src/handlers/ingest.rs
@@ -60,39 +60,30 @@ pub async fn post_ingest(
     Ok(HttpResponse::Accepted().finish())
 }
 
-/// One `(column index, payload)` entry of the SSZ batch-ingest body. The
-/// payload stays opaque here, exactly as in the JSON envelope.
+/// One `(column index, payload)` entry of the SSZ batch-ingest body.
 #[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode)]
 pub struct WireIndexedPayload {
     pub index: u64,
-    /// Opaque column payload; the bound is a per-column byte ceiling, not a
-    /// scheme statement. Even at the SSZ spec's theoretical 4096-blob maximum
-    /// a sidecar is only ~8.8 MB (4096 × 2144 B), so 16 MiB never rejects a
+    /// At the SSZ spec's theoretical 4096-blob maximum a sidecar is
+    /// ~8.8 MB (4096 × 2144 B), so 16 MiB never rejects a
     /// legitimate column while still refusing absurd length claims.
     pub payload: VariableList<u8, typenum::U16777216>,
 }
 
-/// SSZ body of `POST /data/v0/ingest/block/{block_root}`: at most one payload
-/// per column of one block (the list bound mirrors `NUMBER_OF_COLUMNS`).
+/// SSZ body of `POST /data/v0/ingest/block/{block_root}`
 pub type WireBlockBatch = VariableList<WireIndexedPayload, typenum::U128>;
 
 /// Query string of `POST /data/v0/ingest/block/{block_root}`.
 #[derive(Deserialize)]
 pub struct BlockIngestQuery {
-    /// Slot of the block the columns belong to — consensus context the node
-    /// cannot read out of the opaque payloads itself.
     slot: u64,
 }
 
 /// `POST /data/v0/ingest/block/{block_root}?slot={slot}` — admit a whole block's
 /// columns in one request.
 ///
-/// The body is SSZ over `application/octet-stream`: a list of
-/// `(column index, payload)` entries, payloads verbatim — no hex, no JSON.
-/// Metadata the node cannot derive from opaque payloads (block root, slot)
-/// travels in the URL. The batch is queued or refused as one unit, through the
-/// same load-shedding [`IngestHandle::try_submit_block`] path as the
-/// single-column endpoint.
+/// The batch is queued or refused as one unit, through the same load-shedding
+/// [`IngestHandle::try_submit_block`] path as the single-column endpoint.
 #[post("/ingest/block/{block_root}")]
 pub async fn post_ingest_block(
     handle: Data<IngestHandle>,

--- a/crates/rpc/data_availability/src/handlers/ingest.rs
+++ b/crates/rpc/data_availability/src/handlers/ingest.rs
@@ -1,15 +1,29 @@
 use actix_web::{
-    HttpResponse, Responder, post,
-    web::{self, Data},
+    HttpMessage, HttpRequest, HttpResponse, Responder, post,
+    web::{self, Bytes, Data, Path, Query},
 };
 use alloy_primitives::B256;
-use ream_api_types_common::error::ApiError;
+use ream_api_types_common::{error::ApiError, id::ID};
 use ream_data_availability::{
-    column::{CandidateColumn, ColumnContext},
+    column::{CandidateBlock, CandidateColumn, ColumnContext},
     id::ColumnId,
 };
-use ream_data_availability_node::{error::IngestionError, ingest::IngestHandle};
+use ream_data_availability_node::ingest::IngestHandle;
 use serde::Deserialize;
+use ssz::Decode;
+use ssz_derive::{Decode as SszDecode, Encode as SszEncode};
+use ssz_types::{VariableList, typenum};
+
+use crate::handlers::{block_root_from_id, submission_error};
+
+/// Byte ceiling for a batch-ingest request body.
+///
+/// Size arithmetic: each blob contributes 2144 B to a column sidecar (one
+/// 2048-B cell + 48-B commitment + 48-B proof), plus ~356 B of fixed fields.
+/// At today's 21-blob schedule cap one sidecar is ~44 KB, so a whole
+/// 128-column block is ~5.7 MB; a future 48-blob cap (~13 MB) still fits.
+/// 32 MiB buys that headroom without revisiting this constant every fork.
+pub const MAX_BATCH_INGEST_BODY_BYTES: usize = 1 << 25; // 32 MiB
 
 /// JSON body of `POST /data/v0/ingest`; the payload travels as a hex string.
 #[derive(Deserialize)]
@@ -42,13 +56,71 @@ pub async fn post_ingest(
     body: web::Json<IngestRequest>,
 ) -> Result<impl Responder, ApiError> {
     let candidate = body.into_inner().into_candidate()?;
-    handle.try_submit(candidate).map_err(|err| match err {
-        IngestionError::Overloaded => {
-            ApiError::ServiceUnavailable("verification queue is full; retry shortly".to_string())
-        }
-        IngestionError::Closed => {
-            ApiError::InternalError("verification service is unavailable".to_string())
-        }
-    })?;
+    handle.try_submit(candidate).map_err(submission_error)?;
+    Ok(HttpResponse::Accepted().finish())
+}
+
+/// One `(column index, payload)` entry of the SSZ batch-ingest body. The
+/// payload stays opaque here, exactly as in the JSON envelope.
+#[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode)]
+pub struct WireIndexedPayload {
+    pub index: u64,
+    /// Opaque column payload; the bound is a per-column byte ceiling, not a
+    /// scheme statement. Even at the SSZ spec's theoretical 4096-blob maximum
+    /// a sidecar is only ~8.8 MB (4096 × 2144 B), so 16 MiB never rejects a
+    /// legitimate column while still refusing absurd length claims.
+    pub payload: VariableList<u8, typenum::U16777216>,
+}
+
+/// SSZ body of `POST /data/v0/ingest/block/{block_root}`: at most one payload
+/// per column of one block (the list bound mirrors `NUMBER_OF_COLUMNS`).
+pub type WireBlockBatch = VariableList<WireIndexedPayload, typenum::U128>;
+
+/// Query string of `POST /data/v0/ingest/block/{block_root}`.
+#[derive(Deserialize)]
+pub struct BlockIngestQuery {
+    /// Slot of the block the columns belong to — consensus context the node
+    /// cannot read out of the opaque payloads itself.
+    slot: u64,
+}
+
+/// `POST /data/v0/ingest/block/{block_root}?slot={slot}` — admit a whole block's
+/// columns in one request.
+///
+/// The body is SSZ over `application/octet-stream`: a list of
+/// `(column index, payload)` entries, payloads verbatim — no hex, no JSON.
+/// Metadata the node cannot derive from opaque payloads (block root, slot)
+/// travels in the URL. The batch is queued or refused as one unit, through the
+/// same load-shedding [`IngestHandle::try_submit_block`] path as the
+/// single-column endpoint.
+#[post("/ingest/block/{block_root}")]
+pub async fn post_ingest_block(
+    handle: Data<IngestHandle>,
+    block_root: Path<ID>,
+    query: Query<BlockIngestQuery>,
+    request: HttpRequest,
+    body: Bytes,
+) -> Result<impl Responder, ApiError> {
+    if request.content_type() != "application/octet-stream" {
+        return Err(ApiError::UnsupportedMediaType(format!(
+            "batch ingest takes an SSZ body as application/octet-stream, got `{}`",
+            request.content_type()
+        )));
+    }
+
+    let block_root = block_root_from_id(block_root.into_inner())?;
+    let entries = WireBlockBatch::from_ssz_bytes(&body)
+        .map_err(|err| ApiError::BadRequest(format!("body is not a valid SSZ batch: {err:?}")))?;
+
+    let columns = entries
+        .into_iter()
+        .map(|entry| (entry.index, entry.payload.to_vec()))
+        .collect();
+    // CandidateBlock::new re-checks the batch shape (empty, range, duplicates),
+    // so a malformed batch dies here with a 400 instead of inside the pipeline.
+    let block = CandidateBlock::new(block_root, ColumnContext { slot: query.slot }, columns)
+        .map_err(|err| ApiError::BadRequest(format!("invalid batch: {err}")))?;
+
+    handle.try_submit_block(block).map_err(submission_error)?;
     Ok(HttpResponse::Accepted().finish())
 }

--- a/crates/rpc/data_availability/src/handlers/mod.rs
+++ b/crates/rpc/data_availability/src/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod retention;
 
 use alloy_primitives::B256;
 use ream_api_types_common::{error::ApiError, id::ID};
+use ream_data_availability_node::error::IngestionError;
 
 /// Resolve a request-path [`ID`] to a concrete block root.
 pub(crate) fn block_root_from_id(id: ID) -> Result<B256, ApiError> {
@@ -24,5 +25,17 @@ pub(crate) fn slot_from_id(id: ID) -> Result<u64, ApiError> {
         other => Err(ApiError::BadRequest(format!(
             "the data node accepts a concrete slot only; `{other}` is not supported"
         ))),
+    }
+}
+
+/// Map a queue submission error onto the RPC's status codes.
+pub(crate) fn submission_error(err: IngestionError) -> ApiError {
+    match err {
+        IngestionError::Overloaded => {
+            ApiError::ServiceUnavailable("verification queue is full; retry shortly".to_string())
+        }
+        IngestionError::Closed => {
+            ApiError::InternalError("verification service is unavailable".to_string())
+        }
     }
 }

--- a/crates/rpc/data_availability/src/handlers/retention.rs
+++ b/crates/rpc/data_availability/src/handlers/retention.rs
@@ -3,12 +3,9 @@ use actix_web::{
     web::{Data, Path},
 };
 use ream_api_types_common::{error::ApiError, id::ID};
-use ream_data_availability_node::{
-    error::IngestionError,
-    ingest::{IngestHandle, RetentionHint},
-};
+use ream_data_availability_node::ingest::{IngestHandle, RetentionHint};
 
-use crate::handlers::slot_from_id;
+use crate::handlers::{slot_from_id, submission_error};
 
 /// `POST /data/v0/retention/{slot}` — prune every stored column whose slot is
 /// strictly below `{slot}`. The hint rides the verification queue, so pruning
@@ -21,14 +18,7 @@ pub async fn post_retention(
     let slot = slot_from_id(slot.into_inner())?;
     handle
         .try_submit_retention(RetentionHint { slot })
-        .map_err(|err| match err {
-            IngestionError::Overloaded => ApiError::ServiceUnavailable(
-                "verification queue is full; retry shortly".to_string(),
-            ),
-            IngestionError::Closed => {
-                ApiError::InternalError("verification service is unavailable".to_string())
-            }
-        })?;
+        .map_err(submission_error)?;
 
     Ok(HttpResponse::Accepted().finish())
 }

--- a/crates/rpc/data_availability/src/routes/mod.rs
+++ b/crates/rpc/data_availability/src/routes/mod.rs
@@ -12,9 +12,6 @@ use crate::handlers::{
 pub fn register_routers(config: &mut ServiceConfig) {
     config.service(
         scope("/data/v0")
-            // A whole block's batch is ~5.7 MB at today's 21-blob cap (~44 KB per
-            // column sidecar × 128 columns), so raise the ceiling scope-wide.
-            // JSON bodies keep their own separate limit.
             .app_data(PayloadConfig::new(MAX_BATCH_INGEST_BODY_BYTES))
             .configure(register_v0_routes),
     );

--- a/crates/rpc/data_availability/src/routes/mod.rs
+++ b/crates/rpc/data_availability/src/routes/mod.rs
@@ -1,21 +1,29 @@
-use actix_web::web::{ServiceConfig, scope};
+use actix_web::web::{PayloadConfig, ServiceConfig, scope};
 
 use crate::handlers::{
     availability::get_availability,
     column::{get_column, get_columns},
     health::get_health,
-    ingest::post_ingest,
+    ingest::{MAX_BATCH_INGEST_BODY_BYTES, post_ingest, post_ingest_block},
     retention::post_retention,
 };
 
 /// Register every data-availability API route under the versioned `/data/v0` scope.
 pub fn register_routers(config: &mut ServiceConfig) {
-    config.service(scope("/data/v0").configure(register_v0_routes));
+    config.service(
+        scope("/data/v0")
+            // A whole block's batch is ~5.7 MB at today's 21-blob cap (~44 KB per
+            // column sidecar × 128 columns), so raise the ceiling scope-wide.
+            // JSON bodies keep their own separate limit.
+            .app_data(PayloadConfig::new(MAX_BATCH_INGEST_BODY_BYTES))
+            .configure(register_v0_routes),
+    );
 }
 
 fn register_v0_routes(config: &mut ServiceConfig) {
     config.service(get_health);
     config.service(post_ingest);
+    config.service(post_ingest_block);
     config.service(post_retention);
     config.service(get_availability);
     config.service(get_column);

--- a/crates/rpc/data_availability/src/tests.rs
+++ b/crates/rpc/data_availability/src/tests.rs
@@ -21,8 +21,13 @@ use ream_data_availability_node::{
     store::FileColumnStore,
 };
 use serde_json::{Value, json};
+use ssz::Encode;
+use ssz_types::VariableList;
 
-use crate::routes::register_routers;
+use crate::{
+    handlers::ingest::{WireBlockBatch, WireIndexedPayload},
+    routes::register_routers,
+};
 
 /// A temp-dir-backed store that cleans up on drop.
 struct TempStore {
@@ -34,8 +39,10 @@ impl TempStore {
     fn new() -> Self {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let root =
-            std::env::temp_dir().join(format!("ream-rpc-data-test-{}-{n}", std::process::id()));
+        let root = std::env::temp_dir().join(format!(
+            "ream-rpc-data-availabilityta-test-{}-{n}",
+            std::process::id()
+        ));
         let inner = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
         Self { inner, root }
     }
@@ -172,6 +179,121 @@ async fn ingest_rejects_out_of_range_index() {
         .to_request();
     let resp = test::call_service(&app, req).await;
 
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// /ingest/block/{block_root}
+// ---------------------------------------------------------------------------
+
+/// SSZ-encode a batch body from `(index, payload)` pairs.
+fn batch_body(entries: &[(u64, &[u8])]) -> Vec<u8> {
+    let entries: Vec<WireIndexedPayload> = entries
+        .iter()
+        .map(|(index, payload)| WireIndexedPayload {
+            index: *index,
+            payload: VariableList::new(payload.to_vec()).expect("payload within bound"),
+        })
+        .collect();
+    let batch: WireBlockBatch = VariableList::new(entries).expect("batch within bound");
+    batch.as_ssz_bytes()
+}
+
+#[actix_web::test]
+async fn ingest_block_accepts_an_ssz_batch() {
+    let (handle, mut rx) = ingest_channel(8);
+    let app = test::init_service(
+        App::new()
+            .app_data(Data::new(handle))
+            .configure(register_routers),
+    )
+    .await;
+
+    let root = B256::repeat_byte(7);
+    let req = test::TestRequest::post()
+        .uri(&format!("/data/v0/ingest/block/0x{root:x}?slot=42"))
+        .insert_header(("content-type", "application/octet-stream"))
+        .set_payload(batch_body(&[(0, &[0xaa]), (5, &[0xbb]), (127, &[0xcc])]))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+    // The whole batch landed on the queue as one item, decoded verbatim.
+    match rx.try_recv().expect("a batch was enqueued") {
+        IngestWorkItem::CandidateBlock(block) => {
+            assert_eq!(block.block_root(), root);
+            assert_eq!(block.context().slot, 42);
+            assert_eq!(block.columns_len(), 3);
+            let expected = [(0, vec![0xaa]), (5, vec![0xbb]), (127, vec![0xcc])];
+            for ((index, payload), (expected_index, expected_bytes)) in
+                block.columns().iter().zip(&expected)
+            {
+                assert_eq!(index, expected_index);
+                assert_eq!(payload, expected_bytes);
+            }
+        }
+        other => panic!("expected a block batch, got {other:?}"),
+    }
+}
+
+#[actix_web::test]
+async fn ingest_block_rejects_a_non_ssz_content_type() {
+    let (handle, _rx) = ingest_channel(8);
+    let app = test::init_service(
+        App::new()
+            .app_data(Data::new(handle))
+            .configure(register_routers),
+    )
+    .await;
+
+    let root = B256::repeat_byte(7);
+    let req = test::TestRequest::post()
+        .uri(&format!("/data/v0/ingest/block/0x{root:x}?slot=1"))
+        .insert_header(("content-type", "application/json"))
+        .set_payload(batch_body(&[(0, &[0x00])]))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[actix_web::test]
+async fn ingest_block_rejects_a_malformed_ssz_body() {
+    let (handle, _rx) = ingest_channel(8);
+    let app = test::init_service(
+        App::new()
+            .app_data(Data::new(handle))
+            .configure(register_routers),
+    )
+    .await;
+
+    let root = B256::repeat_byte(7);
+    let req = test::TestRequest::post()
+        .uri(&format!("/data/v0/ingest/block/0x{root:x}?slot=1"))
+        .insert_header(("content-type", "application/octet-stream"))
+        // A bare offset pointing nowhere: not a decodable batch.
+        .set_payload(vec![0xff, 0x00, 0x01])
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[actix_web::test]
+async fn ingest_block_rejects_a_duplicate_column_index() {
+    let (handle, _rx) = ingest_channel(8);
+    let app = test::init_service(
+        App::new()
+            .app_data(Data::new(handle))
+            .configure(register_routers),
+    )
+    .await;
+
+    let root = B256::repeat_byte(7);
+    let req = test::TestRequest::post()
+        .uri(&format!("/data/v0/ingest/block/0x{root:x}?slot=1"))
+        .insert_header(("content-type", "application/octet-stream"))
+        .set_payload(batch_body(&[(3, &[0x00]), (3, &[0x01])]))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 

--- a/crates/rpc/data_availability/src/tests.rs
+++ b/crates/rpc/data_availability/src/tests.rs
@@ -9,7 +9,14 @@ use std::{
     },
 };
 
-use actix_web::{App, http::StatusCode, test, web::Data};
+use actix_web::{
+    App,
+    body::MessageBody,
+    dev::ServiceResponse,
+    http::{StatusCode, header},
+    test,
+    web::Data,
+};
 use alloy_primitives::B256;
 use ream_data_availability::{
     column::{ColumnContext, VerifiedColumn},
@@ -21,7 +28,7 @@ use ream_data_availability_node::{
     store::FileColumnStore,
 };
 use serde_json::{Value, json};
-use ssz::Encode;
+use ssz::{Decode, Encode};
 use ssz_types::VariableList;
 
 use crate::{
@@ -40,7 +47,7 @@ impl TempStore {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let root = std::env::temp_dir().join(format!(
-            "ream-rpc-data-availabilityta-test-{}-{n}",
+            "ream-rpc-data-availabilityta-availabilityta-test-{}-{n}",
             std::process::id()
         ));
         let inner = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
@@ -372,6 +379,16 @@ async fn availability_rejects_non_root_id() {
 // /columns/{block_root}[/{index}]
 // ---------------------------------------------------------------------------
 
+/// Assert a response carries the SSZ/raw-bytes content type.
+fn assert_octet_stream(resp: &ServiceResponse<impl MessageBody>) {
+    assert_eq!(
+        resp.headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/octet-stream"),
+    );
+}
+
 #[actix_web::test]
 async fn get_column_returns_stored_payload() {
     let store = TempStore::new();
@@ -390,11 +407,11 @@ async fn get_column_returns_stored_payload() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
+    assert_octet_stream(&resp);
 
-    let body: Value = test::read_body_json(resp).await;
-    assert_eq!(body["index"].as_u64(), Some(5));
-    assert_eq!(body["slot"].as_u64(), Some(77));
-    assert_eq!(body["payload"].as_str(), Some("0xdeadbeef"));
+    // The payload comes back verbatim: no SSZ wrapper, no hex, no metadata.
+    let body = test::read_body(resp).await;
+    assert_eq!(body.as_ref(), &[0xde, 0xad, 0xbe, 0xef]);
 }
 
 #[actix_web::test]
@@ -440,8 +457,9 @@ async fn get_column_out_of_range_index_is_400() {
 async fn get_columns_returns_every_held_column() {
     let store = TempStore::new();
     let root = B256::repeat_byte(4);
-    for index in [0u64, 1, 2] {
-        store.put(root, index, 30, b"x");
+    let payloads = [(0u64, &[0xaa][..]), (1, &[0xbb, 0xbb]), (2, &[0xcc])];
+    for (index, payload) in payloads {
+        store.put(root, index, 30, payload);
     }
 
     let app = test::init_service(
@@ -456,16 +474,41 @@ async fn get_columns_returns_every_held_column() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::OK);
+    assert_octet_stream(&resp);
 
-    let body: Value = test::read_body_json(resp).await;
-    let columns = body.as_array().expect("an array of columns");
-    assert_eq!(columns.len(), 3);
-    let mut indices: Vec<u64> = columns
-        .iter()
-        .map(|c| c["index"].as_u64().expect("index"))
-        .collect();
-    indices.sort_unstable();
-    assert_eq!(indices, vec![0, 1, 2]);
+    // The body is the same batch shape the ingest endpoint accepts, in
+    // ascending column-index order.
+    let body = test::read_body(resp).await;
+    let batch = WireBlockBatch::from_ssz_bytes(&body).expect("a decodable batch");
+    assert_eq!(batch.len(), 3);
+    for (entry, (expected_index, expected_payload)) in batch.iter().zip(&payloads) {
+        assert_eq!(entry.index, *expected_index);
+        assert_eq!(entry.payload.as_ref(), *expected_payload);
+    }
+}
+
+#[actix_web::test]
+async fn get_columns_unknown_block_is_an_empty_batch() {
+    let store = TempStore::new();
+    let app = test::init_service(
+        App::new()
+            .app_data(Data::new(store.read_handle()))
+            .configure(register_routers),
+    )
+    .await;
+
+    // An unknown block is "nothing held", not an error.
+    let unknown = B256::repeat_byte(9);
+    let req = test::TestRequest::get()
+        .uri(&format!("/data/v0/columns/0x{unknown:x}"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_octet_stream(&resp);
+
+    let body = test::read_body(resp).await;
+    let batch = WireBlockBatch::from_ssz_bytes(&body).expect("a decodable batch");
+    assert!(batch.is_empty());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### What was wrong?

1. Addressed the payload being in hex string: https://github.com/ReamLabs/ream/pull/1485#discussion_r3679994972.
2. Supported batch checks instead of checking per column. 

### How was it fixed?

#### Summary
This PR makes a whole block the unit of DA ingestion, which cuts
1. KZG verification from 128 checks down to 1 batched check,
3. RPC requests from 128 down to 1, and
4. wire size roughly in half (hex JSON → raw SSZ bytes).

Admission is all-or-nothing: the batch is either fully accepted or fully shed, never split. A request is rejected (400) when SSZ decoding fails, the batch is empty, or a column index is duplicated or out of range. Verification, however, is per column: once admitted, every valid column is stored individually, so a single broken column proof doesn't break the others — the batched KZG check falls back to per-column checks to isolate the culprit.

#### Measured
End to end (mainnet slot 14722952, 17 blobs):
- one SSZ batch: 1.05 s (submission: 12.90 ms)
- 128 JSON requests: 1.46 s (submission: 31.28 ms)

**~28%** faster end to end. 
The submission phase — request round trips plus request decoding (hex JSON vs raw SSZ) — is ~2.4× faster on its own, but in absolute terms that is ~18 ms of the ~410 ms saved: the bulk of the gain is node-side, one batched KZG pairing check instead of 128.

```bash
# restart the DA node between the two runs 

# this PR: one SSZ batch
./target/release/ream-da-tool feed --beacon-url https://ethereum-beacon-api.publicnode.com 14722952

# old path: one request per column
./target/release/ream-da-tool feed --beacon-url https://ethereum-beacon-api.publicnode.com 14722952 --per-column