### PR TITLE
build: enable jemalloc by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG FEATURES=""
 ENV FEATURES=$FEATURES
 
 # Disable default features (e.g. for `shadow-integration`, which must drop the
-# default `jemalloc` and `devnet4` features). Empty for a normal build.
+# default `jemalloc` and `devnet5` features). Empty for a normal build.
 ARG NO_DEFAULT_FEATURES=""
 ENV NO_DEFAULT_FEATURES=$NO_DEFAULT_FEATURES
 

--- a/bin/ream/Cargo.toml
+++ b/bin/ream/Cargo.toml
@@ -20,7 +20,7 @@ name = "ream-data-availability-tool"
 path = "src/data_availability_tool/main.rs"
 
 [features]
-default = ["devnet5"]
+default = ["devnet5", "jemalloc"]
 devnet5 = [
     "ream-chain-lean/devnet5",
     "ream-consensus-lean/devnet5",


### PR DESCRIPTION
`jemalloc` has been an opt-in feature since #1468 ("change the memory allocator to jemalloc"), but it was never added to `default`, which has only ever tracked the current devnet:

```
f8f1a8b0: default = ["devnet1"]
83a58ca6: default = ["devnet2"]
12061728: default = ["devnet4"]
5863302f: default = ["devnet5"]   # today
```

Nothing in the repo turns it on — not CI, not the Makefile, and not the Dockerfile, which passes an empty `FEATURES` for normal builds. So every release and devnet image has been running on the system allocator, and the commit that set out to change the allocator never changed it for any shipped build.

Two things in the tree were already written on the assumption that it *was* a default, which is what makes this look like an oversight rather than a decision:

- the `compile_error!` in `main.rs` guarding `jemalloc` against `shadow-integration` — you only add that guard if you expect jemalloc to normally be on
- the Dockerfile comment describing `jemalloc` as one of the default features `shadow-integration` has to drop

## Why it matters

glibc malloc retains freed spans in its arenas rather than returning them to the OS, so a workload that repeatedly allocates and frees large short-lived buffers holds a resident high-water mark instead of a sawtooth. On devnet-5 ream's nodes plateaued at ~14.6 GiB of anonymous heap on 15.2 GiB hosts and were OOM-killed repeatedly. jemalloc releases far more readily and would likely have kept that recoverable.

This is complementary to #1573, which removes one such allocate-and-free pattern; this change reduces the blast radius of any others.

## Verification

- default build links `tikv-jemallocator` (confirmed via `cargo tree`; 1154 jemalloc symbols in the binary) and `ream --version` runs
- `--no-default-features --features "shadow-integration devnet5"` still compiles and links no jemalloc
- the `compile_error!` still fires when both features are enabled together
- both Shadow build paths in the Makefile already pass `--no-default-features`, so the incompatible combination stays excluded
- `cargo clippy --workspace --all-targets` clean

Also corrects the Dockerfile comment, which still referred to devnet4.

## Note for reviewers

Worth a sanity check on the platforms CI builds for — jemalloc adds a C dependency, so if any cross target in `Cross.toml` lacks a working `tikv-jemalloc-sys` build it would need `--no-default-features` there too. I verified the native build (darwin-aarch64) only.