### PR TITLE
feat(DA): Column Reconstruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6679,6 +6679,7 @@ name = "ream-data-availability-node"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "rand 0.10.2",
  "ream-data-availability",
  "ream-executor",
  "serde",

--- a/bin/ream/src/main.rs
+++ b/bin/ream/src/main.rs
@@ -50,9 +50,11 @@ use ream_consensus_misc::{
     misc::compute_epoch_at_slot,
 };
 use ream_data_availability_node::{
-    ingest::ingest_channel, service::DataAvailabilityVerificationService, store::FileColumnStore,
+    ingest::ingest_channel,
+    service::{DEFAULT_RECONSTRUCTION_DELAY, DataAvailabilityVerificationService},
+    store::FileColumnStore,
 };
-use ream_data_availability_verifier_kzg::KzgVerifier;
+use ream_data_availability_verifier_kzg::KzgAdapter;
 use ream_events_beacon::BeaconEvent;
 use ream_execution_engine::ExecutionEngine;
 use ream_executor::ReamExecutor;
@@ -719,17 +721,22 @@ pub async fn run_data_availability_node(
     let max_blobs_per_block_electra =
         NonZeroUsize::new(network_spec.max_blobs_per_block_electra as usize)
             .expect("network spec max_blobs_per_block must be nonzero");
-    let verifier = Arc::new(KzgVerifier::new(
+    let verifier = Arc::new(KzgAdapter::new(
         network_spec.blob_schedule.clone(),
         max_blobs_per_block_electra,
     ));
 
     let (ingest_handle, rx) = ingest_channel(DATA_AVAILABILITY_VERIFICATION_QUEUE_CAPACITY);
+    // The KZG adapter is both the verifier and the reconstructor: the two
+    // capabilities share one trusted setup.
     let service = DataAvailabilityVerificationService::new(
         rx,
         verifier.clone(),
+        verifier.clone(),
         store.clone(),
         executor.clone(),
+        ingest_handle.downgrade(),
+        DEFAULT_RECONSTRUCTION_DELAY,
     );
     let mut service_task = AbortOnDrop(executor.spawn(service.run()));
 
@@ -740,7 +747,7 @@ pub async fn run_data_availability_node(
     // Warm the trusted setup (multi-second) off the async workers before the
     // first column arrives.
     if let Err(err) = executor
-        .spawn_blocking(KzgVerifier::warm_up_trusted_setup)
+        .spawn_blocking(KzgAdapter::warm_up_trusted_setup)
         .await
     {
         error!("failed to warm up KZG trusted setup: {err}");

--- a/crates/common/data_availability/src/availability.rs
+++ b/crates/common/data_availability/src/availability.rs
@@ -112,12 +112,12 @@ mod tests {
         let held_of = |count: u32| (1u128 << count) - 1;
 
         // 63 of 128: below half, recovery is mathematically impossible.
-        assert!(!DaAvailability::new(held_of(63), all).is_reconstructable());
+        assert!(!ColumnAvailability::new(held_of(63), all).is_reconstructable());
         // 64 and 127: enough to recover, and something is missing.
-        assert!(DaAvailability::new(held_of(64), all).is_reconstructable());
-        assert!(DaAvailability::new(held_of(127), all).is_reconstructable());
+        assert!(ColumnAvailability::new(held_of(64), all).is_reconstructable());
+        assert!(ColumnAvailability::new(held_of(127), all).is_reconstructable());
         // Full set: nothing to recover.
-        assert!(!DaAvailability::new(all, all).is_reconstructable());
+        assert!(!ColumnAvailability::new(all, all).is_reconstructable());
     }
 
     #[test]

--- a/crates/common/data_availability/src/availability.rs
+++ b/crates/common/data_availability/src/availability.rs
@@ -30,6 +30,12 @@ impl ColumnAvailability {
         index < NUMBER_OF_COLUMNS && self.held & (1u128 << index) != 0
     }
 
+    /// Whether the missing columns can be erasure-recovered locally: at least
+    /// half of the full column set is held, yet some column is still missing.
+    pub fn is_reconstructable(&self) -> bool {
+        (NUMBER_OF_COLUMNS / 2..NUMBER_OF_COLUMNS).contains(&self.held_count())
+    }
+
     /// Column indices expected but not held, ascending.
     pub fn missing_indices(&self) -> Vec<u64> {
         column_indices(self.expected & !self.held)
@@ -98,6 +104,20 @@ mod tests {
         assert!(!availability.is_complete());
         assert_eq!(availability.held_count(), 2);
         assert_eq!(availability.missing_indices(), vec![70, 99]);
+    }
+
+    #[test]
+    fn reconstructable_only_between_half_held_and_full() {
+        let all = u128::MAX;
+        let held_of = |count: u32| (1u128 << count) - 1;
+
+        // 63 of 128: below half, recovery is mathematically impossible.
+        assert!(!DaAvailability::new(held_of(63), all).is_reconstructable());
+        // 64 and 127: enough to recover, and something is missing.
+        assert!(DaAvailability::new(held_of(64), all).is_reconstructable());
+        assert!(DaAvailability::new(held_of(127), all).is_reconstructable());
+        // Full set: nothing to recover.
+        assert!(!DaAvailability::new(all, all).is_reconstructable());
     }
 
     #[test]

--- a/crates/common/data_availability/src/error.rs
+++ b/crates/common/data_availability/src/error.rs
@@ -48,6 +48,9 @@ pub enum ValidationError {
 
     #[error("duplicate column index {column_index} in block batch")]
     DuplicateColumnIndex { column_index: u64 },
+
+    #[error("reconstruction failed: {0}")]
+    ReconstructionFailure(String),
 }
 
 #[derive(Debug, Error)]

--- a/crates/common/data_availability/src/lib.rs
+++ b/crates/common/data_availability/src/lib.rs
@@ -2,5 +2,6 @@ pub mod availability;
 pub mod column;
 pub mod error;
 pub mod id;
+pub mod reconstruction;
 pub mod store;
 pub mod verifier;

--- a/crates/common/data_availability/src/reconstruction.rs
+++ b/crates/common/data_availability/src/reconstruction.rs
@@ -1,0 +1,21 @@
+use crate::{
+    column::{CandidateColumn, VerifiedColumn},
+    error::ValidationError,
+};
+
+/// Rebuilds a block's missing columns from the ones already held.
+pub trait ColumnReconstructor: Send + Sync {
+    /// Recover every column of the block that is absent from `held`, returned
+    /// as *candidates*.
+    ///
+    /// The output is deliberately not [`VerifiedColumn`]: the recovery math is
+    /// sound, but the surrounding assembly (row transposition, metadata
+    /// copying, re-encoding) is ordinary code, so recovered columns re-enter
+    /// through the same verify-then-store gate as network columns. Only the
+    /// verifier mints [`VerifiedColumn`]; the store never holds anything
+    /// self-attested.
+    fn reconstruct(
+        &self,
+        held: Vec<VerifiedColumn>,
+    ) -> Result<Vec<CandidateColumn>, ValidationError>;
+}

--- a/crates/common/data_availability/src/reconstruction.rs
+++ b/crates/common/data_availability/src/reconstruction.rs
@@ -7,13 +7,6 @@ use crate::{
 pub trait ColumnReconstructor: Send + Sync {
     /// Recover every column of the block that is absent from `held`, returned
     /// as *candidates*.
-    ///
-    /// The output is deliberately not [`VerifiedColumn`]: the recovery math is
-    /// sound, but the surrounding assembly (row transposition, metadata
-    /// copying, re-encoding) is ordinary code, so recovered columns re-enter
-    /// through the same verify-then-store gate as network columns. Only the
-    /// verifier mints [`VerifiedColumn`]; the store never holds anything
-    /// self-attested.
     fn reconstruct(
         &self,
         held: Vec<VerifiedColumn>,

--- a/crates/common/data_availability/src/store.rs
+++ b/crates/common/data_availability/src/store.rs
@@ -22,7 +22,12 @@ pub trait ColumnReadStore: Send + Sync {
     fn get(&self, id: &ColumnId) -> Result<Option<VerifiedColumn>, ColumnStoreError>;
     fn availability(&self, block_root: B256) -> Result<ColumnAvailability, ColumnStoreError>;
 
+    /// The current retention floor, as a slot; `0` means no floor yet.
     fn get_retention_floor(&self) -> u64;
+
+    /// Whether a column at `slot` is strictly older than the retention floor
+    /// — the exact predicate [`DaWriteStore::put`] refuses on. A column
+    /// exactly at the floor is kept.
     fn is_below_retention(&self, slot: u64) -> bool;
 }
 

--- a/crates/common/data_availability/src/store.rs
+++ b/crates/common/data_availability/src/store.rs
@@ -26,8 +26,7 @@ pub trait ColumnReadStore: Send + Sync {
     fn get_retention_floor(&self) -> u64;
 
     /// Whether a column at `slot` is strictly older than the retention floor
-    /// — the exact predicate [`ColumnWriteStore::put`] refuses on. A column
-    /// exactly at the floor is kept.
+    /// A column exactly at the floor is kept.
     fn is_below_retention(&self, slot: u64) -> bool;
 }
 
@@ -39,9 +38,5 @@ pub trait ColumnWriteStore: ColumnReadStore {
 
     /// Raise the retention floor to `slot` and prune every stored column below
     /// it, returning how many were removed.
-    ///
-    /// The floor is monotonic and durable: a hint below the current floor is a
-    /// no-op, and it must be recorded before any data is deleted so that an
-    /// interrupted prune resumes on the next startup.
     fn prune_below_slot(&self, slot: u64) -> Result<usize, ColumnStoreError>;
 }

--- a/crates/common/data_availability/src/store.rs
+++ b/crates/common/data_availability/src/store.rs
@@ -20,13 +20,13 @@ pub enum InsertOutcome {
 /// because the store only ever contains verified data.
 pub trait ColumnReadStore: Send + Sync {
     fn get(&self, id: &ColumnId) -> Result<Option<VerifiedColumn>, ColumnStoreError>;
-    fn availability(&self, block_root: B256) -> Result<ColumnAvailability, ColumnStoreError>;
+    fn availability(&self, block_root: B256) -> ColumnAvailability;
 
     /// The current retention floor, as a slot; `0` means no floor yet.
     fn get_retention_floor(&self) -> u64;
 
     /// Whether a column at `slot` is strictly older than the retention floor
-    /// — the exact predicate [`DaWriteStore::put`] refuses on. A column
+    /// — the exact predicate [`ColumnWriteStore::put`] refuses on. A column
     /// exactly at the floor is kept.
     fn is_below_retention(&self, slot: u64) -> bool;
 }

--- a/crates/common/data_availability/src/store.rs
+++ b/crates/common/data_availability/src/store.rs
@@ -11,6 +11,9 @@ pub enum InsertOutcome {
     /// A column was already stored for this id; the insert is an idempotent
     /// no-op and the existing column is kept.
     Duplicated,
+    /// The column's slot is below the retention floor: it was refused and
+    /// nothing was stored.
+    BelowRetention,
 }
 
 /// Read-only storage handle. Serving never re-verifies on the output path
@@ -18,6 +21,9 @@ pub enum InsertOutcome {
 pub trait ColumnReadStore: Send + Sync {
     fn get(&self, id: &ColumnId) -> Result<Option<VerifiedColumn>, ColumnStoreError>;
     fn availability(&self, block_root: B256) -> Result<ColumnAvailability, ColumnStoreError>;
+
+    fn get_retention_floor(&self) -> u64;
+    fn is_below_retention(&self, slot: u64) -> bool;
 }
 
 /// Write-capable storage handle, handed to the verification service only.
@@ -26,5 +32,11 @@ pub trait ColumnReadStore: Send + Sync {
 pub trait ColumnWriteStore: ColumnReadStore {
     fn put(&self, column: VerifiedColumn) -> Result<InsertOutcome, ColumnStoreError>;
 
+    /// Raise the retention floor to `slot` and prune every stored column below
+    /// it, returning how many were removed.
+    ///
+    /// The floor is monotonic and durable: a hint below the current floor is a
+    /// no-op, and it must be recorded before any data is deleted so that an
+    /// interrupted prune resumes on the next startup.
     fn prune_below_slot(&self, slot: u64) -> Result<usize, ColumnStoreError>;
 }

--- a/crates/common/data_availability_adapters/kzg_verifier/Cargo.toml
+++ b/crates/common/data_availability_adapters/kzg_verifier/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 alloy-primitives.workspace = true
 anyhow.workspace = true
 ethereum_ssz.workspace = true
+rust_eth_kzg.workspace = true
 tree_hash.workspace = true
 
 # ream dependencies
@@ -24,7 +25,6 @@ ream-polynomial-commitments.workspace = true
 
 [dev-dependencies]
 ream-execution-rpc-types.workspace = true
-rust_eth_kzg.workspace = true
 serde_json.workspace = true
 ssz_types.workspace = true
 

--- a/crates/common/data_availability_adapters/kzg_verifier/src/lib.rs
+++ b/crates/common/data_availability_adapters/kzg_verifier/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod verifier;
 
-pub use verifier::KzgVerifier;
+pub use verifier::KzgAdapter;

--- a/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
+++ b/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
@@ -71,6 +71,13 @@ impl KzgAdapter {
         let _ = trusted_setup::blst_settings();
     }
 
+    /// The cell-recovery context, built from the trusted setup once and cached
+    /// for the process lifetime.
+    fn recovery_context() -> &'static DASContext {
+        static CONTEXT: OnceLock<DASContext> = OnceLock::new();
+        CONTEXT.get_or_init(|| DASContext::new(&TrustedSetup::default(), UsePrecomp::No))
+    }
+
     fn decode(&self, bytes: &[u8]) -> Result<DataColumnSidecar, ValidationError> {
         DataColumnSidecar::from_ssz_bytes(bytes)
             .map_err(|err| ValidationError::MalformedPayload(format!("{err:?}")))
@@ -265,13 +272,13 @@ impl ColumnReconstructor for KzgAdapter {
         // blob row, so the held cell indices are the same for every row.
         let cell_indices: Vec<u64> = sidecars.iter().map(|sidecar| sidecar.index).collect();
         let mut cells_and_proofs = Vec::with_capacity(blob_count);
-        let das_context = DASContext::new(&TrustedSetup::default(), UsePrecomp::No);
+        let das_context = Self::recovery_context();
         for row in 0..blob_count {
             let cells: Vec<_> = sidecars
                 .iter()
                 .map(|sidecar| sidecar.column[row].clone())
                 .collect();
-            let recovered = recover_cells_and_kzg_proofs(cell_indices.clone(), cells, &das_context)
+            let recovered = recover_cells_and_kzg_proofs(cell_indices.clone(), cells, das_context)
                 .map_err(|err| {
                     ValidationError::ReconstructionFailure(format!("blob row {row}: {err:?}"))
                 })?;

--- a/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
+++ b/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
@@ -21,11 +21,7 @@ use ssz::{Decode, Encode};
 use tree_hash::TreeHash;
 
 /// The PeerDAS adapter for the DA core's cryptographic capabilities — one type
-/// with two roles sharing one trusted setup: [`ColumnVerifier`] decodes a
-/// candidate's payload as an SSZ `DataColumnSidecar` and admits it only if it is
-/// structurally sound and its cells verify against their KZG commitments;
-/// [`ColumnReconstructor`] erasure-recovers a block's missing columns from any held
-/// half.
+/// with two roles sharing one trusted setup.
 #[derive(Debug, Clone)]
 pub struct KzgAdapter {
     /// BPO schedule `(activation epoch, blob limit)`, ascending; zero-limit

--- a/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
+++ b/crates/common/data_availability_adapters/kzg_verifier/src/verifier.rs
@@ -1,32 +1,40 @@
-use std::num::NonZeroUsize;
+use std::{num::NonZeroUsize, sync::OnceLock};
 
-use ream_consensus_beacon::data_column_sidecar::DataColumnSidecar;
+use ream_consensus_beacon::{
+    data_column_sidecar::{DataColumnSidecar, get_data_column_sidecars_from_column_sidecar},
+    matrix_entry::recover_cells_and_kzg_proofs,
+};
 use ream_consensus_misc::{blob_parameters::BlobParameters, misc::compute_epoch_at_slot};
 use ream_data_availability::{
     column::{CandidateBlock, CandidateColumn, VerifiedColumn},
     error::ValidationError,
-    id::ColumnId,
+    id::{ColumnId, NUMBER_OF_COLUMNS},
+    reconstruction::ColumnReconstructor,
     verifier::ColumnVerifier,
 };
 use ream_polynomial_commitments::{
     handlers::{verify_data_column_sidecar_kzg_proofs, verify_data_column_sidecars_batch},
     trusted_setup,
 };
-use ssz::Decode;
+use rust_eth_kzg::{DASContext, TrustedSetup, UsePrecomp};
+use ssz::{Decode, Encode};
 use tree_hash::TreeHash;
 
-/// Decodes a candidate's payload as an SSZ `DataColumnSidecar` and admits it
-/// only if it is structurally sound and its cells verify against their KZG
-/// commitments.
+/// The PeerDAS adapter for the DA core's cryptographic capabilities — one type
+/// with two roles sharing one trusted setup: [`ColumnVerifier`] decodes a
+/// candidate's payload as an SSZ `DataColumnSidecar` and admits it only if it is
+/// structurally sound and its cells verify against their KZG commitments;
+/// [`ColumnReconstructor`] erasure-recovers a block's missing columns from any held
+/// half.
 #[derive(Debug, Clone)]
-pub struct KzgVerifier {
+pub struct KzgAdapter {
     /// BPO schedule `(activation epoch, blob limit)`, ascending; zero-limit
     /// entries — which would reject every column — are dropped at construction.
     blob_schedule: Vec<(u64, NonZeroUsize)>,
     max_blobs_per_block_electra: NonZeroUsize,
 }
 
-impl KzgVerifier {
+impl KzgAdapter {
     pub fn new(
         blob_schedule: impl IntoIterator<Item = BlobParameters>,
         max_blobs_per_block_electra: NonZeroUsize,
@@ -132,7 +140,7 @@ impl KzgVerifier {
     }
 }
 
-impl ColumnVerifier for KzgVerifier {
+impl ColumnVerifier for KzgAdapter {
     fn verify(&self, candidate: CandidateColumn) -> Result<VerifiedColumn, ValidationError> {
         let sidecar = self.precheck(&candidate)?;
 
@@ -204,6 +212,92 @@ impl ColumnVerifier for KzgVerifier {
     }
 }
 
+impl ColumnReconstructor for KzgAdapter {
+    /// PeerDAS recovery
+    fn reconstruct(
+        &self,
+        held: Vec<VerifiedColumn>,
+    ) -> Result<Vec<CandidateColumn>, ValidationError> {
+        let first = held.first().ok_or(ValidationError::EmptyBatch)?;
+        let block_root = first.id().block_root();
+        let context = first.context();
+
+        // Decode every held sidecar. All must belong to one block and agree on
+        // the blob count, or the row transposition below is meaningless.
+        let mut sidecars = Vec::with_capacity(held.len());
+        let mut held_mask = 0u128;
+        for column in &held {
+            if column.id().block_root() != block_root {
+                return Err(ValidationError::ReconstructionFailure(format!(
+                    "mixed blocks in one recovery: {block_root} and {}",
+                    column.id().block_root()
+                )));
+            }
+            let sidecar = self.decode(column.payload())?;
+            if sidecar.index != column.id().index() {
+                return Err(ValidationError::ReconstructionFailure(format!(
+                    "column {} carries a sidecar for index {}",
+                    column.id().index(),
+                    sidecar.index
+                )));
+            }
+            held_mask |= 1u128 << column.id().index();
+            sidecars.push(sidecar);
+        }
+        let blob_count = sidecars[0].kzg_commitments.len();
+        for sidecar in &sidecars {
+            if sidecar.column.len() != blob_count || sidecar.kzg_commitments.len() != blob_count {
+                return Err(ValidationError::ReconstructionFailure(format!(
+                    "column {} disagrees on the block's blob count",
+                    sidecar.index
+                )));
+            }
+        }
+        if u64::from(held_mask.count_ones()) < NUMBER_OF_COLUMNS / 2 {
+            return Err(ValidationError::ReconstructionFailure(format!(
+                "{} distinct columns held, recovery needs at least {}",
+                held_mask.count_ones(),
+                NUMBER_OF_COLUMNS / 2
+            )));
+        }
+
+        // Row-by-row recovery: a column holds cell `column index` of every
+        // blob row, so the held cell indices are the same for every row.
+        let cell_indices: Vec<u64> = sidecars.iter().map(|sidecar| sidecar.index).collect();
+        let mut cells_and_proofs = Vec::with_capacity(blob_count);
+        let das_context = DASContext::new(&TrustedSetup::default(), UsePrecomp::No);
+        for row in 0..blob_count {
+            let cells: Vec<_> = sidecars
+                .iter()
+                .map(|sidecar| sidecar.column[row].clone())
+                .collect();
+            let recovered = recover_cells_and_kzg_proofs(cell_indices.clone(), cells, &das_context)
+                .map_err(|err| {
+                    ValidationError::ReconstructionFailure(format!("blob row {row}: {err:?}"))
+                })?;
+            cells_and_proofs.push(recovered);
+        }
+
+        // Reassemble full sidecars
+        let template = sidecars.into_iter().next().expect("held is non-empty");
+        let all_columns = get_data_column_sidecars_from_column_sidecar(template, cells_and_proofs)
+            .map_err(|err| ValidationError::ReconstructionFailure(format!("{err:?}")))?;
+
+        let mut recovered = Vec::new();
+        for sidecar in all_columns {
+            if held_mask & (1u128 << sidecar.index) != 0 {
+                continue;
+            }
+            recovered.push(CandidateColumn {
+                id: ColumnId::new(block_root, sidecar.index)?,
+                context,
+                payload: sidecar.as_ssz_bytes(),
+            });
+        }
+        Ok(recovered)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
@@ -222,9 +316,10 @@ mod tests {
         polynomial_commitments::{kzg_commitment::KZGCommitment, kzg_proof::KZGProof},
     };
     use ream_data_availability::{
-        column::{CandidateBlock, CandidateColumn, ColumnContext},
+        column::{CandidateBlock, CandidateColumn, ColumnContext, VerifiedColumn},
         error::ValidationError,
         id::ColumnId,
+        reconstruction::ColumnReconstructor,
         verifier::ColumnVerifier,
     };
     use ream_execution_rpc_types::get_blobs::Blob;
@@ -234,14 +329,14 @@ mod tests {
     use ssz_types::{FixedVector, VariableList};
     use tree_hash::TreeHash;
 
-    use super::KzgVerifier;
+    use super::KzgAdapter;
 
     const MAX_BLOBS: usize = 9;
 
     /// A verifier with no BPO schedule: every epoch uses the Electra fallback,
     /// so tests that don't care about the schedule see one fixed limit.
-    fn verifier() -> KzgVerifier {
-        KzgVerifier::new([], NonZeroUsize::new(MAX_BLOBS).expect("nonzero"))
+    fn verifier() -> KzgAdapter {
+        KzgAdapter::new([], NonZeroUsize::new(MAX_BLOBS).expect("nonzero"))
     }
 
     /// A well-formed sidecar whose zeroed inclusion proof never verifies —
@@ -470,7 +565,7 @@ mod tests {
 
     #[test]
     fn blob_schedule_governs_the_limit_per_epoch() {
-        let verifier = KzgVerifier::new(
+        let verifier = KzgAdapter::new(
             [
                 BlobParameters {
                     epoch: 2,
@@ -497,7 +592,7 @@ mod tests {
 
     #[test]
     fn shape_check_uses_the_limit_at_the_sidecars_epoch() {
-        let verifier = KzgVerifier::new(
+        let verifier = KzgAdapter::new(
             [BlobParameters {
                 epoch: 1,
                 max_blobs_per_block: 15,
@@ -541,7 +636,66 @@ mod tests {
         ));
     }
 
-    /// `ream-data-availability` and beacon each define `NUMBER_OF_COLUMNS` and neither may
+    /// A verified column as the store would hand back — the reconstructor's
+    /// input type.
+    fn verified_of(sidecar: &DataColumnSidecar) -> VerifiedColumn {
+        let candidate = candidate_of(sidecar);
+        VerifiedColumn::new_unchecked(candidate.id, candidate.context, candidate.payload)
+    }
+
+    #[test]
+    fn reconstructs_the_missing_half_byte_identically() {
+        let sidecars = real_sidecars();
+        // Hold every even column — exactly half, interleaved with the gaps.
+        let held: Vec<_> = sidecars
+            .iter()
+            .filter(|sidecar| sidecar.index % 2 == 0)
+            .map(verified_of)
+            .collect();
+
+        let recovered = verifier().reconstruct(held).expect("recovery succeeds");
+
+        // Every odd column comes back, byte-identical to the original: the
+        // recovered cells and recomputed proofs match, and so does the copied
+        // block-level metadata.
+        assert_eq!(recovered.len(), 64);
+        for (position, candidate) in recovered.iter().enumerate() {
+            let expected_index = position as u64 * 2 + 1;
+            assert_eq!(candidate.id.index(), expected_index);
+            assert_eq!(
+                candidate.payload,
+                sidecars[expected_index as usize].as_ssz_bytes(),
+            );
+        }
+
+        // Belt and braces: the recovered candidates pass the real verify
+        // gate, exactly as they will on the node's re-admission path.
+        let block = CandidateBlock::new(
+            recovered[0].id.block_root(),
+            recovered[0].context,
+            recovered
+                .into_iter()
+                .map(|candidate| (candidate.id.index(), candidate.payload))
+                .collect(),
+        )
+        .expect("a valid batch");
+        for (index, verdict) in verifier().verify_block(block) {
+            assert!(verdict.is_ok(), "recovered column {index} must re-verify");
+        }
+    }
+
+    #[test]
+    fn reconstruct_refuses_less_than_half() {
+        let sidecars = real_sidecars();
+        // 63 columns: one short of recoverable.
+        let held: Vec<_> = sidecars.iter().take(63).map(verified_of).collect();
+        assert!(matches!(
+            verifier().reconstruct(held),
+            Err(ValidationError::ReconstructionFailure(_))
+        ));
+    }
+
+    /// `ream-da` and beacon each define `NUMBER_OF_COLUMNS` and neither may
     /// depend on the other; this adapter sees both, so it pins them equal.
     #[test]
     fn das_core_column_count_matches_beacon() {

--- a/crates/common/data_availability_node/Cargo.toml
+++ b/crates/common/data_availability_node/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 
 [dependencies]
 alloy-primitives.workspace = true
+rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/common/data_availability_node/src/ingest.rs
+++ b/crates/common/data_availability_node/src/ingest.rs
@@ -104,6 +104,7 @@ impl IngestHandle {
             })
     }
 
+    // TODO: will be removed after using DB instead file store
     /// A weak sender for the verification service's own delayed
     /// reconstruction triggers.
     ///

--- a/crates/common/data_availability_node/src/ingest.rs
+++ b/crates/common/data_availability_node/src/ingest.rs
@@ -105,14 +105,6 @@ impl IngestHandle {
     }
 
     // TODO: will be removed after using DB instead file store
-    /// A weak sender for the verification service's own delayed
-    /// reconstruction triggers.
-    ///
-    /// Weak on purpose: the service consuming the queue must not hold a strong
-    /// handle to it, or "every producer dropped" — the shutdown signal that
-    /// ends the service loop — could never happen. Upgrading fails only once
-    /// all real handles are gone, i.e. the node is shutting down and there is
-    /// nothing left worth submitting.
     pub fn downgrade(&self) -> mpsc::WeakSender<IngestWorkItem> {
         self.sender.downgrade()
     }

--- a/crates/common/data_availability_node/src/ingest.rs
+++ b/crates/common/data_availability_node/src/ingest.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use ream_data_availability::column::{CandidateBlock, CandidateColumn};
 use tokio::sync::mpsc;
 use tracing::debug;
@@ -13,6 +14,16 @@ pub enum IngestWorkItem {
     CandidateBlock(CandidateBlock),
     /// A beacon-issued retention boundary.
     Retention(RetentionHint),
+
+    /// A self-issued request to recover one block's missing columns.
+    /// Queued by the verification service itself — with a settling delay
+    Reconstruction(ReconstructionRequest),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReconstructionRequest {
+    /// Root of the block whose missing columns should be recovered.
+    pub block_root: B256,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,6 +102,18 @@ impl IngestHandle {
                 mpsc::error::TrySendError::Full(_) => IngestionError::Overloaded,
                 mpsc::error::TrySendError::Closed(_) => IngestionError::Closed,
             })
+    }
+
+    /// A weak sender for the verification service's own delayed
+    /// reconstruction triggers.
+    ///
+    /// Weak on purpose: the service consuming the queue must not hold a strong
+    /// handle to it, or "every producer dropped" — the shutdown signal that
+    /// ends the service loop — could never happen. Upgrading fails only once
+    /// all real handles are gone, i.e. the node is shutting down and there is
+    /// nothing left worth submitting.
+    pub fn downgrade(&self) -> mpsc::WeakSender<IngestWorkItem> {
+        self.sender.downgrade()
     }
 }
 

--- a/crates/common/data_availability_node/src/service.rs
+++ b/crates/common/data_availability_node/src/service.rs
@@ -24,14 +24,10 @@ pub const DEFAULT_RECONSTRUCTION_DELAY: Duration = Duration::from_secs(3);
 pub struct DataAvailabilityVerificationService {
     receiver: mpsc::Receiver<IngestWorkItem>,
     verifier: Arc<dyn ColumnVerifier>,
-    /// Recovers a block's missing columns from the held ones
     reconstructor: Arc<dyn ColumnReconstructor>,
     store: Arc<dyn ColumnWriteStore>,
     executor: ReamExecutor,
-    /// Weak self-handle for the delayed reconstruction triggers.
     self_sender: mpsc::WeakSender<IngestWorkItem>,
-    /// Cap on how long a recoverable-but-incomplete block is given to complete
-    /// naturally before recovery is attempted
     max_reconstruction_delay: Duration,
 }
 
@@ -58,7 +54,7 @@ impl DataAvailabilityVerificationService {
     /// Consume work items until the ingest channel closes.
     ///
     /// A single sequential consumer: each item is fully handled before the next
-    /// is taken. That caps throughput but keeps the store single-writer.
+    /// is taken.
     pub async fn run(mut self) {
         info!("Data-availability verification service started");
         while let Some(item) = self.receiver.recv().await {
@@ -775,10 +771,6 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// A candidate below the retention floor is dropped before verification.
-    /// The floor gate in `put` is the correctness backstop; the service's
-    /// early skip is the economics — it must not pay for verifying a column
-    /// it already knows the store will refuse.
     #[test]
     fn below_floor_candidate_is_skipped_before_verification() {
         let executor = ReamExecutor::new().expect("create executor");
@@ -817,10 +809,6 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// Recovers by fabricating a candidate for every index missing from the
-    /// held set — enough to exercise the trigger/worker/re-entry plumbing
-    /// without real erasure coding (that lives in the KZG adapter and is
-    /// tested there).
     struct FillMissingReconstructor {
         calls: AtomicUsize,
     }
@@ -876,10 +864,6 @@ mod tests {
         }
     }
 
-    /// A half-full block batch crosses the recovery threshold: after the
-    /// (zero) settling delay the service recovers the other half by itself,
-    /// and the recovered columns pass through the verifier — the gate is
-    /// never bypassed.
     #[test]
     fn incomplete_block_self_heals_through_the_verify_gate() {
         let executor = ReamExecutor::new().expect("create executor");
@@ -928,8 +912,6 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// A single trickled column that crosses the threshold triggers recovery
-    /// too — the trigger lives on both ingest paths.
     #[test]
     fn a_trickled_column_crossing_the_threshold_triggers_recovery() {
         let executor = ReamExecutor::new().expect("create executor");
@@ -975,9 +957,6 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// When the rest of the block arrives during the settling delay, the
-    /// fired trigger re-checks, finds the block complete, and stands down
-    /// without recovering anything.
     #[test]
     fn reconstruction_stands_down_when_the_block_completes_naturally() {
         let executor = ReamExecutor::new().expect("create executor");
@@ -1028,8 +1007,6 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// Below half the columns recovery is mathematically impossible, so the
-    /// trigger is never armed at all.
     #[test]
     fn no_reconstruction_below_half_the_columns() {
         let executor = ReamExecutor::new().expect("create executor");

--- a/crates/common/data_availability_node/src/service.rs
+++ b/crates/common/data_availability_node/src/service.rs
@@ -15,8 +15,8 @@ use tracing::{debug, error, info, trace, warn};
 
 use crate::ingest::{IngestWorkItem, ReconstructionRequest, RetentionHint};
 
-/// Default settling delay between a block becoming recoverable and the
-/// recovery attempt
+/// Default cap on the settling delay between a block becoming recoverable and
+/// the recovery attempt.
 pub const DEFAULT_RECONSTRUCTION_DELAY: Duration = Duration::from_secs(3);
 
 /// Drains the ingest queue, verifying each candidate and persisting those
@@ -30,9 +30,9 @@ pub struct DataAvailabilityVerificationService {
     executor: ReamExecutor,
     /// Weak self-handle for the delayed reconstruction triggers.
     self_sender: mpsc::WeakSender<IngestWorkItem>,
-    /// How long a recoverable-but-incomplete block is given to complete
-    /// naturally before recovery is attempted.
-    reconstruction_delay: Duration,
+    /// Cap on how long a recoverable-but-incomplete block is given to complete
+    /// naturally before recovery is attempted
+    max_reconstruction_delay: Duration,
 }
 
 impl DataAvailabilityVerificationService {
@@ -43,7 +43,7 @@ impl DataAvailabilityVerificationService {
         store: Arc<dyn ColumnWriteStore>,
         executor: ReamExecutor,
         self_sender: mpsc::WeakSender<IngestWorkItem>,
-        reconstruction_delay: Duration,
+        max_reconstruction_delay: Duration,
     ) -> Self {
         Self {
             receiver,
@@ -52,7 +52,7 @@ impl DataAvailabilityVerificationService {
             store,
             executor,
             self_sender,
-            reconstruction_delay,
+            max_reconstruction_delay,
         }
     }
     /// Consume work items until the ingest channel closes.
@@ -176,13 +176,14 @@ impl DataAvailabilityVerificationService {
             return;
         }
 
+        // Spec: https://ethereum.github.io/consensus-specs/fulu/das-core/#reconstruction-and-cross-seeding
+        // Sample the delay fresh per trigger, in [0, cap)
+        let delay = self.max_reconstruction_delay.mul_f64(rand::random::<f64>());
         debug!(
             "block {block_root} became recoverable with {held} columns, scheduling reconstruction in {delay:?}",
             held = after.held_count(),
-            delay = self.reconstruction_delay
         );
         let sender = self.self_sender.clone();
-        let delay = self.reconstruction_delay;
         self.executor.spawn(async move {
             tokio::time::sleep(delay).await;
             // All real handles gone: shutting down, drop the trigger.

--- a/crates/common/data_availability_node/src/service.rs
+++ b/crates/common/data_availability_node/src/service.rs
@@ -73,6 +73,18 @@ impl DataAvailabilityVerificationService {
         let id = candidate.id;
         let verifier = self.verifier.clone();
 
+        // `put` is the correctness gate; skipping here only avoids paying
+        // verification for a column that is already doomed.
+        if self.store.is_below_retention(candidate.context.slot) {
+            debug!(
+                "refusing column below the retention floor: block root {root}, column {index}, floor {floor}",
+                root = id.block_root(),
+                index = id.index(),
+                floor = self.store.get_retention_floor()
+            );
+            return;
+        }
+
         // Skip already-held columns before paying for verification. A failed
         // pre-check must not drop the candidate: fall through and let
         // verify + put decide.
@@ -131,6 +143,14 @@ impl DataAvailabilityVerificationService {
                             index = id.index()
                         );
                     }
+                    Ok(InsertOutcome::BelowRetention) => {
+                        debug!(
+                            "refused column below the retention floor: block root {root}, column {index}, floor {floor}",
+                            root = id.block_root(),
+                            index = id.index(),
+                            floor = self.store.get_retention_floor()
+                        );
+                    }
                     Err(err) => {
                         error!("failed to persist verified column: {err}");
                     }
@@ -150,6 +170,16 @@ impl DataAvailabilityVerificationService {
     async fn process_candidate_block(&self, candidate: CandidateBlock) {
         let block_root = candidate.block_root();
         let submitted = candidate.columns_len();
+
+        // Same floor pre-check as the single-column path; one slot covers the
+        // whole block, so this skips up to a block's worth of verification.
+        if self.store.is_below_retention(candidate.context().slot) {
+            debug!(
+                "refusing block below the retention floor: block root {block_root}, floor {floor}",
+                floor = self.store.get_retention_floor()
+            );
+            return;
+        }
 
         // One bitmap lookup covers the pre-check for the whole batch. As in
         // the single-column path, a failed pre-check falls through to
@@ -228,6 +258,12 @@ impl DataAvailabilityVerificationService {
                         Ok(InsertOutcome::Inserted) => stored += 1,
                         Ok(InsertOutcome::Duplicated) => {
                             warn!("duplicated column in batch: block root {block_root}")
+                        }
+                        Ok(InsertOutcome::BelowRetention) => {
+                            debug!(
+                                "refused column below the retention floor: block root {block_root}, floor {floor}",
+                                floor = store.get_retention_floor()
+                            )
                         }
                         Err(err) => error!("failed to persist verified column: {err}"),
                     }
@@ -553,6 +589,45 @@ mod tests {
             }
             let rejected = ColumnId::new(block_root, 3).expect("valid index");
             assert_eq!(store.get(&rejected).expect("get"), None);
+        });
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A candidate below the retention floor is dropped before verification.
+    /// The floor gate in `put` is the correctness backstop; the service's
+    /// early skip is the economics — it must not pay for verifying a column
+    /// it already knows the store will refuse.
+    #[test]
+    fn below_floor_candidate_is_skipped_before_verification() {
+        let executor = ReamExecutor::new().expect("create executor");
+        let root = temp_root();
+        let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
+        let verifier = Arc::new(CountingVerifier::accepting_all());
+        let (handle, rx) = ingest_channel(8);
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier.clone(),
+            store.clone(),
+            executor.clone(),
+        );
+
+        // The floor is already at 100 when the candidate arrives.
+        store.prune_below_slot(100).expect("raise the floor");
+        let stale = sample_candidate(B256::repeat_byte(4), 2, 10, b"stale");
+
+        executor.runtime().block_on(async move {
+            let service_task = tokio::spawn(service.run());
+            handle.submit(stale.clone()).await.expect("submit");
+            drop(handle);
+            service_task.await.expect("service task joined");
+
+            assert_eq!(store.get(&stale.id).expect("get"), None, "not stored");
+            assert_eq!(
+                verifier.calls(),
+                0,
+                "a below-floor candidate must be skipped before verification"
+            );
         });
 
         std::fs::remove_dir_all(&root).ok();

--- a/crates/common/data_availability_node/src/service.rs
+++ b/crates/common/data_availability_node/src/service.rs
@@ -1,7 +1,11 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
+use alloy_primitives::B256;
 use ream_data_availability::{
+    availability::ColumnAvailability,
     column::{CandidateBlock, CandidateColumn},
+    id::ColumnId,
+    reconstruction::ColumnReconstructor,
     store::{ColumnWriteStore, InsertOutcome},
     verifier::ColumnVerifier,
 };
@@ -9,34 +13,52 @@ use ream_executor::ReamExecutor;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::ingest::{IngestWorkItem, RetentionHint};
+use crate::ingest::{IngestWorkItem, ReconstructionRequest, RetentionHint};
+
+/// Default settling delay between a block becoming recoverable and the
+/// recovery attempt
+pub const DEFAULT_RECONSTRUCTION_DELAY: Duration = Duration::from_secs(3);
 
 /// Drains the ingest queue, verifying each candidate and persisting those
 /// that pass — the single consumer, and the store's only writer.
 pub struct DataAvailabilityVerificationService {
     receiver: mpsc::Receiver<IngestWorkItem>,
     verifier: Arc<dyn ColumnVerifier>,
+    /// Recovers a block's missing columns from the held ones
+    reconstructor: Arc<dyn ColumnReconstructor>,
     store: Arc<dyn ColumnWriteStore>,
     executor: ReamExecutor,
+    /// Weak self-handle for the delayed reconstruction triggers.
+    self_sender: mpsc::WeakSender<IngestWorkItem>,
+    /// How long a recoverable-but-incomplete block is given to complete
+    /// naturally before recovery is attempted.
+    reconstruction_delay: Duration,
 }
 
 impl DataAvailabilityVerificationService {
     pub fn new(
         receiver: mpsc::Receiver<IngestWorkItem>,
         verifier: Arc<dyn ColumnVerifier>,
+        reconstructor: Arc<dyn ColumnReconstructor>,
         store: Arc<dyn ColumnWriteStore>,
         executor: ReamExecutor,
+        self_sender: mpsc::WeakSender<IngestWorkItem>,
+        reconstruction_delay: Duration,
     ) -> Self {
         Self {
             receiver,
             verifier,
+            reconstructor,
             store,
             executor,
+            self_sender,
+            reconstruction_delay,
         }
     }
     /// Consume work items until the ingest channel closes.
     ///
-    /// TODO: batching can come once a batchable verifier exists.
+    /// A single sequential consumer: each item is fully handled before the next
+    /// is taken. That caps throughput but keeps the store single-writer.
     pub async fn run(mut self) {
         info!("Data-availability verification service started");
         while let Some(item) = self.receiver.recv().await {
@@ -46,9 +68,133 @@ impl DataAvailabilityVerificationService {
                     self.process_candidate_block(candidate).await
                 }
                 IngestWorkItem::Retention(hint) => self.process_retention(hint).await,
+                IngestWorkItem::Reconstruction(request) => {
+                    self.process_reconstruction(request).await
+                }
             }
         }
         info!("Data-availability verification service stopped: ingestion queue closed");
+    }
+
+    /// Recover a block's missing columns and re-admit them through the normal
+    /// verify-then-store path.
+    async fn process_reconstruction(&self, request: ReconstructionRequest) {
+        let block_root = request.block_root;
+
+        // Re-check: during the delay period, naturally-arriving columns can
+        // reach 128 columns and turn this reconstruction into this no-op.
+        let availability = self.store.availability(block_root);
+        if !availability.is_reconstructable() {
+            debug!(
+                "skipping reconstruction of block {block_root}: {held} columns held",
+                held = availability.held_count()
+            );
+            return;
+        }
+
+        let store = self.store.clone();
+        let reconstructor = self.reconstructor.clone();
+        match self
+            .executor
+            .spawn_blocking(move || {
+                Self::recover_block(
+                    store.as_ref(),
+                    reconstructor.as_ref(),
+                    block_root,
+                    availability,
+                )
+            })
+            .await
+        {
+            Ok(Some(block)) => self.process_candidate_block(block).await,
+            Ok(None) => {} // nothing to admit; the worker logged why
+            Err(err) => error!("reconstruction worker panicked or was cancelled: {err}"),
+        }
+    }
+
+    /// Worker body: fetch the block's held columns and recover the missing ones
+    fn recover_block(
+        store: &dyn ColumnWriteStore,
+        reconstructor: &dyn ColumnReconstructor,
+        block_root: B256,
+        availability: ColumnAvailability,
+    ) -> Option<CandidateBlock> {
+        let mut held = Vec::new();
+        for index in availability.held_indices() {
+            let id = ColumnId::new(block_root, index).expect("held indices are always in range");
+            match store.get(&id) {
+                Ok(Some(column)) => held.push(column),
+                // The index says held but the file is gone or unreadable;
+                // recovery still succeeds if at least half remain, so keep
+                // collecting.
+                Ok(None) => {}
+                Err(err) => {
+                    warn!("skipping unreadable column {index} of block {block_root}: {err}")
+                }
+            }
+        }
+        let context = held.first()?.context();
+
+        let recovered = match reconstructor.reconstruct(held) {
+            Ok(recovered) => recovered,
+            Err(err) => {
+                warn!("reconstruction of block {block_root} failed: {err}");
+                return None;
+            }
+        };
+        if recovered.is_empty() {
+            debug!("reconstruction of block {block_root} found nothing missing");
+            return None;
+        }
+
+        let count = recovered.len();
+        let columns = recovered
+            .into_iter()
+            .map(|column| (column.id.index(), column.payload))
+            .collect();
+        match CandidateBlock::new(block_root, context, columns) {
+            Ok(block) => {
+                info!(
+                    "recovered {count} missing columns for block {block_root}, resubmitting for verification"
+                );
+                Some(block)
+            }
+            Err(err) => {
+                warn!("recovered columns of block {block_root} form an invalid batch: {err}");
+                None
+            }
+        }
+    }
+
+    /// Arm the delayed reconstruction trigger if this write moved the block
+    /// *across* the recoverable threshold.
+    fn maybe_schedule_reconstruction(&self, block_root: B256, before: &ColumnAvailability) {
+        let after = self.store.availability(block_root);
+        // Arm only on the crossing: a block that was already recoverable
+        // before this work item was armed by an earlier one.
+        if before.is_reconstructable() || !after.is_reconstructable() {
+            return;
+        }
+
+        debug!(
+            "block {block_root} became recoverable with {held} columns, scheduling reconstruction in {delay:?}",
+            held = after.held_count(),
+            delay = self.reconstruction_delay
+        );
+        let sender = self.self_sender.clone();
+        let delay = self.reconstruction_delay;
+        self.executor.spawn(async move {
+            tokio::time::sleep(delay).await;
+            // All real handles gone: shutting down, drop the trigger.
+            let Some(sender) = sender.upgrade() else {
+                return;
+            };
+            let _ = sender
+                .send(IngestWorkItem::Reconstruction(ReconstructionRequest {
+                    block_root,
+                }))
+                .await;
+        });
     }
 
     async fn process_retention(&self, hint: RetentionHint) {
@@ -85,20 +231,17 @@ impl DataAvailabilityVerificationService {
             return;
         }
 
-        // Skip already-held columns before paying for verification. A failed
-        // pre-check must not drop the candidate: fall through and let
-        // verify + put decide.
-        match self.store.availability(id.block_root()) {
-            Ok(availability) if availability.holds(id.index()) => {
-                debug!(
-                    "skipping already-held column: block root {root}, column {index}",
-                    root = id.block_root(),
-                    index = id.index()
-                );
-                return;
-            }
-            Ok(_) => {}
-            Err(err) => debug!("presence pre-check failed, verifying anyway: {err}"),
+        // Skip already-held columns before paying for verification. The
+        // pre-insert view is kept so the reconstruction trigger can detect a
+        // threshold crossing.
+        let before = self.store.availability(id.block_root());
+        if before.holds(id.index()) {
+            debug!(
+                "skipping already-held column: block root {root}, column {index}",
+                root = id.block_root(),
+                index = id.index()
+            );
+            return;
         }
 
         let verified = match self
@@ -135,6 +278,7 @@ impl DataAvailabilityVerificationService {
                             root = id.block_root(),
                             index = id.index()
                         );
+                        self.maybe_schedule_reconstruction(id.block_root(), &before);
                     }
                     Ok(InsertOutcome::Duplicated) => {
                         warn!(
@@ -181,39 +325,29 @@ impl DataAvailabilityVerificationService {
             return;
         }
 
-        // One bitmap lookup covers the pre-check for the whole batch. As in
-        // the single-column path, a failed pre-check falls through to
-        // verification rather than dropping the batch.
-        let candidate = match self.store.availability(block_root) {
-            Ok(availability) => {
-                let (root, context, mut columns) = candidate.into_parts();
-                columns.retain(|(index, _)| {
-                    let held = availability.holds(*index);
-                    if held {
-                        trace!(
-                            "skipping already-held column: block root {block_root}, column {index}"
-                        );
-                    }
-                    !held
-                });
-                // Re-sending a stored block (e.g. a retry after a 503) is a
-                // normal path, not a fault.
-                if columns.is_empty() {
-                    debug!("skipping fully-held block batch: block root {block_root}");
-                    return;
-                }
-                // Re-assembly cannot fail
-                match CandidateBlock::new(root, context, columns) {
-                    Ok(block) => block,
-                    Err(err) => {
-                        error!("failed to rebuild filtered batch: {err}");
-                        return;
-                    }
-                }
+        // The pre-insert view is kept so the reconstruction trigger can
+        // detect a threshold crossing.
+        let before = self.store.availability(block_root);
+        let (root, context, mut columns) = candidate.into_parts();
+        columns.retain(|(index, _)| {
+            let held = before.holds(*index);
+            if held {
+                trace!("skipping already-held column: block root {block_root}, column {index}");
             }
+            !held
+        });
+        // Re-sending a stored block (e.g. a retry after a 503) is a
+        // normal path, not a fault.
+        if columns.is_empty() {
+            debug!("skipping fully-held block batch: block root {block_root}");
+            return;
+        }
+        // Re-assembly cannot fail
+        let candidate = match CandidateBlock::new(root, context, columns) {
+            Ok(block) => block,
             Err(err) => {
-                debug!("presence pre-check failed, verifying the whole batch: {err}");
-                candidate
+                error!("failed to rebuild filtered batch: {err}");
+                return;
             }
         };
 
@@ -279,6 +413,10 @@ impl DataAvailabilityVerificationService {
             }
         };
 
+        if stored > 0 {
+            self.maybe_schedule_reconstruction(block_root, &before);
+        }
+
         // One summary line per batch instead of one per column.
         if rejected > 0 {
             warn!(
@@ -298,13 +436,15 @@ mod tests {
             Arc,
             atomic::{AtomicU64, AtomicUsize, Ordering},
         },
+        time::Duration,
     };
 
     use alloy_primitives::B256;
     use ream_data_availability::{
         column::{CandidateBlock, CandidateColumn, ColumnContext, VerifiedColumn},
         error::ValidationError,
-        id::ColumnId,
+        id::{ColumnId, NUMBER_OF_COLUMNS},
+        reconstruction::ColumnReconstructor,
         store::{ColumnReadStore, ColumnWriteStore},
         verifier::ColumnVerifier,
     };
@@ -327,6 +467,19 @@ mod tests {
                 candidate.context,
                 candidate.payload,
             ))
+        }
+    }
+
+    /// Reconstruction double for tests that exercise other paths: loud if the
+    /// pipeline ever invokes it unexpectedly.
+    struct PanicReconstructor;
+
+    impl ColumnReconstructor for PanicReconstructor {
+        fn reconstruct(
+            &self,
+            _held: Vec<VerifiedColumn>,
+        ) -> Result<Vec<CandidateColumn>, ValidationError> {
+            panic!("reconstruct must not be called in this test");
         }
     }
 
@@ -357,8 +510,15 @@ mod tests {
         let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
         let verifier = Arc::new(AcceptAllVerifier);
         let (handle, rx) = ingest_channel(8);
-        let service =
-            DataAvailabilityVerificationService::new(rx, verifier, store.clone(), executor.clone());
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier,
+            Arc::new(PanicReconstructor),
+            store.clone(),
+            executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
+        );
 
         let candidates = vec![
             sample_candidate(B256::repeat_byte(1), 0, 10, b"col-0"),
@@ -399,8 +559,15 @@ mod tests {
         let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
         let verifier = Arc::new(AcceptAllVerifier);
         let (handle, rx) = ingest_channel(8);
-        let service =
-            DataAvailabilityVerificationService::new(rx, verifier, store.clone(), executor.clone());
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier,
+            Arc::new(PanicReconstructor),
+            store.clone(),
+            executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
+        );
 
         // Two old columns at slot 10, one newer at slot 20.
         let old_a = sample_candidate(B256::repeat_byte(1), 0, 10, b"old-a");
@@ -494,8 +661,11 @@ mod tests {
         let service = DataAvailabilityVerificationService::new(
             rx,
             verifier.clone(),
+            Arc::new(PanicReconstructor),
             store.clone(),
             executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
         );
 
         let block_root = B256::repeat_byte(5);
@@ -529,8 +699,11 @@ mod tests {
         let service = DataAvailabilityVerificationService::new(
             rx,
             verifier.clone(),
+            Arc::new(PanicReconstructor),
             store.clone(),
             executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
         );
 
         let block_root = B256::repeat_byte(6);
@@ -570,8 +743,15 @@ mod tests {
         let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
         let verifier = Arc::new(CountingVerifier::rejecting(vec![3]));
         let (handle, rx) = ingest_channel(8);
-        let service =
-            DataAvailabilityVerificationService::new(rx, verifier, store.clone(), executor.clone());
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier,
+            Arc::new(PanicReconstructor),
+            store.clone(),
+            executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
+        );
 
         let block_root = B256::repeat_byte(8);
         let block = sample_block(block_root, 40, &[2, 3, 4]);
@@ -608,8 +788,11 @@ mod tests {
         let service = DataAvailabilityVerificationService::new(
             rx,
             verifier.clone(),
+            Arc::new(PanicReconstructor),
             store.clone(),
             executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
         );
 
         // The floor is already at 100 when the candidate arrives.
@@ -627,6 +810,263 @@ mod tests {
                 verifier.calls(),
                 0,
                 "a below-floor candidate must be skipped before verification"
+            );
+        });
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Recovers by fabricating a candidate for every index missing from the
+    /// held set — enough to exercise the trigger/worker/re-entry plumbing
+    /// without real erasure coding (that lives in the KZG adapter and is
+    /// tested there).
+    struct FillMissingReconstructor {
+        calls: AtomicUsize,
+    }
+
+    impl FillMissingReconstructor {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+            })
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    impl ColumnReconstructor for FillMissingReconstructor {
+        fn reconstruct(
+            &self,
+            held: Vec<VerifiedColumn>,
+        ) -> Result<Vec<CandidateColumn>, ValidationError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            let first = held.first().expect("the service never sends an empty set");
+            let (block_root, context) = (first.id().block_root(), first.context());
+            let mut held_mask = 0u128;
+            for column in &held {
+                held_mask |= 1 << column.id().index();
+            }
+            Ok((0..NUMBER_OF_COLUMNS)
+                .filter(|index| held_mask & (1 << index) == 0)
+                .map(|index| CandidateColumn {
+                    id: ColumnId::new(block_root, index).expect("index within range"),
+                    context,
+                    payload: vec![index as u8],
+                })
+                .collect())
+        }
+    }
+
+    /// Poll until the block holds every column or a deadline passes.
+    async fn wait_until_complete(store: &FileColumnStore, block_root: B256) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let held = store.availability(block_root).held_count();
+            if held == NUMBER_OF_COLUMNS {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "block did not self-heal in time ({held} columns held)"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// A half-full block batch crosses the recovery threshold: after the
+    /// (zero) settling delay the service recovers the other half by itself,
+    /// and the recovered columns pass through the verifier — the gate is
+    /// never bypassed.
+    #[test]
+    fn incomplete_block_self_heals_through_the_verify_gate() {
+        let executor = ReamExecutor::new().expect("create executor");
+        let root = temp_root();
+        let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
+        let verifier = Arc::new(CountingVerifier::accepting_all());
+        let reconstructor = FillMissingReconstructor::new();
+        let (handle, rx) = ingest_channel(8);
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier.clone(),
+            reconstructor.clone(),
+            store.clone(),
+            executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
+        );
+
+        let block_root = B256::repeat_byte(9);
+        let first_half: Vec<u64> = (0..NUMBER_OF_COLUMNS / 2).collect();
+        let block = sample_block(block_root, 40, &first_half);
+
+        executor.runtime().block_on(async move {
+            let service_task = tokio::spawn(service.run());
+            handle.submit_block(block).await.expect("submit block");
+
+            // The self-heal round-trips through the queue, so the handle must
+            // stay alive (it backs the service's weak self-sender) until the
+            // block is complete.
+            wait_until_complete(&store, block_root).await;
+            drop(handle);
+            service_task.await.expect("service task joined");
+
+            assert_eq!(reconstructor.calls(), 1, "one crossing, one recovery");
+            assert_eq!(
+                verifier.calls(),
+                NUMBER_OF_COLUMNS as usize,
+                "64 ingested + 64 recovered columns all verified"
+            );
+            let recovered = ColumnId::new(block_root, 100).expect("valid index");
+            let stored = store.get(&recovered).expect("get").expect("present");
+            assert_eq!(stored.payload(), &[100u8]);
+            assert_eq!(stored.context().slot, 40);
+        });
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A single trickled column that crosses the threshold triggers recovery
+    /// too — the trigger lives on both ingest paths.
+    #[test]
+    fn a_trickled_column_crossing_the_threshold_triggers_recovery() {
+        let executor = ReamExecutor::new().expect("create executor");
+        let root = temp_root();
+        let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
+        let verifier = Arc::new(CountingVerifier::accepting_all());
+        let reconstructor = FillMissingReconstructor::new();
+        let (handle, rx) = ingest_channel(8);
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier,
+            reconstructor.clone(),
+            store.clone(),
+            executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
+        );
+
+        // 63 columns are already held; the 64th arrives as a single candidate.
+        let block_root = B256::repeat_byte(10);
+        for index in 0..NUMBER_OF_COLUMNS / 2 - 1 {
+            store
+                .put(VerifiedColumn::new_unchecked(
+                    ColumnId::new(block_root, index).expect("valid index"),
+                    ColumnContext { slot: 40 },
+                    vec![index as u8],
+                ))
+                .expect("seed store");
+        }
+        let crossing = sample_candidate(block_root, NUMBER_OF_COLUMNS / 2 - 1, 40, b"cross");
+
+        executor.runtime().block_on(async move {
+            let service_task = tokio::spawn(service.run());
+            handle.submit(crossing).await.expect("submit");
+
+            wait_until_complete(&store, block_root).await;
+            drop(handle);
+            service_task.await.expect("service task joined");
+
+            assert_eq!(reconstructor.calls(), 1, "one crossing, one recovery");
+        });
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// When the rest of the block arrives during the settling delay, the
+    /// fired trigger re-checks, finds the block complete, and stands down
+    /// without recovering anything.
+    #[test]
+    fn reconstruction_stands_down_when_the_block_completes_naturally() {
+        let executor = ReamExecutor::new().expect("create executor");
+        let root = temp_root();
+        let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
+        let verifier = Arc::new(CountingVerifier::accepting_all());
+        let reconstructor = FillMissingReconstructor::new();
+        let (handle, rx) = ingest_channel(8);
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier,
+            reconstructor.clone(),
+            store.clone(),
+            executor.clone(),
+            handle.downgrade(),
+            Duration::from_millis(300),
+        );
+
+        let block_root = B256::repeat_byte(11);
+        let first_half: Vec<u64> = (0..NUMBER_OF_COLUMNS / 2).collect();
+        let second_half: Vec<u64> = (NUMBER_OF_COLUMNS / 2..NUMBER_OF_COLUMNS).collect();
+
+        executor.runtime().block_on(async move {
+            let service_task = tokio::spawn(service.run());
+            // The first half arms the trigger; the second half completes the
+            // block well inside the 300ms delay.
+            handle
+                .submit_block(sample_block(block_root, 40, &first_half))
+                .await
+                .expect("submit first half");
+            handle
+                .submit_block(sample_block(block_root, 40, &second_half))
+                .await
+                .expect("submit second half");
+
+            // Wait past the delay so the trigger has fired and re-checked.
+            tokio::time::sleep(Duration::from_millis(900)).await;
+            drop(handle);
+            service_task.await.expect("service task joined");
+
+            assert_eq!(
+                reconstructor.calls(),
+                0,
+                "a complete block is never recovered"
+            );
+        });
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Below half the columns recovery is mathematically impossible, so the
+    /// trigger is never armed at all.
+    #[test]
+    fn no_reconstruction_below_half_the_columns() {
+        let executor = ReamExecutor::new().expect("create executor");
+        let root = temp_root();
+        let store = Arc::new(FileColumnStore::new(root.clone()).expect("open store"));
+        let verifier = Arc::new(CountingVerifier::accepting_all());
+        let reconstructor = FillMissingReconstructor::new();
+        let (handle, rx) = ingest_channel(8);
+        let service = DataAvailabilityVerificationService::new(
+            rx,
+            verifier,
+            reconstructor.clone(),
+            store.clone(),
+            executor.clone(),
+            handle.downgrade(),
+            Duration::ZERO,
+        );
+
+        let block_root = B256::repeat_byte(12);
+        let below_half: Vec<u64> = (0..NUMBER_OF_COLUMNS / 2 - 1).collect();
+
+        executor.runtime().block_on(async move {
+            let service_task = tokio::spawn(service.run());
+            handle
+                .submit_block(sample_block(block_root, 40, &below_half))
+                .await
+                .expect("submit block");
+
+            // With a zero delay an armed trigger would fire immediately; give
+            // it ample room to prove it never does.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            drop(handle);
+            service_task.await.expect("service task joined");
+
+            assert_eq!(
+                reconstructor.calls(),
+                0,
+                "below half there is nothing to arm"
             );
         });
 

--- a/crates/common/data_availability_node/src/store.rs
+++ b/crates/common/data_availability_node/src/store.rs
@@ -57,8 +57,6 @@ impl FileColumnStore {
     /// on disk. A missing directory yields an empty store; leftover `*.tmp`
     /// files from an interrupted write are removed.
     pub fn new(root: PathBuf) -> Result<Self, ColumnStoreError> {
-        // The floor must be known before the directory scan, so the scan can
-        // apply it to the column files it finds.
         let retention_floor = Self::load_retention_floor(&root);
         let store = Self {
             root,
@@ -155,9 +153,6 @@ impl FileColumnStore {
                 // A file below the floor survived a prune interrupted between
                 // recording the floor and deleting
                 if self.is_below_retention(slot) {
-                    // A failed removal is a disk leak, not a reason to refuse
-                    // startup: the file stays out of the index either way, so
-                    // it is never served.
                     match fs::remove_file(&path) {
                         Ok(()) => pruned_files += 1,
                         Err(err) => warn!(
@@ -297,8 +292,7 @@ impl ColumnReadStore for FileColumnStore {
 
     fn get_retention_floor(&self) -> u64 {
         // Relaxed is enough: the floor is a monotonic scalar and carries no
-        // ordering relationship with other memory; durability comes from the
-        // persisted file, not the atomic.
+        // ordering relationship with other memory
         self.retention_floor.load(Ordering::Relaxed)
     }
 
@@ -356,9 +350,6 @@ impl ColumnWriteStore for FileColumnStore {
             return Ok(0);
         }
 
-        // Durability first: with the floor recorded before any deletion, a
-        // crash mid-prune re-prunes on the next startup; the reverse order
-        // would delete files and then forget it was supposed to.
         self.persist_retention_floor(slot)?;
         self.retention_floor.fetch_max(slot, Ordering::Relaxed);
 

--- a/crates/common/data_availability_node/src/store.rs
+++ b/crates/common/data_availability_node/src/store.rs
@@ -2,9 +2,12 @@ use std::{
     collections::HashMap,
     fs,
     io::{self, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
-    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{
+        RwLock, RwLockReadGuard, RwLockWriteGuard,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use alloy_primitives::B256;
@@ -19,6 +22,10 @@ use tracing::{debug, info, trace, warn};
 
 /// Committed column files; in-progress writes use `.tmp` instead.
 const COLUMN_FILE_EXTENSION: &str = "ssz";
+
+/// Kept in `root` next to the column files. The name never matches the
+/// column-file scheme, so the startup scan skips it.
+const RETENTION_FLOOR_FILE: &str = "retention_floor";
 
 /// A block's slot plus a 128-bit bitmap of its stored column indices.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -41,6 +48,8 @@ pub struct FileColumnStore {
     root: PathBuf,
     index: RwLock<HashMap<B256, BlockEntry>>,
     // TODO: add a payload cache to avoid reading from files every time.
+    /// Beacon-issued retention floor, as a slot; `0` means no floor yet.
+    retention_floor: AtomicU64,
 }
 
 impl FileColumnStore {
@@ -48,12 +57,57 @@ impl FileColumnStore {
     /// on disk. A missing directory yields an empty store; leftover `*.tmp`
     /// files from an interrupted write are removed.
     pub fn new(root: PathBuf) -> Result<Self, ColumnStoreError> {
+        // The floor must be known before the directory scan, so the scan can
+        // apply it to the column files it finds.
+        let retention_floor = Self::load_retention_floor(&root);
         let store = Self {
             root,
             index: RwLock::new(HashMap::new()),
+            retention_floor: AtomicU64::new(retention_floor),
         };
         store.rebuild_index()?;
         Ok(store)
+    }
+
+    /// Read the persisted retention floor; `0` (no floor) when the file does
+    /// not exist yet.
+    fn load_retention_floor(root: &Path) -> u64 {
+        let path = root.join(RETENTION_FLOOR_FILE);
+        let contents = match fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return 0,
+            Err(err) => {
+                warn!(
+                    "failed to read the retention floor file {}: {err}; starting with no floor",
+                    path.display()
+                );
+                return 0;
+            }
+        };
+        match contents.trim().parse() {
+            Ok(floor) => floor,
+            Err(err) => {
+                warn!(
+                    "malformed retention floor file {}: {err}; starting with no floor",
+                    path.display()
+                );
+                0
+            }
+        }
+    }
+
+    /// Durably record `floor`: temp file + `sync_all` + atomic rename, the same
+    /// discipline as a column write.
+    fn persist_retention_floor(&self, floor: u64) -> Result<(), ColumnStoreError> {
+        // The first retention hint may arrive before any column was written.
+        fs::create_dir_all(&self.root)?;
+        let path = self.root.join(RETENTION_FLOOR_FILE);
+        let tmp_path = path.with_extension("tmp");
+        let mut file = fs::File::create(&tmp_path)?;
+        file.write_all(floor.to_string().as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&tmp_path, &path)?;
+        Ok(())
     }
 
     /// `{slot:08}_{index:03}_{block_root:x}.ssz` under `root`.
@@ -66,6 +120,9 @@ impl FileColumnStore {
     }
 
     fn rebuild_index(&self) -> Result<(), ColumnStoreError> {
+        // make sure that old data will be deleted and won't be loaded
+        self.prune_below_slot(self.get_retention_floor());
+
         let root = self.root.display();
         let entries = match fs::read_dir(&self.root) {
             Ok(entries) => entries,
@@ -106,8 +163,9 @@ impl FileColumnStore {
         }
 
         info!(
-            "loaded column store index from {root}: {column_files} column files across {} blocks",
-            index.len()
+            "loaded DA store index from {root}: {column_files} column files across {} blocks, retention floor at slot {}",
+            index.len(),
+            self.retention_floor.load(Ordering::Relaxed)
         );
         Ok(())
     }
@@ -223,6 +281,17 @@ impl ColumnReadStore for FileColumnStore {
         // pass the node's actual custody set here instead.
         Ok(ColumnAvailability::new(held, ALL_COLUMNS_MASK))
     }
+
+    fn get_retention_floor(&self) -> u64 {
+        // Relaxed is enough: the floor is a monotonic scalar and carries no
+        // ordering relationship with other memory; durability comes from the
+        // persisted file, not the atomic.
+        self.retention_floor.load(Ordering::Relaxed)
+    }
+
+    fn is_below_retention(&self, slot: u64) -> bool {
+        slot < self.get_retention_floor()
+    }
 }
 
 impl ColumnWriteStore for FileColumnStore {
@@ -234,6 +303,10 @@ impl ColumnWriteStore for FileColumnStore {
         let slot = column.context().slot;
         let block_root = id.block_root();
         let column_index = id.index();
+
+        if self.is_below_retention(slot) {
+            return Ok(InsertOutcome::BelowRetention);
+        }
 
         let already_stored = self
             .index_read()
@@ -262,6 +335,17 @@ impl ColumnWriteStore for FileColumnStore {
     }
 
     fn prune_below_slot(&self, slot: u64) -> Result<usize, ColumnStoreError> {
+        if self.is_below_retention(slot) {
+            info!(
+                "ignoring retention hint below the current floor: hint slot {slot}, floor {floor}",
+                floor = self.get_retention_floor()
+            );
+            return Ok(0);
+        }
+
+        self.persist_retention_floor(slot)?;
+        self.retention_floor.fetch_max(slot, Ordering::Relaxed);
+
         let entries = self
             .index_read()
             .iter()
@@ -287,7 +371,7 @@ mod tests {
         store::{ColumnReadStore, ColumnWriteStore, InsertOutcome},
     };
 
-    use super::{BlockEntry, FileColumnStore};
+    use super::{BlockEntry, FileColumnStore, RETENTION_FLOOR_FILE};
 
     fn temp_root() -> PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -433,6 +517,35 @@ mod tests {
 
         assert!(!tmp.exists(), "leftover temp file should be cleaned up");
         assert!(store.index_read().is_empty());
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn retention_floor_survives_reopen() {
+        let root = temp_root();
+        let store = FileColumnStore::new(root.clone()).expect("open store");
+        // A fresh store starts with no floor.
+        assert_eq!(store.retention_floor.load(Ordering::Relaxed), 0);
+
+        store.persist_retention_floor(42).expect("persist floor");
+        drop(store);
+
+        let reopened = FileColumnStore::new(root.clone()).expect("reopen store");
+        assert_eq!(reopened.retention_floor.load(Ordering::Relaxed), 42);
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn malformed_retention_floor_file_degrades_to_no_floor() {
+        let root = temp_root();
+        fs::create_dir_all(&root).expect("create root");
+        fs::write(root.join(RETENTION_FLOOR_FILE), b"not-a-slot").expect("write junk");
+
+        // Fail-open: a corrupt floor file must not brick the store.
+        let store = FileColumnStore::new(root.clone()).expect("open store");
+        assert_eq!(store.retention_floor.load(Ordering::Relaxed), 0);
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/common/data_availability_node/src/store.rs
+++ b/crates/common/data_availability_node/src/store.rs
@@ -120,9 +120,6 @@ impl FileColumnStore {
     }
 
     fn rebuild_index(&self) -> Result<(), ColumnStoreError> {
-        // make sure that old data will be deleted and won't be loaded
-        self.prune_below_slot(self.get_retention_floor());
-
         let root = self.root.display();
         let entries = match fs::read_dir(&self.root) {
             Ok(entries) => entries,
@@ -136,6 +133,7 @@ impl FileColumnStore {
 
         let mut index = self.index_write();
         let mut column_files = 0u64;
+        let mut pruned_files = 0u64;
         for entry in entries {
             let path = entry?.path();
             let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
@@ -154,6 +152,21 @@ impl FileColumnStore {
 
             // Skip anything we did not write: startup must not fail on clutter.
             if let Some((id, slot)) = Self::parse_column_file_name(name) {
+                // A file below the floor survived a prune interrupted between
+                // recording the floor and deleting
+                if self.is_below_retention(slot) {
+                    // A failed removal is a disk leak, not a reason to refuse
+                    // startup: the file stays out of the index either way, so
+                    // it is never served.
+                    match fs::remove_file(&path) {
+                        Ok(()) => pruned_files += 1,
+                        Err(err) => warn!(
+                            "failed to remove a below-floor column file {}: {err}",
+                            path.display()
+                        ),
+                    }
+                    continue;
+                }
                 index
                     .entry(id.block_root())
                     .or_insert(BlockEntry { slot, columns: 0 })
@@ -163,7 +176,7 @@ impl FileColumnStore {
         }
 
         info!(
-            "loaded DA store index from {root}: {column_files} column files across {} blocks, retention floor at slot {}",
+            "loaded DA store index from {root}: {column_files} column files across {} blocks, retention floor at slot {}, {pruned_files} below-floor files removed",
             index.len(),
             self.retention_floor.load(Ordering::Relaxed)
         );
@@ -343,6 +356,9 @@ impl ColumnWriteStore for FileColumnStore {
             return Ok(0);
         }
 
+        // Durability first: with the floor recorded before any deletion, a
+        // crash mid-prune re-prunes on the next startup; the reverse order
+        // would delete files and then forget it was supposed to.
         self.persist_retention_floor(slot)?;
         self.retention_floor.fetch_max(slot, Ordering::Relaxed);
 
@@ -546,6 +562,75 @@ mod tests {
         // Fail-open: a corrupt floor file must not brick the store.
         let store = FileColumnStore::new(root.clone()).expect("open store");
         assert_eq!(store.retention_floor.load(Ordering::Relaxed), 0);
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn put_refuses_columns_below_the_retention_floor() {
+        let root = temp_root();
+        let store = FileColumnStore::new(root.clone()).expect("open store");
+        store.prune_below_slot(15).expect("set floor");
+
+        // Strictly below the floor: refused, and nothing touches disk or index.
+        let stale = sample_column(B256::repeat_byte(1), 0, 14, b"stale");
+        let id = stale.id();
+        assert_eq!(
+            store.put(stale).expect("put"),
+            InsertOutcome::BelowRetention
+        );
+        assert_eq!(store.get(&id).expect("get"), None);
+        assert!(!store.column_path(&id, 14).exists());
+
+        // Exactly at the floor: accepted (the floor keeps slot >= floor).
+        let at_floor = sample_column(B256::repeat_byte(2), 1, 15, b"kept");
+        assert_eq!(store.put(at_floor).expect("put"), InsertOutcome::Inserted);
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn retention_hint_below_the_floor_never_lowers_it() {
+        let root = temp_root();
+        let store = FileColumnStore::new(root.clone()).expect("open store");
+        store.prune_below_slot(100).expect("raise floor");
+
+        // A lower hint is a no-op: nothing pruned, floor unchanged...
+        assert_eq!(store.prune_below_slot(50).expect("lower hint"), 0);
+        assert_eq!(store.get_retention_floor(), 100);
+        drop(store);
+
+        // ...including the persisted copy: the lower hint must not rewrite the
+        // file, or the floor would silently fall back after a restart.
+        let reopened = FileColumnStore::new(root.clone()).expect("reopen");
+        assert_eq!(reopened.get_retention_floor(), 100);
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn startup_reprunes_columns_below_a_persisted_floor() {
+        let root = temp_root();
+        let store = FileColumnStore::new(root.clone()).expect("open store");
+        let old = sample_column(B256::repeat_byte(1), 0, 10, b"old");
+        let recent = sample_column(B256::repeat_byte(2), 1, 20, b"recent");
+        let old_id = old.id();
+        let recent_id = recent.id();
+        store.put(old).expect("put old");
+        store.put(recent).expect("put recent");
+
+        // Simulate a crash between recording the floor and pruning: the floor
+        // file says 15, but the slot-10 column files are still on disk.
+        store.persist_retention_floor(15).expect("persist floor");
+        drop(store);
+
+        // Startup must finish the interrupted prune: below-floor columns are
+        // deleted, not resurrected into the index and served.
+        let reopened = FileColumnStore::new(root.clone()).expect("reopen");
+        assert_eq!(reopened.get_retention_floor(), 15);
+        assert_eq!(reopened.get(&old_id).expect("get"), None);
+        assert!(!reopened.column_path(&old_id, 10).exists());
+        assert!(reopened.get(&recent_id).expect("get").is_some());
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/common/data_availability_node/src/store.rs
+++ b/crates/common/data_availability_node/src/store.rs
@@ -284,7 +284,7 @@ impl ColumnReadStore for FileColumnStore {
         )))
     }
 
-    fn availability(&self, block_root: B256) -> Result<ColumnAvailability, ColumnStoreError> {
+    fn availability(&self, block_root: B256) -> ColumnAvailability {
         let held = self
             .index_read()
             .get(&block_root)
@@ -292,7 +292,7 @@ impl ColumnReadStore for FileColumnStore {
             .unwrap_or(0);
         // Full-custody MVP: every column is expected. Custody groups would
         // pass the node's actual custody set here instead.
-        Ok(ColumnAvailability::new(held, ALL_COLUMNS_MASK))
+        ColumnAvailability::new(held, ALL_COLUMNS_MASK)
     }
 
     fn get_retention_floor(&self) -> u64 {
@@ -695,25 +695,13 @@ mod tests {
                 .put(sample_column(block, index, 8, b"x"))
                 .expect("put");
         }
-        assert_eq!(
-            store
-                .availability(block)
-                .expect("availability")
-                .held_count(),
-            3
-        );
+        assert_eq!(store.availability(block).held_count(), 3);
 
         store.prune_below_slot(100).expect("prune");
 
         // The bitmap reached 0, so the whole entry is removed.
         assert!(store.index_read().get(&block).is_none());
-        assert_eq!(
-            store
-                .availability(block)
-                .expect("availability")
-                .held_count(),
-            0
-        );
+        assert_eq!(store.availability(block).held_count(), 0);
         for index in [0u64, 5, 7] {
             let id = ColumnId::new(block, index).expect("valid index");
             assert_eq!(store.get(&id).expect("get"), None);

--- a/crates/rpc/data_availability/src/handlers/availability.rs
+++ b/crates/rpc/data_availability/src/handlers/availability.rs
@@ -36,8 +36,6 @@ pub async fn get_availability(
     block_root: Path<ID>,
 ) -> Result<impl Responder, ApiError> {
     let block_root = block_root_from_id(block_root.into_inner())?;
-    let availability = store
-        .availability(block_root)
-        .map_err(|err| ApiError::InternalError(format!("availability lookup failed: {err}")))?;
+    let availability = store.availability(block_root);
     Ok(HttpResponse::Ok().json(AvailabilityResponse::from(availability)))
 }

--- a/crates/rpc/data_availability/src/handlers/column.rs
+++ b/crates/rpc/data_availability/src/handlers/column.rs
@@ -62,9 +62,7 @@ pub async fn get_columns(
     block_root: Path<ID>,
 ) -> Result<impl Responder, ApiError> {
     let block_root = block_root_from_id(block_root.into_inner())?;
-    let availability = store
-        .availability(block_root)
-        .map_err(|err| ApiError::InternalError(format!("availability lookup failed: {err}")))?;
+    let availability = store.availability(block_root);
 
     let mut columns = Vec::with_capacity(availability.held_count() as usize);
     for index in availability.held_indices() {

--- a/crates/rpc/data_availability/src/handlers/retention.rs
+++ b/crates/rpc/data_availability/src/handlers/retention.rs
@@ -7,9 +7,12 @@ use ream_data_availability_node::ingest::{IngestHandle, RetentionHint};
 
 use crate::handlers::{slot_from_id, submission_error};
 
-/// `POST /data/v0/retention/{slot}` — prune every stored column whose slot is
-/// strictly below `{slot}`. The hint rides the verification queue, so pruning
-/// stays serialized with verification and off the request path.
+/// `POST /data/v0/retention/{slot}` — raise the retention floor to `{slot}`,
+/// pruning every stored column strictly below it. The floor is monotonic and
+/// persistent, so a hint below the current floor is a no-op.
+///
+/// The hint rides the verification queue, so pruning stays serialized with
+/// verification and off the request path.
 #[post("/retention/{slot}")]
 pub async fn post_retention(
     handle: Data<IngestHandle>,

--- a/crates/rpc/data_availability/src/handlers/retention.rs
+++ b/crates/rpc/data_availability/src/handlers/retention.rs
@@ -10,9 +10,6 @@ use crate::handlers::{slot_from_id, submission_error};
 /// `POST /data/v0/retention/{slot}` — raise the retention floor to `{slot}`,
 /// pruning every stored column strictly below it. The floor is monotonic and
 /// persistent, so a hint below the current floor is a no-op.
-///
-/// The hint rides the verification queue, so pruning stays serialized with
-/// verification and off the request path.
 #[post("/retention/{slot}")]
 pub async fn post_retention(
     handle: Data<IngestHandle>,


### PR DESCRIPTION
### What was wrong?

1. Add a retention floor. If any data is older than the retention floor, it should be deleted and should not be kept in the store.
2. Implement data column reconstruction.  

### How was it fixed?
#### Summary

When a write moves a block across the recoverable threshold — at least half of the column set held (`NUMBER_OF_COLUMNS / 2 = 64`) — the verification service arms a one-shot reconstruction trigger. The trigger fires after a randomized settling delay, giving naturally-arriving columns a chance to complete the block first and desynchronizing reconstruction across nodes, per spec.

Recovered columns are re-admitted through the normal verify-then-store path (`process_candidate_block`) as candidates rather than trusted directly: the recovery math is sound, but the assembly around it is ordinary code, and re-verification catches its bug classes for free.

**Key piece**: `DaReconstructor` trait in `ream-da`, implemented by the KZG adapter — `KzgVerifier` is renamed `KzgAdapter` since one object now serves both roles. Housing both capabilities in one adapter keeps it the node's single home for the KZG machinery: the trusted setup is loaded and cached once per context, and no second KZG-aware component exists anywhere else in the node.

### Next Step
Reconstruction currently routes through the queue because the store's single-writer contract lives outside the store — the queue serializes all writes. Once the file store is replaced by a DB that owns its own concurrency, reconstruction can run self-contained and skip the queue round-trip.

