### PR TITLE
fix(lean): stop materializing every pending block body on each sync tick

### DIFF
--- a/crates/common/chain/lean/src/service.rs
+++ b/crates/common/chain/lean/src/service.rs
@@ -2158,19 +2158,14 @@ impl LeanChainService {
             )
         };
 
-        let stale_roots: Vec<_> = pending_blocks_provider
-            .iter()?
-            .filter_map(|result| match result {
-                Ok((root, block)) => {
-                    let block_slot = pending_block_slot(&block);
-                    let should_prune = !protected_roots.contains(&root)
-                        && (block_provider.contains_key(root)
-                            || block_slot <= latest_finalized_slot);
-                    should_prune.then_some(Ok(root))
-                }
-                Err(err) => Some(Err(err)),
-            })
-            .collect::<Result<_, _>>()?;
+        let mut stale_roots: Vec<B256> = Vec::new();
+        pending_blocks_provider.for_each_metadata(|root, block_slot, _parent_root| {
+            let should_prune = !protected_roots.contains(&root)
+                && (block_provider.contains_key(root) || block_slot <= latest_finalized_slot);
+            if should_prune {
+                stale_roots.push(root);
+            }
+        })?;
 
         if stale_roots.is_empty() {
             return Ok(());

--- a/crates/storage/src/tables/lean/pending_blocks.rs
+++ b/crates/storage/src/tables/lean/pending_blocks.rs
@@ -56,6 +56,21 @@ impl LeanPendingBlocksTable {
             .map(|result| result.map_err(StoreError::from)))
     }
 
+    pub fn for_each_metadata<F>(&self, mut f: F) -> Result<(), StoreError>
+    where
+        F: FnMut(B256, u64, B256),
+    {
+        let read_txn = self.db.begin_read()?;
+        let table = read_txn.open_table(Self::TABLE_DEFINITION)?;
+        for result in table.range::<<SSZEncoding<B256> as redb::Value>::SelfType<'_>>(..)? {
+            let (key, value) = result?;
+            let root = key.value();
+            let block = value.value();
+            f(root, block.block.slot, block.block.parent_root);
+        }
+        Ok(())
+    }
+
     pub fn retain<F>(&self, mut f: F) -> Result<(), crate::errors::StoreError>
     where
         F: FnMut(&B256, &<Self as REDBTable>::Value) -> bool,


### PR DESCRIPTION
`prune_stale_pending_blocks` needs only each pending block's slot, but read the table through `LeanPendingBlocksTable::iter()`, which despite returning `impl Iterator` first collects the entire table into a `Vec`, fully decoding every pending `SignedBlock` — leanVM aggregate proof included, ~233 KiB per block on devnet-5.

It runs on every `step_backfill_sync` tick, so a node with a deep backfill re-materialized its whole pending set several times a second. On devnet-5, where finalization stalled at slot 928 while heads reached ~66-80k, that is tens of thousands of blocks per pass. The deployed build ran on system malloc (jemalloc is not in `devnet5,optimized_leanvm`), so the freed arenas are retained by the allocator and show as a resident plateau rather than a sawtooth.

This matches the observed failure: all three ream nodes climbed to ~14.6 GiB of anonymous heap on 15.2 GiB hosts and were OOM-killed repeatedly. `container_memory_rss` reached ~13.8 GiB while `mapped_file` stayed at ~0.02 GiB, so the growth was heap, not redb's mmap or page cache, and it ramped during the `head=0` backfill phase — before any block was imported.

Adds `for_each_metadata`, which streams `(root, slot, parent_root)` and holds at most one decoded block at a time.

## Notes for reviewers

- Peak memory for the prune goes from O(pending set) to O(1), but it is still O(pending) decodes of CPU/IO per tick. If that shows up as CPU cost or redb cache pressure, the follow-up is a slot-keyed secondary index on `pending_blocks` so the prune never touches block bodies at all.
- `LeanStateTable::iter_values` has the same eager-collect shape and currently has no callers — worth deleting or fixing before it gets used at state scale.

## Not addressed

- The separate devnet-5 sync freeze, where the head stops advancing while gossip keeps flowing (it preceded each OOM by ~20 minutes).
- This is not profiler-confirmed: the reasoning is from container memory metrics and code inspection. A heap profile on a live node would confirm this is the dominant allocation.